### PR TITLE
[Chore]: Update Ivy to 1.2.35 and migrate blades to IBladeContext

### DIFF
--- a/agent-demos/lovable-event-planner/Apps/EventPlanner/EventBrowseView.cs
+++ b/agent-demos/lovable-event-planner/Apps/EventPlanner/EventBrowseView.cs
@@ -8,7 +8,7 @@ public class EventBrowseView : ViewBase
     {
         var service = UseService<EventService>();
         var client = UseService<IClientProvider>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
 
         var search = UseState("");
         var categoryFilter = UseState("All");

--- a/agent-demos/lovable-event-planner/Lovable.Event.Planner.csproj
+++ b/agent-demos/lovable-event-planner/Lovable.Event.Planner.csproj
@@ -11,7 +11,7 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/packages-demos/closedxml/Apps/WorkbooksEditorApp.cs
+++ b/packages-demos/closedxml/Apps/WorkbooksEditorApp.cs
@@ -21,7 +21,7 @@ public class WorkbooksListBlade : ViewBase
 {
     public override object? Build()
     {
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var workbookRepository = this.UseService<WorkbookRepository>();
         var refreshToken = this.UseRefreshToken();
 
@@ -89,7 +89,7 @@ public class WorkbookEditorBlade(string fileName) : ViewBase
 {
     public override object? Build()
     {
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var workbookRepository = this.UseService<WorkbookRepository>();
         var refreshToken = this.UseRefreshToken();
 
@@ -108,7 +108,7 @@ public class WorkbookEditorBlade(string fileName) : ViewBase
 /// <summary>
 /// Worksheet Editor - Allows adding columns, rows, and saving changes
 /// </summary>
-public class WorksheetEditor(DataTable table, string fileName, IBladeService blades) : ViewBase
+public class WorksheetEditor(DataTable table, string fileName, IBladeContext blades) : ViewBase
 {
     public override object? Build()
     {

--- a/packages-demos/closedxml/ClosedXmlExample.csproj
+++ b/packages-demos/closedxml/ClosedXmlExample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/packages-demos/miniexcel/Apps/MiniExcelApp.cs
+++ b/packages-demos/miniexcel/Apps/MiniExcelApp.cs
@@ -16,7 +16,7 @@ public class StudentsListBlade : ViewBase
 {
     public override object? Build()
     {
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var searchTerm = this.UseState("");
         var students = this.UseState(() => StudentService.GetStudents());
@@ -79,7 +79,7 @@ public class StudentDetailBlade(Guid studentId, Action? onRefresh = null) : View
     public override object? Build()
     {
         // 1. Hooks first
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var (alertView, showAlert) = this.UseAlert();
         var student = this.UseState(() => StudentService.GetStudents().FirstOrDefault(s => s.ID == studentId)!);

--- a/packages-demos/miniexcel/MiniExcelExample.csproj
+++ b/packages-demos/miniexcel/MiniExcelExample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/packages-demos/ollamasharp/Apps/ModelListBlade.cs
+++ b/packages-demos/ollamasharp/Apps/ModelListBlade.cs
@@ -9,7 +9,7 @@ public class ModelListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var client = UseService<IClientProvider>();
         var models = UseState(ImmutableArray.Create<ModelListRecord>());
         var modelsLoaded = UseState(false);

--- a/packages-demos/ollamasharp/OllamaSharpExample.csproj
+++ b/packages-demos/ollamasharp/OllamaSharpExample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/autodealer-crm/Apps/Views/CallRecordsApp.CallRecordDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/CallRecordsApp.CallRecordDetailsBlade.cs
@@ -5,7 +5,7 @@ public class CallRecordDetailsBlade(int callRecordId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<AutodealerCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var callRecord = UseState<CallRecord?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/autodealer-crm/Apps/Views/CallRecordsApp.CallRecordListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/CallRecordsApp.CallRecordListBlade.cs
@@ -6,7 +6,7 @@ public class CallRecordListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/CustomersApp.CustomerDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/CustomersApp.CustomerDetailsBlade.cs
@@ -5,7 +5,7 @@ public class CustomerDetailsBlade(int customerId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<AutodealerCrmContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var customer = this.UseState<Customer?>();
         var callRecordCount = this.UseState<int>();

--- a/project-demos/autodealer-crm/Apps/Views/CustomersApp.CustomerListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/CustomersApp.CustomerListBlade.cs
@@ -6,7 +6,7 @@ public class CustomerListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/LeadsApp.LeadDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/LeadsApp.LeadDetailsBlade.cs
@@ -5,7 +5,7 @@ public class LeadDetailsBlade(int leadId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<AutodealerCrmContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var lead = this.UseState<Lead?>();
         var callRecordCount = this.UseState<int>();

--- a/project-demos/autodealer-crm/Apps/Views/LeadsApp.LeadListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/LeadsApp.LeadListBlade.cs
@@ -6,7 +6,7 @@ public class LeadListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/MediaApp.MediumDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/MediaApp.MediumDetailsBlade.cs
@@ -5,7 +5,7 @@ public class MediumDetailsBlade(int mediumId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<AutodealerCrmContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var medium = this.UseState<Medium?>();
         var messageCount = this.UseState<int>();

--- a/project-demos/autodealer-crm/Apps/Views/MediaApp.MediumListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/MediaApp.MediumListBlade.cs
@@ -6,7 +6,7 @@ public class MediumListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/MessagesApp.MessageDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/MessagesApp.MessageDetailsBlade.cs
@@ -5,7 +5,7 @@ public class MessageDetailsBlade(int messageId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<AutodealerCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var message = UseState<Message?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/autodealer-crm/Apps/Views/MessagesApp.MessageListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/MessagesApp.MessageListBlade.cs
@@ -6,7 +6,7 @@ public class MessageListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/TasksApp.TaskDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/TasksApp.TaskDetailsBlade.cs
@@ -7,7 +7,7 @@ public class TaskDetailsBlade(int taskId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<AutodealerCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var task = UseState<Task?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/autodealer-crm/Apps/Views/TasksApp.TaskListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/TasksApp.TaskListBlade.cs
@@ -6,7 +6,7 @@ public class TaskListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/UsersApp.UserDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/UsersApp.UserDetailsBlade.cs
@@ -5,7 +5,7 @@ public class UserDetailsBlade(int userId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<AutodealerCrmContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var user = this.UseState<User?>();
         var callRecordCount = this.UseState<int>();

--- a/project-demos/autodealer-crm/Apps/Views/UsersApp.UserListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/UsersApp.UserListBlade.cs
@@ -6,7 +6,7 @@ public class UserListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/Apps/Views/VehiclesApp.VehicleDetailsBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/VehiclesApp.VehicleDetailsBlade.cs
@@ -5,7 +5,7 @@ public class VehicleDetailsBlade(int vehicleId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<AutodealerCrmContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var vehicle = this.UseState<Vehicle?>();
         var mediaCount = this.UseState<int>();

--- a/project-demos/autodealer-crm/Apps/Views/VehiclesApp.VehicleListBlade.cs
+++ b/project-demos/autodealer-crm/Apps/Views/VehiclesApp.VehicleListBlade.cs
@@ -6,7 +6,7 @@ public class VehicleListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<AutodealerCrmContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/autodealer-crm/AutodealerCrm.csproj
+++ b/project-demos/autodealer-crm/AutodealerCrm.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/crm-vc/Apps/Views/DealsApp.DealDetailsBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/DealsApp.DealDetailsBlade.cs
@@ -5,7 +5,7 @@ public class DealDetailsBlade(int dealId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<VcContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var deal = UseState<Deal?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/crm-vc/Apps/Views/DealsApp.DealListBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/DealsApp.DealListBlade.cs
@@ -6,7 +6,7 @@ public class DealListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<VcContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/crm-vc/Apps/Views/FoundersApp.FounderDetailsBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/FoundersApp.FounderDetailsBlade.cs
@@ -5,7 +5,7 @@ public class FounderDetailsBlade(int founderId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<VcContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var founder = UseState<Founder?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/crm-vc/Apps/Views/FoundersApp.FounderListBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/FoundersApp.FounderListBlade.cs
@@ -6,7 +6,7 @@ public class FounderListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<VcContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/crm-vc/Apps/Views/IndustriesApp.IndustryDetailsBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/IndustriesApp.IndustryDetailsBlade.cs
@@ -5,7 +5,7 @@ public class IndustryDetailsBlade(int industryId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<VcContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var industry = UseState<Industry?>(() => null!);
         var startups = UseState<List<Startup>>(() => new());

--- a/project-demos/crm-vc/Apps/Views/IndustriesApp.IndustryListBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/IndustriesApp.IndustryListBlade.cs
@@ -6,7 +6,7 @@ public class IndustryListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<VcContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/crm-vc/Apps/Views/PartnersApp.PartnerDetailsBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/PartnersApp.PartnerDetailsBlade.cs
@@ -5,7 +5,7 @@ public class PartnerDetailsBlade(int partnerId) : ViewBase
     public override object? Build()
     {
         var factory = UseService<VcContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var partner = UseState<Partner?>(() => null!);
         var (alertView, showAlert) = this.UseAlert();

--- a/project-demos/crm-vc/Apps/Views/PartnersApp.PartnerListBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/PartnersApp.PartnerListBlade.cs
@@ -6,7 +6,7 @@ public class PartnerListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<VcContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/crm-vc/Apps/Views/StartupsApp.StartupDetailsBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/StartupsApp.StartupDetailsBlade.cs
@@ -5,7 +5,7 @@ public class StartupDetailsBlade(int startupId) : ViewBase
     public override object? Build()
     {
         var factory = this.UseService<VcContextFactory>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
         var startup = this.UseState<Startup?>();
         var dealCount = this.UseState<int>();

--- a/project-demos/crm-vc/Apps/Views/StartupsApp.StartupListBlade.cs
+++ b/project-demos/crm-vc/Apps/Views/StartupsApp.StartupListBlade.cs
@@ -6,7 +6,7 @@ public class StartupListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var factory = UseService<VcContextFactory>();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/crm-vc/Vc.csproj
+++ b/project-demos/crm-vc/Vc.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/llm-tornado-ollama/Apps/LlmTornadoApp.cs
+++ b/project-demos/llm-tornado-ollama/Apps/LlmTornadoApp.cs
@@ -15,7 +15,7 @@ public class MainMenuBlade : ViewBase
     public override object? Build()
     {
         // 1. Hooks MUST be at the top
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var client = UseService<IClientProvider>();
         var ollamaUrl = UseState("http://localhost:11434");
         var selectedModel = UseState<string?>(() => null);

--- a/project-demos/llm-tornado-ollama/LlmTornadoExample.csproj
+++ b/project-demos/llm-tornado-ollama/LlmTornadoExample.csproj
@@ -16,7 +16,7 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.34" />
+      <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/llm-tornado-openai/Apps/LlmTornadoApp.cs
+++ b/project-demos/llm-tornado-openai/Apps/LlmTornadoApp.cs
@@ -14,7 +14,7 @@ public class MainMenuBlade : ViewBase
 {
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var client = UseService<IClientProvider>();
         var configuration = UseService<IConfiguration>();
 

--- a/project-demos/llm-tornado-openai/LlmTornadoExample.csproj
+++ b/project-demos/llm-tornado-openai/LlmTornadoExample.csproj
@@ -16,7 +16,7 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.34" />
+      <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/microsoft-agent-framework/MicrosoftAgentFramework.csproj
+++ b/project-demos/microsoft-agent-framework/MicrosoftAgentFramework.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/microsoft-agent-framework/Views/AgentListView.cs
+++ b/project-demos/microsoft-agent-framework/Views/AgentListView.cs
@@ -24,7 +24,7 @@ public class AgentListView : ViewBase
 
     public override object? Build()
     {
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var client = UseService<IClientProvider>();
         var isSettingsOpen = UseState(false);
         var settingsForm = UseState(new ApiSettingsModel

--- a/project-demos/microsoft-agent-framework/Views/AgentSettingsView.cs
+++ b/project-demos/microsoft-agent-framework/Views/AgentSettingsView.cs
@@ -24,7 +24,7 @@ public class AgentSettingsView : ViewBase
 
     public override object? Build()
     {
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var client = UseService<IClientProvider>();
 
         var form = UseState(AgentFormModel.FromConfiguration(_agent));

--- a/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyDetailsBlade.cs
@@ -6,7 +6,7 @@ public class CompanyDetailsBlade(int companyId) : ViewBase
     {
         var isDeleting = UseState(false);
         var factory = UseService<ShowcaseCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 

--- a/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyListBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyListBlade.cs
@@ -6,7 +6,7 @@ public class CompanyListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = UseRefreshToken();
 
         var filter = UseState("");

--- a/project-demos/showcase-crm/Apps/Views/ContactsApp.ContactDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/ContactsApp.ContactDetailsBlade.cs
@@ -6,7 +6,7 @@ public class ContactDetailsBlade(int contactId) : ViewBase
     {
         var isDeleting = UseState(false);
         var factory = UseService<ShowcaseCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 

--- a/project-demos/showcase-crm/Apps/Views/ContactsApp.ContactListBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/ContactsApp.ContactListBlade.cs
@@ -6,7 +6,7 @@ public class ContactListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = UseRefreshToken();
 
         var filter = UseState("");

--- a/project-demos/showcase-crm/Apps/Views/DealsApp.DealDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/DealsApp.DealDetailsBlade.cs
@@ -6,7 +6,7 @@ public class DealDetailsBlade(int dealId) : ViewBase
     {
         var isDeleting = UseState(false);
         var factory = UseService<ShowcaseCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 

--- a/project-demos/showcase-crm/Apps/Views/DealsApp.DealListBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/DealsApp.DealListBlade.cs
@@ -6,7 +6,7 @@ public class DealListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = UseRefreshToken();
 
         var filter = UseState("");

--- a/project-demos/showcase-crm/Apps/Views/LeadsApp.LeadDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/LeadsApp.LeadDetailsBlade.cs
@@ -6,7 +6,7 @@ public class LeadDetailsBlade(int leadId) : ViewBase
     {
         var isDeleting = UseState(false);
         var factory = UseService<ShowcaseCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 

--- a/project-demos/showcase-crm/Apps/Views/LeadsApp.LeadListBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/LeadsApp.LeadListBlade.cs
@@ -6,7 +6,7 @@ public class LeadListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = UseRefreshToken();
 
         var filter = UseState("");

--- a/project-demos/showcase-crm/Apps/Views/UsersApp.UserDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/UsersApp.UserDetailsBlade.cs
@@ -6,7 +6,7 @@ public class UserDetailsBlade(int userId) : ViewBase
     {
         var isDeleting = UseState(false);
         var factory = UseService<ShowcaseCrmContextFactory>();
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 

--- a/project-demos/showcase-crm/Apps/Views/UsersApp.UserListBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/UsersApp.UserListBlade.cs
@@ -6,7 +6,7 @@ public class UserListBlade : ViewBase
 
     public override object? Build()
     {
-        var blades = UseContext<IBladeService>();
+        var blades = UseContext<IBladeContext>();
         var refreshToken = UseRefreshToken();
 
         var filter = UseState("");

--- a/project-demos/showcase-crm/ShowcaseCrm.csproj
+++ b/project-demos/showcase-crm/ShowcaseCrm.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.34"  />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/project-demos/sliplane-manage/Apps/Views/ProjectsView.cs
+++ b/project-demos/sliplane-manage/Apps/Views/ProjectsView.cs
@@ -26,7 +26,7 @@ public class ProjectListBlade : ViewBase
     public override object? Build()
     {
         var client = this.UseService<SliplaneApiClient>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var refreshToken = this.UseRefreshToken();
 
         var filter = this.UseState(string.Empty);
@@ -185,7 +185,7 @@ public class ProjectDetailsBlade : ViewBase
     public override object? Build()
     {
         var client = this.UseService<SliplaneApiClient>();
-        var blades = this.UseContext<IBladeService>();
+        var blades = this.UseContext<IBladeContext>();
         var (alertView, showAlert) = this.UseAlert();
         var refreshToken = this.UseRefreshToken();
 

--- a/project-demos/sliplane-manage/SliplaneManage.csproj
+++ b/project-demos/sliplane-manage/SliplaneManage.csproj
@@ -16,7 +16,7 @@
     <Folder Include="Connections" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
+    <PackageReference Include="Ivy" Version="1.2.35" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.34">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
Bumps **Ivy** and **Ivy.Analyser** (where referenced) from **1.2.34** to **1.2.35** across multiple sample/demo projects.

## API migration
Replaces blade resolution from `UseContext<IBladeService>()` with **`UseContext<IBladeContext>()`** to match the Ivy 1.2.35 API. Primary constructor parameters that previously took `IBladeService` are updated to **`IBladeContext`** where needed (e.g. nested views/helpers).

## Scope (high level)
- Agent demos (e.g. lovable-event-planner)
- Package demos (closedxml, miniexcel, ollamasharp, etc.)
- Project demos (showcase-crm, autodealer-crm, crm-vc, llm-tornado-*, sliplane-manage, microsoft-agent-framework, …) per individual commits