### PR TITLE
[sliplane-deploy]: show deploy URLs inline, fix manage link, and widen error callout

### DIFF
--- a/project-demos/sliplane-deploy/Apps/SliplaneDeployApp.cs
+++ b/project-demos/sliplane-deploy/Apps/SliplaneDeployApp.cs
@@ -11,7 +11,7 @@ using SliplaneDeploy.Services;
 /// </summary>
 [App(
     id: "sliplane-deploy-app",
-    icon: Icons.Rocket,
+    icon: Icons.Server,
     title: "Deploy on Sliplane",
     isVisible: true)]
 public class SliplaneDeployApp : ViewBase
@@ -82,7 +82,6 @@ public class SliplaneDeployApp : ViewBase
         {
             return Layout.Center()
                 | (Layout.Vertical().AlignContent(Align.Center).Gap(6)
-                    | Icons.Rocket.ToIcon()
                     | Text.H2("Deploy to Sliplane")
                     | (draft is not null
                         ? Text.Muted($"Repository: {draft.RepoUrl}")

--- a/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
@@ -3,9 +3,6 @@ namespace SliplaneDeploy.Apps.Views;
 using SliplaneDeploy.Models;
 using SliplaneDeploy.Services;
 
-/// <summary>
-/// Shows deployment status by polling service events after create.
-/// </summary>
 public class DeployStatusView : ViewBase
 {
     private readonly string _apiToken;
@@ -25,79 +22,67 @@ public class DeployStatusView : ViewBase
         var eventsQuery = this.UseQuery<List<SliplaneServiceEvent>, (string, string, string)>(
             key: ("deploy-status-events", _projectId, _service.Id),
             fetcher: async ct => await client.GetServiceEventsAsync(_apiToken, _projectId, _service.Id),
-            options: new QueryOptions
-            {
-                RefreshInterval = TimeSpan.FromSeconds(2),
-                KeepPrevious = true,
-            });
+            options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(2), KeepPrevious = true });
         var serviceQuery = this.UseQuery<SliplaneService?, (string, string, string)>(
             key: ("deploy-service-details", _projectId, _service.Id),
             fetcher: async ct => await client.GetServiceAsync(_apiToken, _projectId, _service.Id),
-            options: new QueryOptions { KeepPrevious = true });
+            options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(3), KeepPrevious = true });
 
         var events = eventsQuery.Value ?? [];
         var status = DeriveStatus(events);
-        var failureMessage = GetFailureMessage(events);
-        var statusText = status switch
-        {
-            DeployStatus.Success => "Deploy succeeded",
-            DeployStatus.Failed => "Deploy failed",
-            DeployStatus.Deploying => "Deploying…",
-            _ => "Initializing…",
-        };
 
-        var calloutVariant = status switch
-        {
-            DeployStatus.Success => CalloutVariant.Success,
-            DeployStatus.Failed => CalloutVariant.Error,
-            _ => CalloutVariant.Info,
-        };
+        var latestService = serviceQuery.Value ?? _service;
+        var siteHost = ResolveSiteHost(latestService) ?? ResolveSiteHost(_service) ?? string.Empty;
+        var siteUrlAbsolute = string.IsNullOrWhiteSpace(siteHost) ? string.Empty
+            : siteHost.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? siteHost
+            : "https://" + siteHost;
 
-        var serviceForUrl = status == DeployStatus.Success ? serviceQuery.Value : _service;
-        var siteUrl = serviceForUrl?.Network?.CustomDomains?.FirstOrDefault()?.Domain
-                   ?? serviceForUrl?.Network?.ManagedDomain
-                   ?? string.Empty;
-        var siteUrlAbsolute = string.IsNullOrWhiteSpace(siteUrl)
-            ? string.Empty
-            : (siteUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
-               || siteUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
-                ? siteUrl
-                : "https://" + siteUrl);
+        var manageUrl = "https://ivy-sliplane-management.sliplane.app/$auth";
 
-        var header = status == DeployStatus.Success
-            ? (Layout.Vertical().Gap(1) | Text.H3(statusText))
-            : (Layout.Vertical().Gap(1) | Text.H3(statusText));
+        var content = Layout.Vertical().Gap(2).AlignContent(Align.Left);
 
-        object? progressBar = null;
-        if (status is DeployStatus.Deploying or DeployStatus.Unknown)
-        {
-            progressBar = new Progress().Indeterminate().Goal("Building and deploying…");
-        }
+        if (!string.IsNullOrEmpty(siteUrlAbsolute))
+            content = content | LabelPlusUrlRow("Your app will be available at:", siteUrlAbsolute);
 
