### PR TITLE
[OpperAI]: fix dialog form width in app

### DIFF
--- a/project-demos/opperai/Apps/OpperaiChatExample.cs
+++ b/project-demos/opperai/Apps/OpperaiChatExample.cs
@@ -315,7 +315,7 @@ namespace OpperaiExample.Apps
                             .ToDialog(isSettingsDialogOpen,
                                 title: "API key/Settings",
                                 submitTitle: "Save",
-                                width: Size.Units(600)
+                                width: Size.Units(150)
                             ) : null);
         }
     }


### PR DESCRIPTION
The issue arose because in OpperAI application the width Size.Units(600) was set for dialog forms, which actually looks like 2400 pixels.
To solve this, I set the value in units equal to 600 pixels, i.e. Size.Units(150).
Fixes [this issue](https://github.com/Ivy-Interactive/Ivy-Framework/issues/1647)

Now it looks as expected:
<img width="1366" height="600" alt="image" src="https://github.com/user-attachments/assets/a7547719-4eff-4abf-8c65-9c45e44c55d1" />
