### PR TITLE
[project-demos]: bump Ivy packages to 1.2.37-pre-20260412104447

### DIFF
--- a/project-demos/book-library/BookLibrary.csproj
+++ b/project-demos/book-library/BookLibrary.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.34">
+    <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/sliplane-deploy/SliplaneDeploy.csproj
+++ b/project-demos/sliplane-deploy/SliplaneDeploy.csproj
@@ -9,12 +9,12 @@
     <UserSecretsId>3901cf22-a0ae-47ab-879c-682515e69029</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.34" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.34">
+    <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.34" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.37-pre-20260412104447" />
   </ItemGroup>
 </Project>
 

--- a/project-demos/sliplane-manage/SliplaneManage.csproj
+++ b/project-demos/sliplane-manage/SliplaneManage.csproj
@@ -16,12 +16,12 @@
     <Folder Include="Connections" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.35" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.34">
+    <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.34" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.37-pre-20260412104447" />
   </ItemGroup>
 </Project>
 


### PR DESCRIPTION
## Summary

Bumps Ivy NuGet packages to **`1.2.37-pre-20260412104447`** so the affected demos use the same pre-release build.

## Projects updated

| Project | Packages |
|--------|----------|
| `project-demos/book-library` | `Ivy`, `Ivy.Analyser` |
| `project-demos/sliplane-deploy` | `Ivy`, `Ivy.Analyser`, `Ivy.Auth.Sliplane` |
| `project-demos/sliplane-manage` | `Ivy`, `Ivy.Analyser`, `Ivy.Auth.Sliplane` |

## Verification

- `dotnet restore` and `dotnet build` for each updated `.csproj` (or the whole solution, if applicable).

## Notes

- Pre-release packages may require the configured NuGet feed / CI secrets; adjust if this repo documents a specific feed for Ivy previews.