-        object? errorSection = null;
+        content = content | LabelPlusUrlRow("You can manage it at:", manageUrl);
+
         if (status == DeployStatus.Failed)
         {
-            errorSection = Text.Block(!string.IsNullOrEmpty(failureMessage)
+            var failureMessage = GetFailureMessage(events);
+            var errBody = !string.IsNullOrEmpty(failureMessage)
                 ? failureMessage
-                : "Deployment failed. Check the service logs in Sliplane dashboard.");
+                : "Deployment failed. Check the service logs in Sliplane dashboard.";
+            content = content | new Callout(Text.Markdown($"**Deployment failed.**\n\n{MarkdownEscapePlain(errBody)}"),
+                variant: CalloutVariant.Error);
         }
 
-        object? linkSection = null;
-        if (status == DeployStatus.Success && !string.IsNullOrEmpty(siteUrlAbsolute))
-        {
-            linkSection = (Layout.Horizontal().AlignContent(Align.Left)| Text.Block("URL:").Bold() | new Button(siteUrl).Link().Url(siteUrlAbsolute).Width(Size.Fit()));
-        }
+        return content;
+    }
 
-        var content = Layout.Vertical().Gap(1).AlignContent(Align.Left)
-            | header;
-        if (progressBar != null)
-            content = content | progressBar;
-        if (errorSection != null)
-            content = content | errorSection;
-        if (linkSection != null)
-            content = content | linkSection;
+    /// <summary>
+    /// Single horizontal row: bold label + link button. Avoids <see cref="Text.Markdown"/> here because
+    /// it renders as block content (line breaks, extra icons) and breaks inline layout with the URL.
+    /// </summary>
+    private static object LabelPlusUrlRow(string label, string absoluteUrl) =>
+        Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+            | Text.Block(label).Bold()
+            | new Button(absoluteUrl).Link().Url(absoluteUrl).Width(Size.Fit());
 
-        return new Callout(content, "Deployment status", calloutVariant).Icon(Icons.Rocket);
+    private static string MarkdownEscapePlain(string s) =>
+        s.Replace("\\", "\\\\", StringComparison.Ordinal)
+         .Replace("*", "\\*", StringComparison.Ordinal)
+         .Replace("_", "\\_", StringComparison.Ordinal)
+         .Replace("#", "\\#", StringComparison.Ordinal)
+         .Replace("`", "\\`", StringComparison.Ordinal);
+
+    private static string? ResolveSiteHost(SliplaneService? s)
+    {
+        if (s == null) return null;
+        var custom = s.Network?.CustomDomains?.FirstOrDefault(d => !string.IsNullOrWhiteSpace(d.Domain))?.Domain;
+        if (!string.IsNullOrWhiteSpace(custom)) return custom.Trim();
+        var managed = s.Network?.ManagedDomain;
+        if (!string.IsNullOrWhiteSpace(managed)) return managed.Trim();
+        return s.Domains?.Select(d => d.Domain).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d))?.Trim();
     }
 
     private enum DeployStatus { Unknown, Deploying, Success, Failed }
@@ -106,23 +91,17 @@ public class DeployStatusView : ViewBase
     {
         if (events.Any(e => e.Type == "service_deploy_success")) return DeployStatus.Success;
         if (events.Any(e => e.Type == "service_deploy_failed" || e.Type == "service_build_failed")) return DeployStatus.Failed;
-
         var last = events.LastOrDefault();
         if (last == null) return DeployStatus.Unknown;
-
         return last.Type switch
         {
-            "service_deploy_success" => DeployStatus.Success,
+            "service_deploy_success"                           => DeployStatus.Success,
             "service_deploy_failed" or "service_build_failed" => DeployStatus.Failed,
-            "service_deploy" => DeployStatus.Deploying,
-            _ => DeployStatus.Deploying,
+            _                                                  => DeployStatus.Deploying,
         };
     }
 
-    private static string? GetFailureMessage(List<SliplaneServiceEvent> events)
-    {
-        var failed = events.LastOrDefault(e =>
-            e.Type == "service_deploy_failed" || e.Type == "service_build_failed");
-        return string.IsNullOrWhiteSpace(failed?.Message) ? null : failed.Message;
-    }
+    private static string? GetFailureMessage(List<SliplaneServiceEvent> events) =>
+        events.LastOrDefault(e => e.Type is "service_deploy_failed" or "service_build_failed")
+              ?.Message is { Length: > 0 } msg ? msg : null;
 }

