### PR TITLE
[QrCoder]: align card header positioning

### DIFF
--- a/qrcoder/Apps/ProfileApp.cs
+++ b/qrcoder/Apps/ProfileApp.cs
@@ -90,8 +90,7 @@ public class ProfileApp : ViewBase
             ).Height(Size.Full())
             : new Card(
                 Layout.Vertical().Padding(2)
-                | (Layout.Center()
-                    | Text.H2("Welcome to Profile Creator"))
+                | Text.H2("Welcome to Profile Creator")
                 | Text.Block("Fill out the form in the sidebar to create your shareable profile QR code.")
                 | Text.Block("Once you submit the form, your QR code will appear here in the main content area.")
             ).Height(Size.Full());


### PR DESCRIPTION
## Summary
Fixed inconsistent H2 header alignment between left and right cards in ProfileApp.

## Before
Left and right cards had different padding, causing H2 headers to be misaligned.

## After
Both cards now have consistent padding, creating a unified and professional appearance.
before ->
<img width="1628" height="917" alt="image" src="https://github.com/user-attachments/assets/132db891-16b5-4aa3-bd8d-879a2cb7558e" />

after->
<img width="1658" height="850" alt="image" src="https://github.com/user-attachments/assets/026da3f2-b5f1-4fcc-bcde-45188044406d" />