### PR TITLE
[DiffEngine]: add clear CI mode notice and explanation in Diff UI

### DIFF
--- a/diffengine/Apps/DiffEngineApp.cs
+++ b/diffengine/Apps/DiffEngineApp.cs
@@ -70,6 +70,11 @@ public class DiffEngineApp : ViewBase
         }
 
         // text diff tab content
+        var ciInfo = Text.Muted($"CI mode: {(DiffService.IsCi ? "On" : "Off")} — " +
+                                   (DiffService.IsCi
+                                       ? "in CI, external diff tools are not launched."
+                                       : "locally you can launch external diff tools (WinMerge / VS Code, etc.)."));
+
         var leftCard =
             Layout.Vertical().Gap(3).Padding(2)
             | Text.H4("Left")
@@ -91,6 +96,7 @@ public class DiffEngineApp : ViewBase
             | (Layout.Horizontal().Gap(4).Grow()
                 | new Card(leftCard)
                 | new Card(rightCard))
+            | ciInfo
             | (Layout.Horizontal().Gap(3)
                 | new Button(Extensions[textExtIndex.Value])
                     .Primary()
@@ -131,6 +137,7 @@ public class DiffEngineApp : ViewBase
             | (Layout.Horizontal().Gap(4).Grow()
                 | new Card(leftFileCard)
                 | new Card(rightFileCard))
+            | ciInfo
             | (Layout.Horizontal().Gap(3)
                 | fileExtDropdown
                 | new Button("Launch Diff (Files)", onClick: () => { _ = launchFiles(); })


### PR DESCRIPTION
- Added a concise, user-friendly CI mode notice (ciInfo) to the Diff Engine demo UI.

- The notice explains what CI mode is and how it affects launching external diff tools:
  - CI mode: On — external GUI diff tools are not launched in CI environments.
  - CI mode: Off — locally you can launch external diff tools (WinMerge / VS Code, etc.).
 
- Displayed the notice under both “Text Diff” and “File Diff” sections for consistent visibility.

<img width="1913" height="911" alt="image" src="https://github.com/user-attachments/assets/c5808c32-84ce-4dd9-9222-63c23cccf295" />