--- a/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
@@ -39,7 +39,7 @@ public class DeployStatusView : ViewBase
 
         var manageUrl = "https://ivy-sliplane-management.sliplane.app/$auth";
 
-        var content = Layout.Vertical().Gap(2).AlignContent(Align.Left);
+        var content = Layout.Vertical().Gap(2).AlignContent(Align.Left).Width(Size.Full());
 
         if (!string.IsNullOrEmpty(siteUrlAbsolute))
             content = content | LabelPlusUrlRow("Your app will be available at:", siteUrlAbsolute);
@@ -53,7 +53,7 @@ public class DeployStatusView : ViewBase
                 ? failureMessage
                 : "Deployment failed. Check the service logs in Sliplane dashboard.";
             content = content | new Callout(Text.Markdown($"**Deployment failed.**\n\n{MarkdownEscapePlain(errBody)}"),
-                variant: CalloutVariant.Error);
+                variant: CalloutVariant.Error).Width(Size.Full());
         }
 
         return content;

--- a/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
@@ -42,12 +42,10 @@ public class DeployView : ViewBase
         _defaultProjectId = defaultProjectId;
     }
 
-    private const string ManageServicesUrl = "https://ivy-sliplane-management.sliplane.app/";
-
     public override object? Build()
     {
         var client = this.UseService<SliplaneApiClient>();
-        var ivyClient = this.UseService<IClientProvider>();
+        var config = this.UseService<IConfiguration>();
         var model = this.UseState(() => new DeployFormModel
         {
             ServerId = _defaultServerId,
@@ -138,13 +136,12 @@ public class DeployView : ViewBase
         }
 
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
-            | Icons.Rocket.ToIcon()
             | Text.H1("Deploy to Sliplane")
             | Text.Lead("Configure and deploy your Ivy app in seconds.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)
-                | new Button("Deploy").Icon(Icons.Rocket).Primary().Large()
+                | new Button("Deploy").Primary().Large()
                     .Loading(loading || isDeploying.Value).Disabled(loading || isDeploying.Value)
                     .Width(Size.Fraction(0.5f))
                     .OnClick(async _ => await HandleDeploy()))
@@ -168,8 +165,7 @@ public class DeployView : ViewBase
                         | Text.Block("Creating service on Sliplane…").Bold()
                         | new Progress().Indeterminate().Goal("Please wait…"),
                     "Deploying",
-                    CalloutVariant.Info)
-                .Icon(Icons.Rocket);
+                    CalloutVariant.Info);
         }
         else if (deployedService.Value is { } deployed)
         {
@@ -185,9 +181,12 @@ public class DeployView : ViewBase
         }
 
         var card = new Card(cardContent).Width(Size.Fraction(0.35f));
-        var manageBtn = new Button("Manage services").Icon(Icons.Settings)
-            .Outline().Large().BorderRadius(BorderRadius.Full)
-            .OnClick(_ => ivyClient.OpenUrl(ManageServicesUrl));
+        var manageServicesUrl = config["Sliplane:ManageServicesUrl"]?.Trim();
+        if (string.IsNullOrEmpty(manageServicesUrl))
+            manageServicesUrl = "https://ivy-sliplane-management.sliplane.app/";
+        var manageBtn = new Button("Manage services")
+            .Link().Url(manageServicesUrl)
+            .Outline().Large().BorderRadius(BorderRadius.Full);
         var manageFloat = new FloatingPanel(manageBtn, Align.BottomRight).Offset(new Thickness(0, 0, 20, 10));
 
         return new Fragment(Layout.Center() | card, manageFloat);


### PR DESCRIPTION
## Summary
Improves the Sliplane deploy demo after a service is created: users see the app URL and manage URL right away, links open reliably (native `Button.Link` instead of markdown-only links), and the failure callout uses the full card width.

## Changes
- **URLs after deploy:** Always show “Your app will be available at:” with the full `https://…` link once Sliplane returns a domain; separate row for manage with `https://ivy-sliplane-management.sliplane.app/$auth`.
- **Navigation:** Use `Button.Link().Url(...)` for external URLs so clicks work consistently (markdown links were not always opening).
- **Layout:** Keep label + URL on one row where possible (`Text.Block` + link button; avoid block markdown next to buttons).
- **Errors:** Deployment failure message in an error `Callout` stretched with `Width(Size.Full())`; vertical section also `Width(Size.Full())`.
- **Copy:** Single fixed phrase for the app URL line (“will be available”) regardless of deploy phase.
