### PR TITLE
[ci/cd]: Improve Ivy version update workflow logic

### DIFF
--- a/.github/workflows/build-all-projects.yml
+++ b/.github/workflows/build-all-projects.yml
@@ -95,7 +95,7 @@ jobs:
   discover-projects:
     name: Discover Projects
     runs-on: ubuntu-latest
-    needs: check-ivy-version
+    needs: [check-ivy-version, update-ivy-version]
     if: needs.check-ivy-version.outputs.should-build == 'true'
     outputs:
       projects: ${{ steps.find-projects.outputs.projects }}
@@ -106,6 +106,13 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Download updated csproj files
+        if: needs.update-ivy-version.outputs.has-changes == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-csproj-files
+          path: .
 
       - name: Find all .NET projects
         id: find-projects
@@ -130,7 +137,7 @@ jobs:
   build-projects:
     name: Build
     runs-on: ubuntu-latest
-    needs: [check-ivy-version, discover-projects]
+    needs: [check-ivy-version, discover-projects, update-ivy-version]
     if: needs.check-ivy-version.outputs.should-build == 'true' && needs.discover-projects.outputs.project-count > 0
     strategy:
       fail-fast: false
@@ -142,6 +149,13 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Download updated csproj files
+        if: needs.update-ivy-version.outputs.has-changes == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-csproj-files
+          path: .
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -163,6 +177,7 @@ jobs:
         run: dotnet restore "${{ matrix.project.path }}"
 
       - name: Build project
+        id: build
         run: |
           echo "🔨 Building: ${{ matrix.project.name }}"
           dotnet build "${{ matrix.project.path }}" \
@@ -170,11 +185,32 @@ jobs:
             --no-restore \
             --verbosity normal
 
-      - name: Upload build artifacts (on failure)
+      - name: Save build result
+        if: always()
+        run: |
+          mkdir -p build-results
+          # Create unique filename from path (replace / and . with -)
+          SAFE_NAME=$(echo "${{ matrix.project.path }}" | sed 's/[\/\.]/-/g')
+          if [ "${{ steps.build.outcome }}" == "success" ]; then
+            echo "success" > "build-results/${SAFE_NAME}.txt"
+          else
+            echo "failure" > "build-results/${SAFE_NAME}.txt"
+          fi
+          echo "SAFE_NAME=${SAFE_NAME}" >> $GITHUB_ENV
+
+      - name: Upload build result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-result-${{ env.SAFE_NAME }}
+          path: build-results/${{ env.SAFE_NAME }}.txt
+          retention-days: 1
+
+      - name: Upload build logs (on failure)
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: build-logs-${{ matrix.project.name }}
+          name: build-logs-${{ env.SAFE_NAME }}
           path: |
             **/bin/**/*.log
             **/obj/**/*.log
@@ -184,7 +220,7 @@ jobs:
     name: Detect Resolved Ivy Version
     runs-on: ubuntu-latest
     needs: [check-ivy-version, build-projects]
-    if: needs.check-ivy-version.outputs.should-build == 'true' && (success() || failure())
+    if: always() && needs.check-ivy-version.outputs.should-build == 'true'
     outputs:
       resolved-version: ${{ steps.get-version.outputs.resolved-version }}
     steps:
@@ -230,12 +266,12 @@ jobs:
     name: Update Ivy Version
     runs-on: ubuntu-latest
     needs: check-ivy-version
