### PR TITLE
(Fix): Add font support for barcode label rendering in Docker

### DIFF
--- a/barcodelib/Dockerfile
+++ b/barcodelib/Dockerfile
@@ -24,6 +24,14 @@ RUN dotnet publish "BarcodelibExample.csproj" -c $BUILD_CONFIGURATION -o /app/pu
 # Final runtime image
 FROM base AS final
 WORKDIR /app
+
+# Install fonts for SkiaSharp text rendering
+RUN apt-get update && apt-get install -y \
+    fontconfig \
+    libfontconfig1 \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=publish /app/publish .
 
 # Set environment variables


### PR DESCRIPTION
## Problem
Barcode labels (digits) are not displayed in the deployed Docker container when "Label: ON" is enabled.

## Root Cause
The base Docker image `mcr.microsoft.com/dotnet/aspnet:9.0` doesn't include system fonts, which SkiaSharp requires for text rendering.

## Solution
Added installation of essential font packages in the Dockerfile:
- `fontconfig` - font configuration system
- `libfontconfig1` - font configuration library  
- `fonts-dejavu-core` - basic TrueType fonts
