### PR TITLE
[sliplane-deploy]: AppShell, stable app id, and draft persistence for repeat visits

### DIFF
--- a/project-demos/sliplane-deploy/Apps/SliplaneDeployApp.cs
+++ b/project-demos/sliplane-deploy/Apps/SliplaneDeployApp.cs
@@ -10,6 +10,7 @@ using SliplaneDeploy.Services;
 /// ?repo= is captured by RepoCaptureFilter, parsed into a DeployDraft, and pre-fills the form.
 /// </summary>
 [App(
+    id: "sliplane-deploy-app",
     icon: Icons.Rocket,
     title: "Deploy on Sliplane",
     isVisible: true)]

--- a/project-demos/sliplane-deploy/Program.cs
+++ b/project-demos/sliplane-deploy/Program.cs
@@ -32,4 +32,11 @@ server.AddConnectionsFromAssembly();
 
 server.UseAuth<SliplaneAuthProvider>();
 
+// DefaultApp is required so that after OAuth redirect (which lands on /) Ivy knows
+// which app to open — without this the shell can't resolve the route and shows "app not found".
+var appShellSettings = new AppShellSettings()
+    .DefaultApp<SliplaneDeployApp>()
+    .UseTabs(preventDuplicates: true);
+server.UseAppShell(appShellSettings);
+
 await server.RunAsync();


### PR DESCRIPTION
## Summary

Improves reliability when opening **Deploy on Sliplane** more than once (e.g. after closing a tab or completing OAuth), and clarifies which host serves the deploy UI vs Sliplane Manage.

## Changes

### `project-demos/sliplane-deploy`
- Register **`UseAppShell`** with **`DefaultApp<SliplaneDeployApp>()`** so that after OAuth redirect to `/` Ivy still resolves a valid app instead of showing “app not found”.
- Set explicit **`[App(id: "sliplane-deploy-app", …)]`** for a stable route.
- **Persist deploy draft** (`?repo=`) in an **HttpOnly cookie** in addition to in-memory storage so multi-replica / non-sticky deployments still restore the repo after the first request.

### `project-demos/sliplane-manage` (if included)
- Explicit **`id`** on Servers and Projects apps for consistent deep links / new tabs.
- README: deploy button points at the **hosted deploy app** URL and notes that **`/sliplane-deploy-app` is not served by Manage**.

### Other (if included)
- `QueryParamIdApp`: add `DefaultApp` for the same “fresh load / new tab” behavior.

## How to test

1. Run **sliplane-deploy** locally (`dotnet watch` in `project-demos/sliplane-deploy`).
2. Open `/sliplane-deploy-app?repo=<a public GitHub repo URL>`, sign in, use the flow, **close the tab**, open the same URL again (or repeat OAuth if session expired).
3. Confirm the deploy app loads instead of “app not found”.
4. (Optional) Hit the app twice behind multiple instances / without sticky sessions and confirm repo pre-fill still works.

## Related

- Fixes repeat-open / post-OAuth “app not found” on the deploy demo.
- Draft cookie mitigates empty state when requests hit different replicas.