-    if: needs.check-ivy-version.outputs.should-build == 'true' && (needs.check-ivy-version.outputs.latest-version != needs.check-ivy-version.outputs.current-version || needs.check-ivy-version.outputs.has-multiple-versions == 'true')
+    if: needs.check-ivy-version.outputs.should-build == 'true'
+    outputs:
+      has-changes: ${{ steps.save-changes.outputs.has-changes }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -245,28 +281,122 @@ jobs:
       - name: Update Ivy version in csproj files
         run: |
           IVY_VERSION="${{ needs.check-ivy-version.outputs.latest-version }}"
-          echo "Updating Ivy to version: $IVY_VERSION"
+          CURRENT_VERSION="${{ needs.check-ivy-version.outputs.current-version }}"
+          HAS_MULTIPLE="${{ needs.check-ivy-version.outputs.has-multiple-versions }}"
+          
+          # Only update if version changed or multiple versions detected
+          if [ "$IVY_VERSION" != "$CURRENT_VERSION" ] || [ "$HAS_MULTIPLE" == "true" ]; then
+            echo "Updating Ivy to version: $IVY_VERSION"
+            
+            for csproj in $(find . -name "*.csproj"); do
+              if grep -q 'PackageReference Include="Ivy"' "$csproj"; then
+                echo "Updating: $csproj"
+                sed -i \
+                  "s|<PackageReference Include=\"Ivy\" Version=\"[^\"]*\"|<PackageReference Include=\"Ivy\" Version=\"$IVY_VERSION\"|g" \
+                  "$csproj"
+              fi
+            done
+          else
+            echo "No version update needed. Current version: $CURRENT_VERSION, Latest: $IVY_VERSION"
+          fi
 
-          for csproj in $(find . -name "*.csproj"); do
-            if grep -q 'PackageReference Include="Ivy"' "$csproj"; then
-              echo "Updating: $csproj"
-              sed -i \
-                "s|<PackageReference Include=\"Ivy\" Version=\"[^\"]*\"|<PackageReference Include=\"Ivy\" Version=\"$IVY_VERSION\"|g" \
-                "$csproj"
-            fi
-          done
-
-      - name: Commit changes if needed
+      - name: Save changes for commit
+        id: save-changes
         run: |
           if git diff --quiet; then
+            echo "has-changes=false" >> $GITHUB_OUTPUT
             echo "No changes to commit."
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add .
-            git commit -m "Update Ivy to version ${{ needs.check-ivy-version.outputs.latest-version }}"
-            git push
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+            echo "Changes will be committed after successful build."
           fi
+
+      - name: Upload updated csproj files
+        if: steps.save-changes.outputs.has-changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-csproj-files
+          path: |
+            **/*.csproj
+          retention-days: 1
+
+  check-build-results:
+    name: Check Build Results
+    runs-on: ubuntu-latest
+    needs: [check-ivy-version, discover-projects, build-projects]
+    if: always() && needs.check-ivy-version.outputs.should-build == 'true'
+
+    outputs:
+      all-succeeded: ${{ steps.calc.outputs.all-succeeded }}
+      success-count: ${{ steps.calc.outputs.success-count }}
+      total-count: ${{ steps.calc.outputs.total-count }}
+
+    steps:
+      - name: Download all build results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: build-result-*
+          path: build-results
+          merge-multiple: true
+
+      - name: Calculate build results
+        id: calc
+        run: |
+          total=${{ needs.discover-projects.outputs.project-count }}
+
+          success_count=$(grep -l "success" build-results/*.txt 2>/dev/null | wc -l | tr -d ' ')
+          failed_count=$(grep -l "failure" build-results/*.txt 2>/dev/null | wc -l | tr -d ' ')
+
+          if [ "$success_count" -eq "$total" ]; then
+            all="true"
+          else
+            all="false"
+          fi
+
+          echo "total-count=$total" >> $GITHUB_OUTPUT
+          echo "success-count=$success_count" >> $GITHUB_OUTPUT
+          echo "all-succeeded=$all" >> $GITHUB_OUTPUT
+
+          echo "## Build Results: $success_count/$total" >> $GITHUB_STEP_SUMMARY
+          echo "- **Successful:** $success_count" >> $GITHUB_STEP_SUMMARY
+          echo "- **Failed:** $failed_count" >> $GITHUB_STEP_SUMMARY
+
+          if [ "$all" != "true" ]; then
+            echo "❌ Build failed" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else
+            echo "✅ All builds passed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  commit-changes:
+    name: Commit Version Updates
+    runs-on: ubuntu-latest
+    needs: [check-ivy-version, update-ivy-version, check-build-results]
+    if: needs.check-build-results.outputs.all-succeeded == 'true' && needs.update-ivy-version.outputs.has-changes == 'true' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+
+      - name: Download updated csproj files
+        uses: actions/download-artifact@v4
+        with:
+          name: updated-csproj-files
+          path: .
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update Ivy to version ${{ needs.check-ivy-version.outputs.latest-version }}"
+          git push origin HEAD:${{ github.ref }}
+
 
   build-summary:
     name: Build Summary
@@ -276,6 +406,7 @@ jobs:
         check-ivy-version,
         discover-projects,
         build-projects,
+        check-build-results,
         detect-resolved-version,
       ]
     if: always() && needs.check-ivy-version.outputs.should-build == 'true'
@@ -285,23 +416,18 @@ jobs:
           echo "# 🚀 Ivy-Examples Build Summary" >> $GITHUB_STEP_SUMMARY
           resolved_version="${{ needs.detect-resolved-version.outputs.resolved-version }}"
           latest_version="${{ needs.check-ivy-version.outputs.latest-version }}"
+          success_count="${{ needs.check-build-results.outputs.success-count }}"
+          total_count="${{ needs.check-build-results.outputs.total-count }}"
           echo "## 📦 Ivy Version Information" >> $GITHUB_STEP_SUMMARY
           echo "- **Resolved Version:** $resolved_version" >> $GITHUB_STEP_SUMMARY
           echo "- **Latest Available:** $latest_version" >> $GITHUB_STEP_SUMMARY
-          echo "**Total Projects:** ${{ needs.discover-projects.outputs.project-count }}" >> $GITHUB_STEP_SUMMARY
-      - name: Set workflow status
-        run: |
-          if [ "${{ needs.build-projects.result }}" != "success" ]; then
-            echo "❌ Build workflow failed"
-            exit 1
-          else
-            echo "✅ Build workflow succeeded"
-          fi
+          echo "## 📊 Build Results" >> $GITHUB_STEP_SUMMARY
+          echo "- **Successful:** $success_count/$total_count" >> $GITHUB_STEP_SUMMARY
 
   create-badge:
     name: Update Build Badge
     runs-on: ubuntu-latest
-    needs: [check-ivy-version, build-summary, detect-resolved-version]
+    needs: [check-ivy-version, build-summary, check-build-results, detect-resolved-version]
     if: github.ref == 'refs/heads/main' && always() && needs.check-ivy-version.outputs.should-build == 'true'
     steps:
       - name: Create build status badge


### PR DESCRIPTION
## Summary

This PR refactors the Ivy version update logic in the `build-all-projects.yml` workflow to make it safer and more reliable. Version updates now only occur on the main branch after successful builds, and PRs are no longer affected by automatic version changes.

## Key Changes

### Version Updates Only on Main Branch
- Version updates in project files can only occur on the `main` or `develop` branches
- Pull requests are excluded from automatic version updates to prevent conflicts and unexpected changes

### Skip Updates in Pull Requests
- The `commit-changes` job now explicitly skips when `github.event_name == 'pull_request'`
- When running `build-all-projects.yml` in a PR context, the version update step is skipped, ensuring PRs remain unchanged

### Build-First Validation
- Version updates only commit if **all projects build successfully**
- If any project fails to build, version updates are not committed, preventing broken states

### Improved Build Flow
- Projects are built **after** the latest Ivy version is set in project files
- Updated `.csproj` files are saved as artifacts and downloaded by build jobs
- This ensures builds use the latest version while keeping the workflow atomic

## Technical Details

- `update-ivy-version` job now saves changes as artifacts instead of committing immediately
- `discover-projects` and `build-projects` jobs download updated `.csproj` files from artifacts
- `commit-changes` job only runs when:
  - All builds succeeded (`all-succeeded == 'true'`)
  - Changes exist (`has-changes == 'true'`)
  - Not a pull request (`github.event_name != 'pull_request'`)
  - On main or develop branch

## Benefits

- PRs remain clean and unaffected by automatic version updates
- Version updates only happen when all projects build successfully
- Builds use the latest Ivy version before committing changes
- Prevents broken states from partial updates

### This is how the Actions run looks on main. Note that there are no old Ivy versions in the .csproj files on main, so the version update step is skipped.
<img width="1026" height="658" alt="image" src="https://github.com/user-attachments/assets/4abc8a0b-081c-4c89-a5ae-cadc057deea6" />

### This is how the Action looks when projects are not being build. In that case, an informational message shows how many projects were successfully build.
<img width="959" height="877" alt="image" src="https://github.com/user-attachments/assets/ac4a804b-3c91-4c09-ad3f-78a885e27fc2" />

### This is how the Action looks when everything succeeds and the Ivy version needed to be updated.
<img width="951" height="877" alt="image" src="https://github.com/user-attachments/assets/6457e88d-f4dc-4b6c-bf2c-462e07fe835b" />




