### PR TITLE
[DiffPlex]: set DiffEngineApp as default app

### DIFF
--- a/diffplex/Program.cs
+++ b/diffplex/Program.cs
@@ -1,4 +1,4 @@
-
+using DiffPlexExample.Apps;
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 var server = new Server();
 #if DEBUG
@@ -6,8 +6,11 @@ server.UseHotReload();
 #endif
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
+var customHeader = Layout.Vertical().Gap(2)
+    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdiffplex%2Fdevcontainer.json&location=EuropeWest");
 var chromeSettings = new ChromeSettings()
-
-    .UseTabs(preventDuplicates: true);
+    .DefaultApp<DiffPlexApp>()
+    .UseTabs(preventDuplicates: true)
+    .Header(customHeader);
 server.UseChrome(chromeSettings);
 await server.RunAsync();


### PR DESCRIPTION
- Set DiffPlexApp as the default Chrome app.

- Added a header embed button that opens a ready-to-use GitHub Codespaces environment for the DiffPlex demo.
<img width="1910" height="904" alt="image" src="https://github.com/user-attachments/assets/8a2f6333-c66e-4f7f-871f-941f82dd7c9d" />
