### PR TITLE
[00074] Add DotnetFormat verification to Examples project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+end_of_line = lf
+
+# IDE0005: Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning

--- a/packages-demos/HtmlAgilityPack/Apps/HtmlAgilityPack.cs
+++ b/packages-demos/HtmlAgilityPack/Apps/HtmlAgilityPack.cs
@@ -16,7 +16,7 @@ public class HtmlAgilityPackApp : ViewBase
         var urlSocialState = UseState<string>("");
         var errorState = UseState<string>("");
         var parsingState = UseState(false);
-        
+
         // Data type selection
         var dataTypesSelect = UseState<string[]>(new[] { "title", "meta", "images", "structure", "social", "links" });
         var dataTypeOptions = new[] { "title", "meta", "images", "structure", "social", "links" }.ToOptions();
@@ -76,13 +76,13 @@ public class HtmlAgilityPackApp : ViewBase
             if (document == null)
                 return string.Empty;
             string links = string.Empty;
-            var socialDomains = new[] { 
-                "facebook.com", "twitter.com", "x.com", "linkedin.com", "instagram.com", 
+            var socialDomains = new[] {
+                "facebook.com", "twitter.com", "x.com", "linkedin.com", "instagram.com",
                 "youtube.com", "tiktok.com", "discord.gg", "discord.com", "github.com",
                 "reddit.com", "pinterest.com", "snapchat.com", "telegram.org", "whatsapp.com",
                 "discord.gg/", "github.com/"
             };
-            
+
             var metaTags = document.DocumentNode.SelectNodes("//a");
             if (metaTags != null)
             {
@@ -101,7 +101,7 @@ public class HtmlAgilityPackApp : ViewBase
                                 break;
                             }
                         }
-                        
+
                         if (!isSocialLink)
                         {
                             links += href + System.Environment.NewLine;
@@ -130,12 +130,12 @@ public class HtmlAgilityPackApp : ViewBase
                     var alt = img.Attributes["alt"]?.Value ?? "";
                     var width = img.Attributes["width"]?.Value ?? "";
                     var height = img.Attributes["height"]?.Value ?? "";
-                    
+
                     if (!string.IsNullOrEmpty(src))
                     {
                         images += $"{src}";
                         if (!string.IsNullOrEmpty(alt)) images += $" (Alt: {alt})";
-                        if (!string.IsNullOrEmpty(width) || !string.IsNullOrEmpty(height)) 
+                        if (!string.IsNullOrEmpty(width) || !string.IsNullOrEmpty(height))
                             images += $" [{width}x{height}]";
                         images += System.Environment.NewLine;
                     }
@@ -149,7 +149,7 @@ public class HtmlAgilityPackApp : ViewBase
             if (document == null)
                 return string.Empty;
             string structure = string.Empty;
-            
+
             // Headers
             for (int i = 1; i <= 6; i++)
             {
@@ -166,28 +166,28 @@ public class HtmlAgilityPackApp : ViewBase
                     if (headers.Count > 5) structure += $"  ... and {headers.Count - 5} more" + System.Environment.NewLine;
                 }
             }
-            
+
             // Paragraphs
             var paragraphs = document.DocumentNode.SelectNodes("//p");
             if (paragraphs != null && paragraphs.Count > 0)
             {
                 structure += $"Paragraphs ({paragraphs.Count})" + System.Environment.NewLine;
             }
-            
+
             // Lists
             var lists = document.DocumentNode.SelectNodes("//ul | //ol");
             if (lists != null && lists.Count > 0)
             {
                 structure += $"Lists ({lists.Count})" + System.Environment.NewLine;
             }
-            
+
             // Tables
             var tables = document.DocumentNode.SelectNodes("//table");
             if (tables != null && tables.Count > 0)
             {
                 structure += $"Tables ({tables.Count})" + System.Environment.NewLine;
             }
-            
+
             return structure;
         };
 
@@ -196,13 +196,13 @@ public class HtmlAgilityPackApp : ViewBase
             if (document == null)
                 return string.Empty;
             string social = string.Empty;
-            
+
             // Social media links only (no meta tags)
             var socialLinks = document.DocumentNode.SelectNodes("//a[@href]");
             if (socialLinks != null)
             {
-                var socialDomains = new[] { 
-                    "facebook.com", "twitter.com", "x.com", "linkedin.com", "instagram.com", 
+                var socialDomains = new[] {
+                    "facebook.com", "twitter.com", "x.com", "linkedin.com", "instagram.com",
                     "youtube.com", "tiktok.com", "discord.gg", "discord.com", "github.com",
                     "reddit.com", "pinterest.com", "snapchat.com", "telegram.org", "whatsapp.com",
                     "discord.gg/", "github.com/"
@@ -226,7 +226,7 @@ public class HtmlAgilityPackApp : ViewBase
                     }
                 }
             }
-            
+
             return social;
         };
 
@@ -280,7 +280,7 @@ public class HtmlAgilityPackApp : ViewBase
                         (selectedTypes.Contains("structure") && urlStructureState.Value.Length > 0) ||
                         (selectedTypes.Contains("social") && urlSocialState.Value.Length > 0) ||
                         (selectedTypes.Contains("links") && urlLinksState.Value.Length > 0);
-                        
+
         var resultsContent = !hasAnyData
             ? Layout.Vertical().Gap(2)
                 | Text.H3("HTML Parser Results")
@@ -293,37 +293,37 @@ public class HtmlAgilityPackApp : ViewBase
                     "Site Title",
                     Text.Code(urlTitleState.Value)
                 ) : null)
-                
+
                 // Meta data
                 | (selectedTypes.Contains("meta") && urlMetaState.Value.Length > 0 ? new Expandable(
                     "Site Meta Data",
                     Text.Code(urlMetaState.Value)
                 ) : null)
-                
+
                 // Images
                 | (selectedTypes.Contains("images") && urlImagesState.Value.Length > 0 ? new Expandable(
                     "Images Found",
                     Text.Code(urlImagesState.Value)
                 ) : null)
-                
+
                 // Page structure
                 | (selectedTypes.Contains("structure") && urlStructureState.Value.Length > 0 ? new Expandable(
                     "Page Structure",
                     Text.Code(urlStructureState.Value)
                 ) : null)
-                
+
                 // Social media
                 | (selectedTypes.Contains("social") && urlSocialState.Value.Length > 0 ? new Expandable(
                     "Social Media Links",
                     Text.Code(urlSocialState.Value)
                 ) : null)
-                
+
                 // External links
                 | (selectedTypes.Contains("links") && urlLinksState.Value.Length > 0 ? new Expandable(
                     "External Links",
                     Text.Code(urlLinksState.Value)
                 ) : null)
-                
+
                 // Error display
                 | (errorState.Value.Length > 0 ? new Expandable(
                     "Error",

--- a/packages-demos/HtmlAgilityPack/GlobalUsings.cs
+++ b/packages-demos/HtmlAgilityPack/GlobalUsings.cs
@@ -1,11 +1,5 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/HtmlAgilityPack/Program.cs
+++ b/packages-demos/HtmlAgilityPack/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhtmlagilitypack%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhtmlagilitypack%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<HtmlAgilityPackApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/aspose-ocr/Apps/ImageToTextApp.cs
+++ b/packages-demos/aspose-ocr/Apps/ImageToTextApp.cs
@@ -1,5 +1,4 @@
 using Aspose.OCR;
-using System.IO;
 
 namespace AsposeOcrExample.Apps;
 

--- a/packages-demos/aspose-ocr/GlobalUsings.cs
+++ b/packages-demos/aspose-ocr/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/aspose-ocr/Program.cs
+++ b/packages-demos/aspose-ocr/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Faspose-ocr%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Faspose-ocr%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ImageToTextApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/aspose-words/Apps/AsposeWordsApp.cs
+++ b/packages-demos/aspose-words/Apps/AsposeWordsApp.cs
@@ -1,5 +1,4 @@
 using Aspose.Words;
-using Aspose.Words.Drawing;
 using Aspose.Words.Tables;
 
 namespace AsposeWordsExample.Apps;

--- a/packages-demos/aspose-words/GlobalUsings.cs
+++ b/packages-demos/aspose-words/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/barcodelib/GlobalUsings.cs
+++ b/packages-demos/barcodelib/GlobalUsings.cs
@@ -1,13 +1,4 @@
 ﻿global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/barcodelib/Program.cs
+++ b/packages-demos/barcodelib/Program.cs
@@ -1,6 +1,4 @@
 using BarcodeLibExample.Apps;
-using Ivy;
-using System.Globalization;
 
 var culture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentCulture = culture;
@@ -13,7 +11,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fbarcodelib%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fbarcodelib%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<BarcodeLibApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/bogus/Apps/BogusApp.cs
+++ b/packages-demos/bogus/Apps/BogusApp.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Collections.Immutable;
-using Ivy.Views.Builders;
-using Bogus;
-using Bogus.DataSets;
+﻿using Bogus;
 
 namespace BogusExample.Apps
 {
@@ -90,7 +83,7 @@ namespace BogusExample.Apps
               | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Bogus](https://github.com/bchavez/Bogus)");
 
             var leftCard = new Card(leftCardBody).Width(Size.Fraction(LeftCardWidth)).Height(Size.Fit().Min(Size.Full()));
-            
+
             // Right Card: Generated Orders Table
             var rightCardBody = Layout.Vertical().Gap(4).Padding(3)
               | Text.H2("Generated Orders")

--- a/packages-demos/bogus/GlobalUsings.cs
+++ b/packages-demos/bogus/GlobalUsings.cs
@@ -1,13 +1,5 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/bogus/Program.cs
+++ b/packages-demos/bogus/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fbogus%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fbogus%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<BogusApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/closedxml/Apps/WorkbooksEditorApp.cs
+++ b/packages-demos/closedxml/Apps/WorkbooksEditorApp.cs
@@ -75,7 +75,7 @@ public class WorkbooksListBlade : ViewBase
 
             return filtered
                 .Select(f => new WorkbookListRecord(
-                    f.FileName, 
+                    f.FileName,
                     f.Workbook.Worksheets.FirstOrDefault()?.ColumnsUsed().Count() ?? 0))
                 .ToArray();
         });
@@ -118,7 +118,7 @@ public class WorksheetEditor(DataTable table, string fileName, IBladeContext bla
         var selectedType = this.UseState("string");
         var columnName = this.UseState<string?>(() => null);
         var columnTypes = new string[] { "int", "double", "decimal", "long", "string" };
-        
+
 
         var addColumnButton = new Button("Add Column", _ =>
         {
@@ -132,10 +132,10 @@ public class WorksheetEditor(DataTable table, string fileName, IBladeContext bla
             {
                 var colName = columnName.Value;
                 table.Columns.Add(colName, GetColumnTypeFromString(selectedType.Value));
-                
+
                 // Auto-save changes - passing fileName directly to avoid shared state issues
                 workbookRepository.Save(fileName, table);
-                
+
                 columnName.Set(String.Empty);
                 refreshToken.Refresh();
                 client.Toast($"Column '{colName}' added and saved!");

--- a/packages-demos/closedxml/Apps/WorkbooksViewerApp.cs
+++ b/packages-demos/closedxml/Apps/WorkbooksViewerApp.cs
@@ -14,11 +14,11 @@ public class WorkbooksViewerApp : ViewBase
         var refreshToken = this.UseRefreshToken();
         var selectedFileIndex = this.UseState(0);
         var files = workbookRepository.GetFiles();
-        
+
         // Get selected file data
         DataTable? selectedTable = null;
         WorkbookFileInfo? selectedFile = null;
-        
+
         if (files.Count > 0 && selectedFileIndex.Value < files.Count)
         {
             selectedFile = files[selectedFileIndex.Value];
@@ -31,25 +31,25 @@ public class WorkbooksViewerApp : ViewBase
                 // Handle error silently
             }
         }
-        
+
         // Dropdown menu items for file selection
         var fileMenuItems = files
             .Select((file, idx) => MenuItem.Default(file.FileName).OnSelect(() => selectedFileIndex.Value = idx))
             .ToArray();
-        
+
         var fileDropDown = new Button(selectedFile?.FileName ?? "Select File")
             .Primary()
             .Icon(Icons.ChevronDown)
             .WithDropDown(fileMenuItems);
-        
+
         var refreshButton = Icons.RefreshCw.ToButton(_ => refreshToken.Refresh())
             .Variant(ButtonVariant.Secondary)
             .WithTooltip("Refresh file list");
-        
+
         // Left Card - File Selection and Info
         var columnCount = selectedTable?.Columns.Count ?? 0;
         var rowCount = selectedTable?.Rows.Count ?? 0;
-        
+
         var leftCard = new Card(
             Layout.Vertical().Gap(4).Padding(2)
             | Text.H2("File Selection")
@@ -61,48 +61,48 @@ public class WorkbooksViewerApp : ViewBase
             | Text.Block("This demo uses the ClosedXML NuGet package to work with Excel files.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [ClosedXML](https://github.com/ClosedXML/ClosedXML)")
         ).Width(Size.Fraction(0.45f)).Height(Size.Units(110));
-        
+
         // Right Card - Data Table
         var tableContent = selectedTable != null && selectedTable.Columns.Count > 0
             ? BuildDataTable(selectedTable)
             : Text.Muted("No data to display");
-        
+
         var rightCard = new Card(
             Layout.Vertical().Gap(4).Padding(2)
             | Text.H2("Data Preview")
             | Text.Muted(selectedFile != null ? $"Viewing: {selectedFile.FileName}" : "Select a file")
             | tableContent
         ).Width(Size.Fraction(0.45f)).Height(Size.Fit().Min(110));
-        
+
         return Layout.Horizontal().Gap(6).AlignContent(Align.Center)
             | leftCard
             | rightCard;
     }
-    
+
     private object BuildDataTable(DataTable table)
     {
         var rows = table.AsEnumerable().ToList();
         var tableColumns = table.Columns.Cast<DataColumn>().ToList();
         var listOfTableRows = new List<TableRow>();
-        
+
         // Header row
-        var headerCells = tableColumns.Select(col => 
+        var headerCells = tableColumns.Select(col =>
             new TableCell(col.ColumnName).IsHeader()
         ).ToList();
         listOfTableRows.Add(new TableRow([.. headerCells]));
-        
+
         // Data rows - limit to first 50 rows for performance
         var displayRows = rows.Take(50).ToList();
         foreach (var row in displayRows)
         {
-            var dataCells = row.ItemArray.Select(value => 
+            var dataCells = row.ItemArray.Select(value =>
                 new TableCell(value?.ToString() ?? "")
             ).ToList();
             listOfTableRows.Add(new TableRow([.. dataCells]));
         }
-        
+
         var tableView = new Table([.. listOfTableRows]);
-        
+
         // Show message if there are more rows
         if (rows.Count > 50)
         {
@@ -110,7 +110,7 @@ public class WorkbooksViewerApp : ViewBase
                 | tableView
                 | Text.Block($"Showing first 50 of {rows.Count} rows");
         }
-        
+
         return tableView;
     }
 }

--- a/packages-demos/closedxml/Connections/IvyClosedXml/WorkbookConnection.cs
+++ b/packages-demos/closedxml/Connections/IvyClosedXml/WorkbookConnection.cs
@@ -1,6 +1,3 @@
-using Ivy;
-using System.Data;
-
 /// <summary>
 /// Implement IConnection interface so that WorkbookConnection is registered in the DI container
 /// </summary>

--- a/packages-demos/closedxml/Connections/IvyClosedXml/WorkbookRepository.cs
+++ b/packages-demos/closedxml/Connections/IvyClosedXml/WorkbookRepository.cs
@@ -48,7 +48,7 @@ public class WorkbookRepository
     {
         if (currentFile == null)
             throw new InvalidOperationException("No current file is set. Call SetCurrentFile() first.");
-        
+
         return GetCurrentTable(currentFile.FileName);
     }
 
@@ -63,18 +63,18 @@ public class WorkbookRepository
         var file = GetFileByName(fileName);
         var worksheet = file.Workbook.Worksheets.FirstOrDefault();
         var table = worksheet?.Tables.FirstOrDefault();
-        
+
         if (table == null)
             return new DataTable() { TableName = "FirstTable" };
 
         var dataTable = table.AsNativeDataTable();
-        
+
         // Remove empty rows that ClosedXML might have created
         RemoveEmptyRows(dataTable);
-        
+
         return dataTable;
     }
-    
+
     /// <summary>
     /// Removes rows that are completely empty (all cells are null or whitespace).
     /// </summary>
@@ -82,7 +82,7 @@ public class WorkbookRepository
     private void RemoveEmptyRows(DataTable dataTable)
     {
         var rowsToDelete = new List<DataRow>();
-        
+
         foreach (DataRow row in dataTable.Rows)
         {
             bool isEmptyRow = true;
@@ -94,13 +94,13 @@ public class WorkbookRepository
                     break;
                 }
             }
-            
+
             if (isEmptyRow)
             {
                 rowsToDelete.Add(row);
             }
         }
-        
+
         foreach (var row in rowsToDelete)
         {
             dataTable.Rows.Remove(row);
@@ -201,7 +201,7 @@ public class WorkbookRepository
     {
         if (currentFile == null)
             throw new InvalidOperationException("No current file is set. Call SetCurrentFile() first.");
-        
+
         Save(currentFile.FileName, table);
     }
 
@@ -216,7 +216,7 @@ public class WorkbookRepository
     {
         var file = GetFileByName(fileName);
         var worksheet = file.Workbook.Worksheets.FirstOrDefault();
-        
+
         TryRemoveExistingTable(worksheet);
 
         worksheet

--- a/packages-demos/closedxml/GlobalUsings.cs
+++ b/packages-demos/closedxml/GlobalUsings.cs
@@ -1,11 +1,6 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;

--- a/packages-demos/closedxml/Models/Document.cs
+++ b/packages-demos/closedxml/Models/Document.cs
@@ -14,10 +14,10 @@ public class Document
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? LastAccessedAt { get; set; }
-    
+
     public string DisplayName => $"{FileName} ({SheetCount} sheets)";
-    public string FileSizeFormatted => FileSize < 1024 ? $"{FileSize} B" 
-        : FileSize < 1024 * 1024 ? $"{FileSize / 1024} KB" 
+    public string FileSizeFormatted => FileSize < 1024 ? $"{FileSize} B"
+        : FileSize < 1024 * 1024 ? $"{FileSize / 1024} KB"
         : $"{FileSize / (1024 * 1024)} MB";
 }
 

--- a/packages-demos/closedxml/Program.cs
+++ b/packages-demos/closedxml/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fclosedxml%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fclosedxml%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<WorkbooksViewerApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/closedxml/Services/DocumentStorage.cs
+++ b/packages-demos/closedxml/Services/DocumentStorage.cs
@@ -41,7 +41,7 @@ public static class DocumentStorage
     {
         lock (_lock)
         {
-            return _documents.FirstOrDefault(d => 
+            return _documents.FirstOrDefault(d =>
                 string.Equals(d.FileName, fileName, StringComparison.OrdinalIgnoreCase));
         }
     }
@@ -53,7 +53,7 @@ public static class DocumentStorage
     {
         lock (_lock)
         {
-            return _documents.Where(d => 
+            return _documents.Where(d =>
                 string.Equals(d.Author, author, StringComparison.OrdinalIgnoreCase))
                 .ToList();
         }
@@ -69,7 +69,7 @@ public static class DocumentStorage
             document.Id = _nextId++;
             document.CreatedAt = DateTime.UtcNow;
             document.UpdatedAt = DateTime.UtcNow;
-            
+
             _documents.Add(document);
             return document;
         }
@@ -94,7 +94,7 @@ public static class DocumentStorage
             existingDocument.SheetCount = document.SheetCount;
             existingDocument.FileSize = document.FileSize;
             existingDocument.UpdatedAt = DateTime.UtcNow;
-            
+
             return existingDocument;
         }
     }
@@ -159,7 +159,7 @@ public static class DocumentStorage
     {
         lock (_lock)
         {
-            return _documents.Where(d => 
+            return _documents.Where(d =>
                 d.CreatedAt >= startDate && d.CreatedAt <= endDate)
                 .ToList();
         }

--- a/packages-demos/constructs/GlobalUsings.cs
+++ b/packages-demos/constructs/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/constructs/Program.cs
+++ b/packages-demos/constructs/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fconstructs%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fconstructs%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ConstructsApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/diffengine/Apps/DiffEngineApp.cs
+++ b/packages-demos/diffengine/Apps/DiffEngineApp.cs
@@ -4,7 +4,7 @@ namespace DiffengineExample.Apps;
 public class DiffEngineApp : ViewBase
 {
     private const float MainCardWidthFraction = 0.8f;
-    
+
     private static readonly string[] Extensions =
     {
         "txt", "json"

--- a/packages-demos/diffengine/GlobalUsings.cs
+++ b/packages-demos/diffengine/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using DiffengineExample.Apps;

--- a/packages-demos/diffengine/Program.cs
+++ b/packages-demos/diffengine/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed(CodespacesUrl);
+    | new Embed(CodespacesUrl);
 var appShellSettings = new AppShellSettings()
     .DefaultApp<DiffEngineApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/dnsclient/Apps/DnsLookUpApp.cs
+++ b/packages-demos/dnsclient/Apps/DnsLookUpApp.cs
@@ -3,7 +3,7 @@ using DnsClientExample.Forms;
 
 namespace DnsClientExample.Apps;
 
-[App(icon: Icons.Server, title:"DNS Client")]
+[App(icon: Icons.Server, title: "DNS Client")]
 public class DnsLookUpApp : ViewBase
 {
     public override object? Build()

--- a/packages-demos/dnsclient/Components/DnsQueryResults.cs
+++ b/packages-demos/dnsclient/Components/DnsQueryResults.cs
@@ -14,7 +14,7 @@ public class DnsQueryResults : ViewBase
 
         UseEffect(() => signal.Receive(results =>
         {
-            queryResults.Set(results);           
+            queryResults.Set(results);
 
             return true;
         }));

--- a/packages-demos/dnsclient/Forms/DnsLookupForm.cs
+++ b/packages-demos/dnsclient/Forms/DnsLookupForm.cs
@@ -6,7 +6,7 @@ using DnsClientExample.Utils;
 namespace DnsClientExample.Forms;
 
 public class DnsLookupForm : ViewBase
-{ 
+{
     public override object? Build()
     {
         var signal = this.Context.UseSignal<DnsQueryResultsSignal, DnsQueryResponse?, bool>();

--- a/packages-demos/dnsclient/GlobalUsings.cs
+++ b/packages-demos/dnsclient/GlobalUsings.cs
@@ -1,12 +1,5 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/dnsclient/Program.cs
+++ b/packages-demos/dnsclient/Program.cs
@@ -14,7 +14,7 @@ server.AddConnectionsFromAssembly();
 server.Services.AddSingleton<ILookupClient>(i => new LookupClient());
 
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdnsclient%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdnsclient%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<DnsLookUpApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/enums-net/Apps/Enums.cs
+++ b/packages-demos/enums-net/Apps/Enums.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using EnumsNET;
 // Target: Enums.NET v5.0.0

--- a/packages-demos/enums-net/Apps/EnumsNetDemoApp.cs
+++ b/packages-demos/enums-net/Apps/EnumsNetDemoApp.cs
@@ -1,5 +1,4 @@
 using EnumsNET;
-using EnumsNetApp.Apps;
 using System.ComponentModel;
 /// <summary>
 /// Enums.NET demo view for Ivy samples.

--- a/packages-demos/enums-net/GlobalUsings.cs
+++ b/packages-demos/enums-net/GlobalUsings.cs
@@ -1,11 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;

--- a/packages-demos/enums-net/Program.cs
+++ b/packages-demos/enums-net/Program.cs
@@ -6,7 +6,7 @@ server.UseHotReload();
 #endif
 server.AddAppsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fenums-net%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fenums-net%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<EnumsNetDemoApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/exceldatareader/Apps/ExcelDataReaderApp.cs
+++ b/packages-demos/exceldatareader/Apps/ExcelDataReaderApp.cs
@@ -1,7 +1,4 @@
 using System.Data;
-using System.IO;
-using System.Collections.Generic;
-using ExcelDataReader;
 
 namespace ExcelDataReaderExample;
 
@@ -237,10 +234,10 @@ public class ExcelDataReaderApp : ViewBase
             }
 
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = fileInfo.Extension.ToLowerInvariant() == ".csv" 
+            using var reader = fileInfo.Extension.ToLowerInvariant() == ".csv"
                 ? ExcelReaderFactory.CreateCsvReader(stream)
                 : ExcelReaderFactory.CreateReader(stream);
-            
+
             if (reader == null)
             {
                 throw new InvalidOperationException("Failed to create reader for the file");
@@ -297,7 +294,7 @@ public class ExcelDataReaderApp : ViewBase
                     // Log error but continue processing
                     Console.WriteLine($"Error processing merge cells: {ex.Message}");
                 }
-                
+
                 // For CSV files, set MergeCellsCount to 0 since CSV doesn't support merged cells
                 if (fileInfo.Extension.ToLowerInvariant() == ".csv")
                 {

--- a/packages-demos/exceldatareader/GlobalUsings.cs
+++ b/packages-demos/exceldatareader/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using ExcelDataReader;

--- a/packages-demos/exceldatareader/Program.cs
+++ b/packages-demos/exceldatareader/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fexceldatareader%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fexceldatareader%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ExcelDataReaderApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/fuzzysharp/Apps/FuzzySharpApp.cs
+++ b/packages-demos/fuzzysharp/Apps/FuzzySharpApp.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using static FuzzySharp.Process;
 using FuzzySharp.Extractor;
-using Ivy.Core;
 
 [App(icon: Icons.Search, title: "FuzzySharp")]
 public class FuzzySharpApp : ViewBase
@@ -68,7 +64,7 @@ public class FuzzySharpApp : ViewBase
 
         var rightCard = new Card(
             Layout.Vertical().Gap(4).Padding(2)
-            | (results.Any() ? 
+            | (results.Any() ?
                 Layout.Vertical()
                     | Text.H2("Results")
                     | Text.Muted("Search results with similarity scores")

--- a/packages-demos/fuzzysharp/GlobalUsings.cs
+++ b/packages-demos/fuzzysharp/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/fuzzysharp/Program.cs
+++ b/packages-demos/fuzzysharp/Program.cs
@@ -1,4 +1,3 @@
-using FuzzySharpExample;
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 var server = new Server();
 #if DEBUG
@@ -7,7 +6,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffuzzysharp%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffuzzysharp%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<FuzzySharpApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/handlebars-net/Apps/HandlebarsNetApp.cs
+++ b/packages-demos/handlebars-net/Apps/HandlebarsNetApp.cs
@@ -28,7 +28,8 @@ public class HandlebarsNetApp : ViewBase
 </div>");
 
         // State for the JSON model string
-        var modelState = this.UseState<string>(JsonSerializer.Serialize(new {
+        var modelState = this.UseState<string>(JsonSerializer.Serialize(new
+        {
             name = "John Smith",
             company = "TechCorp",
             department = "Engineering",
@@ -78,13 +79,13 @@ public class HandlebarsNetApp : ViewBase
             | new Card(
                 Layout.Vertical()
                     | Layout.Tabs(
-                        new Tab("Template", 
+                        new Tab("Template",
                             Layout.Vertical().Gap(2)
                                 | Text.H3("Handlebars Template")
                                 | Text.Muted("Write your Handlebars template here. Use {{variable}} for data binding, {{#each}} for loops, and {{#if}} for conditions.")
                                 | templateState.ToCodeInput().Language(Languages.Html).Height(Size.Auto())
                         ).Icon(Icons.Code),
-                        new Tab("Data", 
+                        new Tab("Data",
                             Layout.Vertical().Gap(2)
                                 | Text.H3("JSON Data")
                                 | Text.Muted("Provide your data as JSON. This will be used to populate the template variables.")
@@ -102,7 +103,7 @@ public class HandlebarsNetApp : ViewBase
                     | new Spacer()
                     | Text.Block("This demo uses Handlebars.Net library for server-side HTML templating with data binding.")
                     | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Handlebars.Net](https://github.com/Handlebars-Net/Handlebars.Net)")
-                    
+
             ).Width(Size.Fraction(0.4f)).Height(Size.Fit().Min(Size.Full()));
     }
 }

--- a/packages-demos/handlebars-net/GlobalUsings.cs
+++ b/packages-demos/handlebars-net/GlobalUsings.cs
@@ -1,10 +1,8 @@
 global using Ivy;
-global using Ivy.Core;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text.Json;
 global using HandlebarsDotNet;
-global using HandlebarsDotNet.Helpers;
 global using System.Text.Json.Nodes;
 
 namespace HandlebarsNetExample;

--- a/packages-demos/handlebars-net/Program.cs
+++ b/packages-demos/handlebars-net/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhandlebars-net%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhandlebars-net%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<HandlebarsNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/humanizer/Apps/PlainTextHumanizer.cs
+++ b/packages-demos/humanizer/Apps/PlainTextHumanizer.cs
@@ -35,11 +35,11 @@ public class PlainTextHumanizerApp : ViewBase
             | new Card(
                 Layout.Vertical().Gap(4)
                     | Text.H3("Transformed Results")
-                    | (humanizedTexts.Value.Any() 
+                    | (humanizedTexts.Value.Any()
                         ? Layout.Vertical().Gap(2)
                             | Text.Muted("You can use these transformed texts in your code, documentation, or anywhere you need formatted text.")
                             | new Spacer()
-                            | humanizedTexts.Value.Reverse().Select(text => 
+                            | humanizedTexts.Value.Reverse().Select(text =>
                                 Text.Code(text)
                             ).ToArray()
                         : Layout.Vertical().Gap(2)

--- a/packages-demos/humanizer/Apps/PlainTextOptions.cs
+++ b/packages-demos/humanizer/Apps/PlainTextOptions.cs
@@ -1,4 +1,5 @@
 namespace HumanizerExample;
+
 public class PlainTextOptions : ViewBase
 {
     readonly IState<string> InputText;
@@ -20,11 +21,11 @@ public class PlainTextOptions : ViewBase
 
     public override object? Build()
     {
-        
+
         var transformationOptions = new[]
         {
             "Humanize (Sentence)",
-            "Humanize (Title)", 
+            "Humanize (Title)",
             "Humanize (All Caps)",
             "Humanize (Lower Case)",
             "Truncate (Sentence)",
@@ -45,7 +46,7 @@ public class PlainTextOptions : ViewBase
 
             var currentText = InputText.Value;
             var selectedOption = SelectedTransformation.Value;
-            
+
             switch (selectedOption)
             {
                 case "Humanize (Sentence)":
@@ -87,7 +88,7 @@ public class PlainTextOptions : ViewBase
                     currentText = NormalizeSeparator(currentText, '-');
                     break;
             }
-            
+
             HumanizedTexts.Set(HumanizedTexts.Value.Add(currentText));
         }
 
@@ -107,7 +108,7 @@ public class PlainTextOptions : ViewBase
                 | new Button("Clear History", onClick: _ => { HumanizedTexts.Set([]); })
                     .Variant(ButtonVariant.Destructive)
                     .Width(Size.Full());
-                
+
     }
 
     /// <summary>

--- a/packages-demos/humanizer/GlobalUsings.cs
+++ b/packages-demos/humanizer/GlobalUsings.cs
@@ -1,11 +1,5 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text.RegularExpressions;

--- a/packages-demos/humanizer/Program.cs
+++ b/packages-demos/humanizer/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhumanizer%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fhumanizer%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<PlainTextHumanizerApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/jwt/Apps/JwtDemoApp.cs
+++ b/packages-demos/jwt/Apps/JwtDemoApp.cs
@@ -13,7 +13,7 @@ public class JwtDemoApp : ViewBase
         var tokenInput = this.UseState<string>();
         var generatedToken = this.UseState<string>();
         var validationResult = this.UseState<string>();
-        
+
         var jwtService = new JwtService();
         // Generate a sample token
         var generateToken = new Action(() =>
@@ -43,7 +43,7 @@ public class JwtDemoApp : ViewBase
             var result = jwtService.ValidateToken(token);
             if (result.IsValid)
             {
-                var claimsText = result.Claims != null 
+                var claimsText = result.Claims != null
                     ? string.Join("\n", result.Claims.Select(kvp => $"{kvp.Key}: {kvp.Value}"))
                     : "No claims found";
                 validationResult.Set($"Token is valid!\n\nClaims:\n{claimsText}");

--- a/packages-demos/jwt/Apps/JwtService.cs
+++ b/packages-demos/jwt/Apps/JwtService.cs
@@ -34,12 +34,12 @@ public class JwtService
         // In a real application, use the JWT package for proper token generation
         var header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
         var payload = CreatePayload(claims, expirationMinutes);
-        
+
         // Simple base64 encoding (not proper JWT encoding)
         var headerEncoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
         var payloadEncoded = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(payload));
         var signature = "demo-signature"; // This would be a proper HMAC signature in real implementation
-        
+
         return $"{headerEncoded}.{payloadEncoded}.{signature}";
     }
 
@@ -68,7 +68,7 @@ public class JwtService
             var payload = parts[1];
             var payloadJson = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(payload));
             var payloadData = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(payloadJson);
-            
+
             if (payloadData == null)
             {
                 return new JwtValidationResult

--- a/packages-demos/magick-net-q16-anycpu/Apps/MagickNetApp.cs
+++ b/packages-demos/magick-net-q16-anycpu/Apps/MagickNetApp.cs
@@ -33,7 +33,7 @@ public class MagickNetApp : ViewBase
         var quality = UseState(90);
 
         var client = this.UseService<IClientProvider>();
-        
+
         // When a file is uploaded, process it
         UseEffect(() =>
         {
@@ -296,7 +296,7 @@ public class MagickNetApp : ViewBase
                              | Text.Block("Quality:")
                              | quality.ToNumberInput().Min(1).Max(100).Step(1)
                            : Text.Block(""))
-                           
+
                        | (Layout.Horizontal().Gap(4)
                        | (uploadedImageBytes.Value != null
                            ? new Button("Magic Image", onClick: ProcessImage)
@@ -319,7 +319,7 @@ public class MagickNetApp : ViewBase
                        | new Spacer().Height(Size.Units(10))
                        | (Layout.Center()
                        | new Image(processedImageDataUri.Value))
-                       
+
                      );
 
         return Layout.Vertical().Padding(3)

--- a/packages-demos/magick-net-q16-anycpu/Program.cs
+++ b/packages-demos/magick-net-q16-anycpu/Program.cs
@@ -16,7 +16,7 @@ server.AddConnectionsFromAssembly();
 
 // Configure Chrome to start with MagickApp
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmagick-net-q16-anycpu%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmagick-net-q16-anycpu%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<MagickNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/mapster/GlobalUsings.cs
+++ b/packages-demos/mapster/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text.Json;

--- a/packages-demos/mapster/Mapping/MapsterConfig.cs
+++ b/packages-demos/mapster/Mapping/MapsterConfig.cs
@@ -21,7 +21,7 @@
                         dest.FirstName = parts[0];
                         dest.LastName = parts[1];
                     }
-                    else 
+                    else
                     {
                         dest.FirstName = src.FullName;
                         dest.LastName = "";

--- a/packages-demos/mapster/Program.cs
+++ b/packages-demos/mapster/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmapster%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmapster%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<MapsterApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/microsoft-semantickernel/Apps/MicrosoftSemanticKernelApp.cs
+++ b/packages-demos/microsoft-semantickernel/Apps/MicrosoftSemanticKernelApp.cs
@@ -30,7 +30,7 @@ Next steps: Everyone should update their progress in the project management tool
         var isLoading = UseState(false);
         var triggerRefresh = UseState(0);
         var tasks = UseState<string[]>([]);
-        
+
         UseEffect(async () =>
         {
             isLoading.Set(true);
@@ -56,7 +56,7 @@ Next steps: Everyone should update their progress in the project management tool
                 isLoading.Set(false);
             }
         }, triggerRefresh);
-        
+
         return Layout.Horizontal().Gap(5).Padding(5)
             | new Card(
                 Layout.Vertical()

--- a/packages-demos/microsoft-semantickernel/Program.cs
+++ b/packages-demos/microsoft-semantickernel/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmicrosoft-semantickernel%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmicrosoft-semantickernel%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<MicrosoftSemanticKernelApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/mimemapping/Apps/MimeMappingApp.cs
+++ b/packages-demos/mimemapping/Apps/MimeMappingApp.cs
@@ -11,11 +11,11 @@ public class MimeMappingApp : ViewBase
         var fileInput = this.UseState<string>();
         var uploadState = this.UseState<FileUpload<byte[]>?>();
         var uploadBase = this.UseUpload(MemoryStreamUploadHandler.Create(uploadState));
-        
+
         var mimeTypeInput = this.UseState<string>();
         var searchQuery = this.UseState<string>();
         var currentPage = this.UseState(1);
-        
+
         // Reset to page 1 when search query changes
         UseEffect(() =>
         {
@@ -42,7 +42,7 @@ public class MimeMappingApp : ViewBase
         // Get paginated types
         var totalItems = allFilteredTypes.Count;
         var totalPages = (int)Math.Ceiling(totalItems / (double)itemsPerPage);
-        
+
         // Ensure current page is valid
         if (currentPage.Value < 1)
         {
@@ -52,7 +52,7 @@ public class MimeMappingApp : ViewBase
         {
             currentPage.Set(totalPages);
         }
-        
+
         var filteredTypes = allFilteredTypes.Skip((currentPage.Value - 1) * itemsPerPage).Take(itemsPerPage);
 
         return Layout.Vertical()
@@ -77,7 +77,7 @@ public class MimeMappingApp : ViewBase
         // Validation
         string? fileInputError = null;
         string? fileUploadError = null;
-        
+
         if (inputMethod.Value == InputMethod.UploadFile && uploadState.Value != null)
         {
             var detected = MimeUtility.GetMimeMapping(uploadState.Value.FileName);
@@ -94,11 +94,11 @@ public class MimeMappingApp : ViewBase
                 fileInputError = "Unknown file type - returns default application/octet-stream";
             }
         }
-        
+
         // Check if inputs have values
         bool hasUploadValue = inputMethod.Value == InputMethod.UploadFile && uploadState.Value != null;
         bool hasInputValue = inputMethod.Value == InputMethod.EnterFileName && !string.IsNullOrEmpty(fileInput.Value);
-        
+
         object inputSection = inputMethod.Value == InputMethod.UploadFile
             ? Layout.Vertical()
                 | Text.Label("Choose File")
@@ -146,7 +146,7 @@ public class MimeMappingApp : ViewBase
             | (totalPages > 1
                 ? new Pagination(currentPage.Value, totalPages, evt => currentPage.Set(evt.Value))
                 : null);
-            
+
     }
 
     private object BuildReverseLookupDemo(IState<string> mimeTypeInput, string[]? extensions)
@@ -168,7 +168,7 @@ public class MimeMappingApp : ViewBase
                 mimeTypeError = "This MIME type is not recognized or has no associated extensions";
             }
         }
-        
+
         // Determine if we should show results
         bool showResults = isValidInput && mimeTypeError == null && hasValidExtensions;
 
@@ -180,7 +180,7 @@ public class MimeMappingApp : ViewBase
                 | mimeTypeInput.ToInput(placeholder: "e.g., image/jpeg, application/pdf, text/html")
                     .Invalid(mimeTypeError)
                 )
-            
+
             | new Card(
                 Layout.Vertical().Gap(5)
                 | Text.H3("Lookup Result")

--- a/packages-demos/mimemapping/GlobalUsings.cs
+++ b/packages-demos/mimemapping/GlobalUsings.cs
@@ -1,9 +1,4 @@
 ﻿global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using MimeMapping;

--- a/packages-demos/mimemapping/Program.cs
+++ b/packages-demos/mimemapping/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmimemapping%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmimemapping%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<MimeMappingApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/miniexcel/GlobalUsings.cs
+++ b/packages-demos/miniexcel/GlobalUsings.cs
@@ -1,11 +1,6 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Data;
-global using System.Diagnostics;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Linq;

--- a/packages-demos/naudio/Apps/NAudioApp.cs
+++ b/packages-demos/naudio/Apps/NAudioApp.cs
@@ -162,9 +162,9 @@ public class NAudioApp : ViewBase
                             mixDataUrl.Set("data:audio/wav;base64," + Convert.ToBase64String(mixed));
                             client.Toast("Audio mixed successfully");
                         }
-                        catch (Exception ex) 
-                        { 
-                            mixError.Set(ex.Message); 
+                        catch (Exception ex)
+                        {
+                            mixError.Set(ex.Message);
                             mixBytes.Set((byte[]?)null);
                             mixDataUrl.Set((string?)null);
                         }

--- a/packages-demos/naudio/GlobalUsings.cs
+++ b/packages-demos/naudio/GlobalUsings.cs
@@ -1,12 +1,6 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
-global using NAudio;
 global using NAudio.Wave;
 global using NAudio.Wave.SampleProviders;
 global using NAudio.MediaFoundation;

--- a/packages-demos/naudio/Program.cs
+++ b/packages-demos/naudio/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnaudio%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnaudio%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<NAudioApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/newtonsoft-json/Apps/NewtonsoftJsonApp.cs
+++ b/packages-demos/newtonsoft-json/Apps/NewtonsoftJsonApp.cs
@@ -39,7 +39,7 @@ namespace NewtonsoftJsonExample
             // Simple email validation (Ivy-style via Invalid)
             UseEffect(() =>
             {
-                
+
                 if (!(email.Value.Contains("@") && email.Value.Contains(".")))
                 {
                     emailInvalid.Set("Please enter a valid email address");
@@ -113,23 +113,23 @@ namespace NewtonsoftJsonExample
                 Layout.Horizontal().Gap(8)
                     | new Card(
                         Layout.Vertical()
-						| Text.H4("Source JSON")
-						| Text.Muted("Edit sample JSON (add roles, tweak fields) then click Deserialize to load it here.")
+                        | Text.H4("Source JSON")
+                        | Text.Muted("Edit sample JSON (add roles, tweak fields) then click Deserialize to load it here.")
                         | rawData.ToCodeInput(variant: CodeInputVariant.Default, language: Languages.Json).Height(Size.Fit())
                             .Disabled(!isSerialized.Value)
                         | new Button("Deserialize", _ => HandleButtonClick())
                             .Disabled(!isSerialized.Value)
                             .Icon(Icons.ArrowRight, Align.Right)
                         | new Spacer()
-                        |   ("This demo uses Newtonsoft.Json library to serialize and deserialize JSON data.")
+                        | ("This demo uses Newtonsoft.Json library to serialize and deserialize JSON data.")
                         | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json)")
                         )
                         .Width(Size.Half()).Height(Size.Fit().Min(Size.Full()))
 
                     | new Card(
                         Layout.Vertical()
-						| Text.H4("User Editor")
-						| Text.Muted("Modify user fields, pick date and roles, then click Serialize to push changes back to JSON.")
+                        | Text.H4("User Editor")
+                        | Text.Muted("Modify user fields, pick date and roles, then click Serialize to push changes back to JSON.")
 
                         | Text.Label("Full name")
                         | fullName.ToTextInput(placeholder: "Full name")

--- a/packages-demos/newtonsoft-json/GlobalUsings.cs
+++ b/packages-demos/newtonsoft-json/GlobalUsings.cs
@@ -1,14 +1,6 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using Newtonsoft.Json;
-global using Newtonsoft.Json.Converters;
-global using Newtonsoft.Json.Linq;
-global using System.Reflection;
 
 namespace NewtonsoftJsonExample;

--- a/packages-demos/newtonsoft-json/Models/Users.cs
+++ b/packages-demos/newtonsoft-json/Models/Users.cs
@@ -1,4 +1,5 @@
 ﻿namespace NewtonsoftJsonExample;
+
 public class UserData
 {
     public string FullName { get; set; } = string.Empty;

--- a/packages-demos/newtonsoft-json/Program.cs
+++ b/packages-demos/newtonsoft-json/Program.cs
@@ -8,7 +8,7 @@ server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnewtonsoft-json%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnewtonsoft-json%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<NewtonsoftJsonApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/nodatime/Apps/NodaTimeApp.cs
+++ b/packages-demos/nodatime/Apps/NodaTimeApp.cs
@@ -7,10 +7,10 @@ public class NodaTimeApp : ViewBase
     {
         var tzState = this.UseState<string>();
         var timeState = this.UseState<object?>(Text.Muted("Select a timezone to see results..."));
-        
+
         // Update time whenever timezone selection changes
         UseEffect(() => { UpdateTime(tzState.Value); }, tzState);
-        
+
         // Helper function: updates the UI whenever a timezone is selected
         void UpdateTime(string tzId)
         {
@@ -86,8 +86,8 @@ public class NodaTimeApp : ViewBase
                 // Display the structured time output
                 | new Card(timeState.Value)
                 | new Spacer()
-				| Text.Block("This demo uses NodaTime to handle timezones and display UTC and local times.")
-			    | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [NodaTime](https://github.com/nodatime/nodatime)")
+                | Text.Block("This demo uses NodaTime to handle timezones and display UTC and local times.")
+                | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [NodaTime](https://github.com/nodatime/nodatime)")
             )
             .Width(Size.Fit().Min(100).Max(600)));
     }

--- a/packages-demos/nodatime/GlobalUsings.cs
+++ b/packages-demos/nodatime/GlobalUsings.cs
@@ -1,12 +1,6 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
-global using System.Reflection;
 global using NodaTime;
 global using NodaTime.Text;
 

--- a/packages-demos/nodatime/Program.cs
+++ b/packages-demos/nodatime/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnodatime%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fnodatime%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<NodaTimeApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/ollamasharp/Apps/OllamaSharpApp.cs
+++ b/packages-demos/ollamasharp/Apps/OllamaSharpApp.cs
@@ -5,7 +5,7 @@ public class OllamaSharpChatApp : ViewBase
 {
     public override object? Build()
     {
-        var blades =this.UseBlades(() => new ModelListBlade(), "Models");
+        var blades = this.UseBlades(() => new ModelListBlade(), "Models");
         return blades;
     }
 }

--- a/packages-demos/ollamasharp/GlobalUsings.cs
+++ b/packages-demos/ollamasharp/GlobalUsings.cs
@@ -1,9 +1,5 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text;

--- a/packages-demos/openai/Apps/OpenAIExample.cs
+++ b/packages-demos/openai/Apps/OpenAIExample.cs
@@ -1,5 +1,4 @@
-﻿using Ivy;
-using OpenAI.Chat;
+﻿using OpenAI.Chat;
 
 namespace OpenAIExample.Apps
 {

--- a/packages-demos/openai/GlobalUsings.cs
+++ b/packages-demos/openai/GlobalUsings.cs
@@ -1,9 +1,5 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/qrcoder/Apps/ProfileApp.cs
+++ b/packages-demos/qrcoder/Apps/ProfileApp.cs
@@ -20,7 +20,7 @@ public class ProfileApp : ViewBase
         var profile = UseState(() => new ProfileModel("", "", "", null, null, null));
         var qrCodeBase64 = UseState<string>("");
         var profileSubmitted = UseState<bool>(false);
-        
+
         var qrCodeService = new QrCodeService();
         var formBuilder = profile.ToForm()
             .Required(m => m.FirstName, m => m.LastName, m => m.Email)

--- a/packages-demos/qrcoder/GlobalUsings.cs
+++ b/packages-demos/qrcoder/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/qrcoder/Program.cs
+++ b/packages-demos/qrcoder/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fqrcoder%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fqrcoder%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ProfileApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/qrcoder/Services/QrCodeService.cs
+++ b/packages-demos/qrcoder/Services/QrCodeService.cs
@@ -23,41 +23,41 @@ public class QrCodeService : IQrCodeService
     private static string GenerateVCard(string firstName, string lastName, string email, string? phone, string? linkedin, string? github)
     {
         var vCard = new StringBuilder();
-        
+
         // vCard header
         vCard.AppendLine("BEGIN:VCARD");
         vCard.AppendLine("VERSION:3.0");
-        
+
         // Full name
         vCard.AppendLine($"FN:{firstName} {lastName}");
-        
+
         // Structured name (Last;First;;;)
         vCard.AppendLine($"N:{lastName};{firstName};;;");
-        
+
         // Email
         vCard.AppendLine($"EMAIL;TYPE=INTERNET:{email}");
-        
+
         // Phone (if provided)
         if (!string.IsNullOrWhiteSpace(phone))
         {
             vCard.AppendLine($"TEL;TYPE=CELL:{phone}");
         }
-        
+
         // LinkedIn URL as a URL field
         if (!string.IsNullOrWhiteSpace(linkedin))
         {
             vCard.AppendLine($"URL;TYPE=LinkedIn:{linkedin}");
         }
-        
+
         // GitHub URL as a URL field
         if (!string.IsNullOrWhiteSpace(github))
         {
             vCard.AppendLine($"URL;TYPE=GitHub:{github}");
         }
-        
+
         // vCard footer
         vCard.AppendLine("END:VCARD");
-        
+
         return vCard.ToString();
     }
 }

--- a/packages-demos/restsharp/Apps/RestsharpApp.cs
+++ b/packages-demos/restsharp/Apps/RestsharpApp.cs
@@ -5,7 +5,7 @@ public class RestSharpApp : ViewBase
 {
     private const string BaseApiUrl = "https://api.restful-api.dev/objects";
 
-    private static bool RequiresResourceId(string? method) => 
+    private static bool RequiresResourceId(string? method) =>
         method?.ToUpper() is "DELETE" or "PUT" or "PATCH";
 
     private static string BuildUrlWithResourceId(string? resourceId) =>
@@ -80,7 +80,7 @@ public class RestSharpApp : ViewBase
             try
             {
                 // Build final URL with ID if needed
-                var finalUrl = RequiresResourceId(method.Value) 
+                var finalUrl = RequiresResourceId(method.Value)
                     ? BuildUrlWithResourceId(resourceId.Value)
                     : url.Value;
 

--- a/packages-demos/restsharp/GlobalUsings.cs
+++ b/packages-demos/restsharp/GlobalUsings.cs
@@ -1,6 +1,5 @@
 global using Ivy;
 global using System.Globalization;
-global using System.Collections.Immutable;
 global using System.Reactive.Linq;
 global using System.Text.Json;
 global using System.Net;

--- a/packages-demos/restsharp/Program.cs
+++ b/packages-demos/restsharp/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Frestsharp%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Frestsharp%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<RestSharpApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/serialize-linq/Apps/SerializeLinqApp.cs
+++ b/packages-demos/serialize-linq/Apps/SerializeLinqApp.cs
@@ -100,7 +100,7 @@ public class SerializeLinqApp : ViewBase
             | new Spacer().Height(Size.Units(5))
             | Text.Block("This demo demonstrates the use of Serialize.Linq to serialize and deserialize LINQ expressions.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Serialize.Linq](https://github.com/esskar/Serialize.Linq)")
-             
+
         ).Title("Input Data").Width(Size.Fraction(0.4f));
 
         // Right card - Results

--- a/packages-demos/serialize-linq/GlobalUsings.cs
+++ b/packages-demos/serialize-linq/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Linq.Expressions;

--- a/packages-demos/serialize-linq/Program.cs
+++ b/packages-demos/serialize-linq/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fserialize-linq%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fserialize-linq%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SerializeLinqApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/simmetrics-net/Apps/SimMetricsNetApp.cs
+++ b/packages-demos/simmetrics-net/Apps/SimMetricsNetApp.cs
@@ -35,7 +35,7 @@ public class SimMetricsNetApp : ViewBase
             nameList.Set(results);
         }, inputString, inputMetric);
 
-        
+
         List<NameSimilarity> CreateInitialNameList() =>
             Enumerable.Range(1, 10)
                 .Select(_ => new NameSimilarity(new Faker().Name.FullName(), 0.0))

--- a/packages-demos/simmetrics-net/GlobalUsings.cs
+++ b/packages-demos/simmetrics-net/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using Bogus;

--- a/packages-demos/simmetrics-net/Program.cs
+++ b/packages-demos/simmetrics-net/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsimmetrics-net%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsimmetrics-net%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SimMetricsNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/superpower/Apps/DateTimeParserView.cs
+++ b/packages-demos/superpower/Apps/DateTimeParserView.cs
@@ -1,6 +1,6 @@
 ﻿namespace SuperpowerExample
 {
-    internal class DateTimeParserView: ViewBase
+    internal class DateTimeParserView : ViewBase
     {
         public override object? Build()
         {
@@ -70,11 +70,11 @@
             var resultCard = new Card(
                 Layout.Vertical().Gap(3).Padding(3)
                 | Text.H4("Result")
-                | (errorState.Value.Length > 0 
+                | (errorState.Value.Length > 0
                     ? Layout.Vertical().Gap(2)
                         | Text.Block("Parsing Error:")
                         | Text.Code(errorState.Value)
-                    : resultState.Value 
+                    : resultState.Value
                         ? Layout.Vertical().Gap(2)
                             | Text.Muted("Parsed date/time details:")
                             | Text.Label("Formatted date:")

--- a/packages-demos/superpower/Apps/IntegerCalculatorView.cs
+++ b/packages-demos/superpower/Apps/IntegerCalculatorView.cs
@@ -1,6 +1,6 @@
 ﻿namespace SuperpowerExample
 {
-    internal class IntegerCalculatorView: ViewBase
+    internal class IntegerCalculatorView : ViewBase
     {
         public override object? Build()
         {
@@ -73,11 +73,11 @@
             var resultCard = new Card(
                 Layout.Vertical().Gap(3).Padding(3)
                 | Text.H4("Result")
-                | (errorState.Value.Length > 0 
+                | (errorState.Value.Length > 0
                     ? Layout.Vertical().Gap(2)
                         | Text.Block("Calculation Error:")
                         | Text.Code(errorState.Value)
-                    : resultState.Value 
+                    : resultState.Value
                         ? Layout.Vertical().Gap(2)
                             | Text.Muted("Evaluation output:")
                             | Text.Code(resultValueState.Value.ToString())

--- a/packages-demos/superpower/Apps/JsonParserView.cs
+++ b/packages-demos/superpower/Apps/JsonParserView.cs
@@ -29,7 +29,7 @@
                     {
                         parsedDataState.Set("");
                         parsingState.Set(false);
-                        errorState.Set($"Error: {error}\nPosition: {errorPosition.Column}");                        
+                        errorState.Set($"Error: {error}\nPosition: {errorPosition.Column}");
                     }
                 }
                 parsingState.Set(false);
@@ -78,11 +78,11 @@
             var resultCard = new Card(
                 Layout.Vertical().Gap(3).Padding(3)
                 | Text.H4("Result")
-                | (errorState.Value.Length > 0 
+                | (errorState.Value.Length > 0
                     ? Layout.Vertical().Gap(2)
                         | Text.Block("Parsing Error:")
                         | Text.Code(errorState.Value)
-                    : parsedDataState.Value.Length > 0 
+                    : parsedDataState.Value.Length > 0
                         ? Layout.Vertical().Gap(2)
                             | Text.Muted("Structured parser output:")
                             | Text.Code(parsedDataState.Value)
@@ -100,12 +100,12 @@
         static string GetIndentedText(object? value, int indent = 0)
         {
             string result = "";
-            
+
             void Indent(int amount, string text)
             {
                 result += $"{new string(' ', amount)}{text}\n";
             }
-            
+
             switch (value)
             {
                 case null:

--- a/packages-demos/superpower/GlobalUsings.cs
+++ b/packages-demos/superpower/GlobalUsings.cs
@@ -1,10 +1,5 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using SuperpowerExample.Helpers;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Diagnostics.CodeAnalysis;

--- a/packages-demos/superpower/Helpers/ArithmeticExpressionToken.cs
+++ b/packages-demos/superpower/Helpers/ArithmeticExpressionToken.cs
@@ -6,7 +6,7 @@
 
         Number,
 
-        [Token(Category="operator", Example = "+")]
+        [Token(Category = "operator", Example = "+")]
         Plus,
 
         [Token(Category = "operator", Example = "-")]

--- a/packages-demos/superpower/Helpers/DateTimeTextParser.cs
+++ b/packages-demos/superpower/Helpers/DateTimeTextParser.cs
@@ -1,7 +1,7 @@
 namespace SuperpowerExample.Helpers
 {
     public static class DateTimeTextParser
-    {        
+    {
         static TextParser<int> IntDigits(int count) =>
             Character.Digit
                 .Repeat(count)
@@ -14,7 +14,7 @@ namespace SuperpowerExample.Helpers
         static TextParser<char> Colon { get; } = Character.EqualTo(':');
         static TextParser<char> TimeSeparator { get; } = Character.In('T', ' ');
 
-        static TextParser<DateTime> Date { get; } = 
+        static TextParser<DateTime> Date { get; } =
             from year in FourDigits
             from _ in Dash
             from month in TwoDigits

--- a/packages-demos/superpower/Helpers/JsonParser.cs
+++ b/packages-demos/superpower/Helpers/JsonParser.cs
@@ -1,5 +1,5 @@
 ﻿namespace SuperpowerExample.Helpers
-{   
+{
     // This is an example JSON parser. It correctly and completely implements the
     // language spec at https://json.org (or should), but the goal isn't to use
     // this "for real" - there are no tests, after all! :-)

--- a/packages-demos/superpower/Program.cs
+++ b/packages-demos/superpower/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsuperpower%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsuperpower%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SuperpowerApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/ulid/GlobalUsings.cs
+++ b/packages-demos/ulid/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/ulid/Program.cs
+++ b/packages-demos/ulid/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fulid%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fulid%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<UlidApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/xlparser/Apps/XLParserApp.cs
+++ b/packages-demos/xlparser/Apps/XLParserApp.cs
@@ -124,11 +124,11 @@ public class XLParserApp : ViewBase
             state.SelectedToken.Set(parseTree.FirstOrDefault());
         }
         catch (ArgumentException)
-        {            
+        {
             state.Result.Set(FormulaParseResult.NotParsed);
         }
         catch (Exception)
-        {         
+        {
             state.Result.Set(FormulaParseResult.UnexpectedError);
         }
     }

--- a/packages-demos/xlparser/GlobalUsings.cs
+++ b/packages-demos/xlparser/GlobalUsings.cs
@@ -1,10 +1,5 @@
 global using Ivy;
 global using Irony.Parsing;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using XLParser;

--- a/packages-demos/xlparser/Program.cs
+++ b/packages-demos/xlparser/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fxlparser%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fxlparser%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<XLParserApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/xlparser/Services/ParseTreeNodeInfo.cs
+++ b/packages-demos/xlparser/Services/ParseTreeNodeInfo.cs
@@ -7,7 +7,7 @@ internal class ParseTreeNodeInfo
 
     public string NodeValue => TreeNode.Print();
 
-    public List<NodeMetadata> NodeInfo =>    
+    public List<NodeMetadata> NodeInfo =>
         [
             new("Term", TreeNode.Term.ToString()) ,
             new("Is token", (TreeNode.Token is not null).ToString()) ,
@@ -30,7 +30,7 @@ internal class ParseTreeNodeInfo
             new("Is unary postfix operation", TreeNode.IsUnaryPostfixOperation().ToString()) ,
             new("Is unary prefix operation", TreeNode.IsUnaryPrefixOperation().ToString()) ,
             new("Is union", TreeNode.IsUnion().ToString()) ,
-        ];    
+        ];
 }
 
 internal class NodeMetadata

--- a/packages-demos/yamldotnet/Apps/DeserializationApp.cs
+++ b/packages-demos/yamldotnet/Apps/DeserializationApp.cs
@@ -67,7 +67,7 @@ addresses:
 
             // First parse YAML as dictionary to check which fields exist
             var yamlDict = deserializer.Deserialize<Dictionary<object, object>>(yamlInput);
-            
+
             // Then deserialize to Person object
             var person = deserializer.Deserialize<Person>(yamlInput);
 
@@ -88,19 +88,19 @@ addresses:
     {
         var lines = new List<string> { "{" };
         var personFields = new List<string>();
-        
+
         // Check if name exists in YAML
         if (yamlDict.ContainsKey("name") && yamlDict["name"] != null && !string.IsNullOrWhiteSpace(person.Name))
             personFields.Add($"    Name = \"{person.Name}\"");
-        
+
         // Check if age exists in YAML
         if (yamlDict.ContainsKey("age") && yamlDict["age"] != null)
             personFields.Add($"    Age = {person.Age}");
-        
+
         // Check if height_in_inches exists in YAML
         if (yamlDict.ContainsKey("height_in_inches") && yamlDict["height_in_inches"] != null)
             personFields.Add($"    HeightInInches = {person.HeightInInches}f");
-        
+
         // Check if addresses exist in YAML
         if (yamlDict.ContainsKey("addresses") && yamlDict["addresses"] != null)
         {
@@ -110,7 +110,7 @@ addresses:
                 var addressLines = new List<string>();
                 addressLines.Add("    Addresses = new Dictionary<string, Address>");
                 addressLines.Add("    {");
-                
+
                 foreach (var address in person.Addresses)
                 {
                     // Check if this address key exists in YAML
@@ -120,38 +120,38 @@ addresses:
                         if (addressDict != null)
                         {
                             var addrFields = new List<string>();
-                            
+
                             // Only include fields that exist in YAML address dict
-                            if (addressDict.ContainsKey("street") && addressDict["street"] != null && 
+                            if (addressDict.ContainsKey("street") && addressDict["street"] != null &&
                                 !string.IsNullOrWhiteSpace(address.Value.Street))
                                 addrFields.Add($"            Street = \"{address.Value.Street}\"");
-                            if (addressDict.ContainsKey("city") && addressDict["city"] != null && 
+                            if (addressDict.ContainsKey("city") && addressDict["city"] != null &&
                                 !string.IsNullOrWhiteSpace(address.Value.City))
                                 addrFields.Add($"            City = \"{address.Value.City}\"");
-                            if (addressDict.ContainsKey("state") && addressDict["state"] != null && 
+                            if (addressDict.ContainsKey("state") && addressDict["state"] != null &&
                                 !string.IsNullOrWhiteSpace(address.Value.State))
                                 addrFields.Add($"            State = \"{address.Value.State}\"");
-                            if (addressDict.ContainsKey("zip") && addressDict["zip"] != null && 
+                            if (addressDict.ContainsKey("zip") && addressDict["zip"] != null &&
                                 !string.IsNullOrWhiteSpace(address.Value.Zip))
                                 addrFields.Add($"            Zip = \"{address.Value.Zip}\"");
-                            
+
                             if (addrFields.Count > 0)
                             {
                                 addressLines.Add($"        {{\"{address.Key}\", new Address");
                                 addressLines.Add("        {");
-                                
+
                                 // Add fields with commas except the last one
                                 for (int i = 0; i < addrFields.Count; i++)
                                 {
                                     addressLines.Add(addrFields[i] + (i < addrFields.Count - 1 ? "," : ""));
                                 }
-                                
+
                                 addressLines.Add("        }},");
                             }
                         }
                     }
                 }
-                
+
                 if (addressLines.Count > 2) // More than just opening lines
                 {
                     addressLines.Add("    }");
@@ -159,13 +159,13 @@ addresses:
                 }
             }
         }
-        
+
         // Add person fields with commas except the last one
         for (int i = 0; i < personFields.Count; i++)
         {
             lines.Add(personFields[i] + (i < personFields.Count - 1 ? "," : ""));
         }
-        
+
         lines.Add("};");
         return string.Join("\n", lines) + "\n";
     }

--- a/packages-demos/yamldotnet/Apps/SerializationApp.cs
+++ b/packages-demos/yamldotnet/Apps/SerializationApp.cs
@@ -64,7 +64,7 @@ Addresses = new Dictionary<string, Address> {
         try
         {
             errorMessage.Value = string.Empty;
-            
+
             // Validate address keys - only "home" and "work" are allowed
             var addressKeyValidation = ValidateAddressKeys(personCode);
             if (!string.IsNullOrEmpty(addressKeyValidation))
@@ -74,21 +74,21 @@ Addresses = new Dictionary<string, Address> {
                 yamlOutput.Value = string.Empty;
                 return;
             }
-            
+
             var person = ParsePersonCode(personCode);
             var serializer = new SerializerBuilder()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 
             var data = new Dictionary<string, object?>();
-            
+
             if (System.Text.RegularExpressions.Regex.IsMatch(personCode, @"Name\s*=") && !string.IsNullOrWhiteSpace(person.Name))
                 data["name"] = person.Name;
             if (System.Text.RegularExpressions.Regex.IsMatch(personCode, @"Age\s*="))
                 data["age"] = person.Age;
             if (System.Text.RegularExpressions.Regex.IsMatch(personCode, @"HeightInInches\s*="))
                 data["heightInInches"] = person.HeightInInches;
-            
+
             if (person.Addresses?.Count > 0)
             {
                 var addresses = new Dictionary<string, object>();
@@ -103,7 +103,7 @@ Addresses = new Dictionary<string, Address> {
                 }
                 if (addresses.Count > 0) data["addresses"] = addresses;
             }
-            
+
             var yaml = serializer.Serialize(data);
             yamlOutput.Value = yaml;
             resultOutput.Value = yaml;
@@ -119,10 +119,10 @@ Addresses = new Dictionary<string, Address> {
     private string ValidateAddressKeys(string code)
     {
         if (!code.Contains("Addresses =")) return string.Empty;
-        
+
         // Find all address keys in the dictionary
         var matches = System.Text.RegularExpressions.Regex.Matches(code, @"""(?<key>[^""]+)"",\s*new\s+Address");
-        
+
         foreach (System.Text.RegularExpressions.Match match in matches)
         {
             var key = match.Groups["key"].Value;
@@ -131,14 +131,14 @@ Addresses = new Dictionary<string, Address> {
                 return $"Invalid address key: '{key}'. Only 'home' and 'work' keys are allowed for Address objects.";
             }
         }
-        
+
         return string.Empty;
     }
 
     private Person ParsePersonCode(string code)
     {
         var person = new Person();
-        
+
         var m = System.Text.RegularExpressions.Regex.Match(code, @"Name\s*=\s*""([^""]+)""");
         if (m.Success) person.Name = m.Groups[1].Value;
 
@@ -160,7 +160,7 @@ Addresses = new Dictionary<string, Address> {
             foreach (var key in new[] { "home", "work" })
             {
                 var addr = ExtractAddress(code, key);
-                if (addr != null && (!string.IsNullOrWhiteSpace(addr.Street) || !string.IsNullOrWhiteSpace(addr.City) || 
+                if (addr != null && (!string.IsNullOrWhiteSpace(addr.Street) || !string.IsNullOrWhiteSpace(addr.City) ||
                     !string.IsNullOrWhiteSpace(addr.State) || !string.IsNullOrWhiteSpace(addr.Zip)))
                     person.Addresses[key] = addr;
             }
@@ -173,13 +173,13 @@ Addresses = new Dictionary<string, Address> {
     {
         var m = System.Text.RegularExpressions.Regex.Match(code, $@"""{key}"",\s*new\s+Address\s*\{{([^}}]*)\}}");
         if (!m.Success) return null;
-        
+
         var block = m.Groups[1].Value;
         var street = ExtractProperty(block, "Street");
         var city = ExtractProperty(block, "City");
         var state = ExtractProperty(block, "State");
         var zip = ExtractProperty(block, "Zip");
-        
+
         if (street == null && city == null && state == null && zip == null) return null;
         return new Address { Street = street ?? "", City = city ?? "", State = state ?? "", Zip = zip ?? "" };
     }

--- a/packages-demos/yamldotnet/GlobalUsings.cs
+++ b/packages-demos/yamldotnet/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using YamlDotNetExample.Models;

--- a/packages-demos/yamldotnet/Program.cs
+++ b/packages-demos/yamldotnet/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fyamldotnet%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fyamldotnet%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SerializationApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/zstring/Apps/ZStringApp.cs
+++ b/packages-demos/zstring/Apps/ZStringApp.cs
@@ -4,20 +4,20 @@ namespace ZStringExample;
 public class ZStringApp : ViewBase
 {
     private static readonly Dictionary<string, (string code, Func<string> execute)> Operations = new()
-        {
-            ["Concat"] = (
+    {
+        ["Concat"] = (
                 "var output = ZString.Concat(\"Hello\", \" \", \"Ivy\", \" \", 2025);",
                 () => ZString.Concat("Hello", " ", "Ivy", " ", 2025)
             ),
-            ["Format"] = (
+        ["Format"] = (
                 "var output = ZString.Format(\"Pi is {0:0.00}\", 3.14159);",
                 () => ZString.Format("Pi is {0:0.00}", 3.14159)
             ),
-            ["Join"] = (
+        ["Join"] = (
                 "var output = ZString.Join(\", \", new[] { \"A\", \"B\", \"C\" });",
                 () => ZString.Join(", ", new[] { "A", "B", "C" })
             ),
-            ["CreateStringBuilder"] = (
+        ["CreateStringBuilder"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.Append(\"foo\");\n" +
                 "sb.AppendLine(42);\n" +
@@ -31,8 +31,8 @@ public class ZStringApp : ViewBase
                     sb.AppendFormat("{0} {1:.###}", "bar", 123.456789);
                     return sb.ToString();
                 }
-            ),
-            ["Prepared Format"] = (
+        ),
+        ["Prepared Format"] = (
                 "var tpl = ZString.PrepareUtf16<int, int>(\"x:{0}, y:{1:000}\");\n" +
                 "var output = tpl.Format(10, 20);",
                 () =>
@@ -40,8 +40,8 @@ public class ZStringApp : ViewBase
                     var tpl = ZString.PrepareUtf16<int, int>("x:{0}, y:{1:000}");
                     return tpl.Format(10, 20);
                 }
-            ),
-            ["AppendJoin"] = (
+        ),
+        ["AppendJoin"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.AppendJoin(\" -> \", new[] { \"Start\", \"Middle\", \"End\" });\n" +
                 "var output = sb.ToString();",
@@ -51,8 +51,8 @@ public class ZStringApp : ViewBase
                     sb.AppendJoin(" -> ", new[] { "Start", "Middle", "End" });
                     return sb.ToString();
                 }
-            ),
-            ["AppendFormat Multiple"] = (
+        ),
+        ["AppendFormat Multiple"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.AppendFormat(\"Name: {0}, Age: {1}, Score: {2:F2}\", \"Alice\", 28, 95.678);\n" +
                 "var output = sb.ToString();",
@@ -62,8 +62,8 @@ public class ZStringApp : ViewBase
                     sb.AppendFormat("Name: {0}, Age: {1}, Score: {2:F2}", "Alice", 28, 95.678);
                     return sb.ToString();
                 }
-            ),
-            ["AppendLine"] = (
+        ),
+        ["AppendLine"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.AppendLine(\"First line\");\n" +
                 "sb.AppendLine(\"Second line\");\n" +
@@ -79,8 +79,8 @@ public class ZStringApp : ViewBase
                     sb.AppendLine("After empty line");
                     return sb.ToString();
                 }
-            ),
-            ["Append With Format"] = (
+        ),
+        ["Append With Format"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.Append(3.14159, \"F4\");\n" +
                 "sb.Append(\" | \");\n" +
@@ -98,8 +98,8 @@ public class ZStringApp : ViewBase
                     sb.Append(42, "X");
                     return sb.ToString();
                 }
-            ),
-            ["TryCopyTo"] = (
+        ),
+        ["TryCopyTo"] = (
                 "using var sb = ZString.CreateStringBuilder();\n" +
                 "sb.Append(\"Hello, World!\");\n" +
                 "var buffer = new char[sb.Length];\n" +
@@ -118,7 +118,7 @@ public class ZStringApp : ViewBase
                     }
                     return "Failed to copy";
                 }
-            )
+        )
     };
 
     public override object Build()
@@ -176,7 +176,7 @@ public class ZStringApp : ViewBase
                 | new Spacer().Height(Size.Units(5))
                 | Text.Block("This demo uses ZString library to format strings.")
                 | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [ZString](https://github.com/Cysharp/ZString)")
-            
+
             ).Width(Size.Fraction(0.4f));
     }
 }

--- a/packages-demos/zstring/GlobalUsings.cs
+++ b/packages-demos/zstring/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using Cysharp.Text;

--- a/packages-demos/zstring/Program.cs
+++ b/packages-demos/zstring/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fzstring%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fzstring%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ZStringApp>()
     .UseTabs(preventDuplicates: true)

--- a/project-demos/cold-call-tracker/Apps/HelloApp.cs
+++ b/project-demos/cold-call-tracker/Apps/HelloApp.cs
@@ -1,6 +1,6 @@
 namespace ColdCallTracker.Apps;
 
-[App(icon:Icons.PartyPopper, title:"Hello")]
+[App(icon: Icons.PartyPopper, title: "Hello")]
 public class HelloApp : ViewBase
 {
     public override object? Build()

--- a/project-demos/cold-call-tracker/GlobalUsings.cs
+++ b/project-demos/cold-call-tracker/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/project-demos/helloworld/Apps/HelloApp.cs
+++ b/project-demos/helloworld/Apps/HelloApp.cs
@@ -1,6 +1,6 @@
 namespace Helloworld.Apps;
 
-[App(icon:Icons.PartyPopper, title:"Hello")]
+[App(icon: Icons.PartyPopper, title: "Hello")]
 public class HelloApp : ViewBase
 {
     public override object? Build()

--- a/project-demos/helloworld/GlobalUsings.cs
+++ b/project-demos/helloworld/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/project-demos/opperai/Apps/OpperaiChatExample.cs
+++ b/project-demos/opperai/Apps/OpperaiChatExample.cs
@@ -1,4 +1,3 @@
-using Ivy;
 using OpperDotNet;
 
 namespace OpperaiExample.Apps
@@ -15,15 +14,15 @@ namespace OpperaiExample.Apps
         public override object? Build()
         {
             var client = UseService<IClientProvider>();
-            
+
             // API Key state - initialize from environment variable if available
             var apiKey = UseState<string?>(Environment.GetEnvironmentVariable("OPPER_API_KEY"));
             var opperClient = UseState<OpperClient?>(default(OpperClient?));
             var isValidating = UseState<bool>(false);
             var customInstructions = UseState<string>("You are a helpful AI assistant. When responding:\n\n1. Use Markdown formatting for better readability (headers, lists, code blocks, etc.)\n2. For mathematical expressions, use LaTeX notation with proper delimiters:\n   - Inline math: $expression$ (e.g., $\\sqrt{-1}$ or $x^2 + y^2 = r^2$)\n   - Block math: $$expression$$ for displayed equations\n   - Examples: $\\sqrt{-1} = i$, $E = mc^2$, $\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$\n3. Ensure all math expressions render clearly and correctly\n4. Keep your responses concise, relevant, and well-formatted.");
             var isSettingsDialogOpen = UseState(false);
-            var settingsForm = UseState(new SettingsRequest 
-            { 
+            var settingsForm = UseState(new SettingsRequest
+            {
                 ApiKey = apiKey.Value ?? string.Empty,
                 Instructions = customInstructions.Value
             });
@@ -101,10 +100,10 @@ namespace OpperaiExample.Apps
                 {
                     opperClient.Value?.Dispose();
                     var testClient = new OpperClient(key);
-                    
+
                     // Try to make a simple API call to validate the key
                     await testClient.ListModelsAsync(limit: 1);
-                    
+
                     // If successful, set the client and show success toast
                     opperClient.Set(testClient);
                     client.Toast("API key validated successfully!", "Success");
@@ -113,7 +112,7 @@ namespace OpperaiExample.Apps
                 {
                     // If validation fails, show error toast
                     opperClient.Set(default(OpperClient?));
-                    var errorMessage = ex is OpperException opperEx 
+                    var errorMessage = ex is OpperException opperEx
                         ? $"API key validation error: {opperEx.Message}"
                         : $"API key validation error: {ex.Message}";
                     client.Toast(errorMessage, "Error");
@@ -185,12 +184,12 @@ namespace OpperaiExample.Apps
                             {
                                 return new Option<string>($"{model.HostingProvider}/{model.Name}", model.Name);
                             }
-                            
+
                             // If model not found, return default model option anyway
                             if (modelName == DefaultModelName)
                             {
                                 var parts = DefaultModel.Split('/');
-                                var defaultModelFromApi = response.Data.FirstOrDefault(m => 
+                                var defaultModelFromApi = response.Data.FirstOrDefault(m =>
                                     m.HostingProvider == parts[0] && m.Name == parts[1]);
                                 if (defaultModelFromApi != null)
                                 {
@@ -199,7 +198,7 @@ namespace OpperaiExample.Apps
                                 // Fallback: return default model even if not in API response
                                 return new Option<string>($"{DefaultModel}", DefaultModelName);
                             }
-                            
+
                             return null;
                         }
                         catch
@@ -219,7 +218,7 @@ namespace OpperaiExample.Apps
                 if (opperClient.Value == null)
                 {
                     messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.User, @event.Value)));
-                    messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.Assistant, 
+                    messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.Assistant,
                         "Please click the 'Enter API Key' button above to enter your Opper.ai API key and start chatting. " +
                         "You can get your API key at https://platform.opper.ai/settings/api-keys")));
                     return;
@@ -229,7 +228,7 @@ namespace OpperaiExample.Apps
                 if (string.IsNullOrWhiteSpace(selectedModel.Value))
                 {
                     messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.User, @event.Value)));
-                    messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.Assistant, 
+                    messages.Set(messages.Value.Add(new Ivy.ChatMessage(ChatSender.Assistant,
                         "Please select a model from the dropdown above before sending a message. " +
                         "The model selection is located in the header area.")));
                     return;
@@ -296,7 +295,7 @@ namespace OpperaiExample.Apps
                         Layout.Vertical().Gap(3).Padding(4)
                         | Text.H4("Welcome to OpperAI Chat!")
                         | Text.Muted("To get started, you need an API key from Opper.ai:")
-                        
+
                         | (Layout.Vertical().Gap(1).Padding(2)
                             | Text.Markdown(@"1. Visit [https://platform.opper.ai](https://platform.opper.ai)
 2. Sign up or log in to your [account](https://platform.opper.ai/settings/details)
@@ -316,7 +315,7 @@ namespace OpperaiExample.Apps
                         | header.Width(Size.Fraction(0.6f)).Height(Size.Fit().Max(Size.Fraction(0.1f)))
                         | chatCard.Width(Size.Fraction(0.6f)).Height(Size.Full().Max(Size.Fraction(0.9f)))
                         )
-                    | (isSettingsDialogOpen.Value ? 
+                    | (isSettingsDialogOpen.Value ?
                         settingsForm.ToForm()
                             .Builder(e => e.ApiKey, e => e.ToPasswordInput(placeholder: "Enter your Opper.ai API key..."))
                             .Label(e => e.ApiKey, "API Key:")

--- a/project-demos/opperai/GlobalUsings.cs
+++ b/project-demos/opperai/GlobalUsings.cs
@@ -1,9 +1,5 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/project-demos/opperai/OpperDotNet/OpperClient.cs
+++ b/project-demos/opperai/OpperDotNet/OpperClient.cs
@@ -11,7 +11,7 @@ public class OpperClient : IDisposable
     private const string DefaultBaseUrl = "https://api.opper.ai";
     private const string CallEndpoint = "/v2/call";
     private const string ModelsEndpoint = "/v2/models";
-    
+
     private readonly HttpClient _httpClient;
     private readonly bool _disposeHttpClient;
 
@@ -50,7 +50,7 @@ public class OpperClient : IDisposable
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The API response</returns>
     public async Task<OpperCallResponse> CallAsync(
-        OpperCallRequest request, 
+        OpperCallRequest request,
         CancellationToken cancellationToken = default)
     {
         if (request == null)
@@ -68,8 +68,8 @@ public class OpperClient : IDisposable
         try
         {
             var response = await _httpClient.PostAsJsonAsync(
-                CallEndpoint, 
-                request, 
+                CallEndpoint,
+                request,
                 cancellationToken);
 
             if (!response.IsSuccessStatusCode)

--- a/project-demos/opperai/OpperDotNet/OpperException.cs
+++ b/project-demos/opperai/OpperDotNet/OpperException.cs
@@ -12,12 +12,12 @@ public class OpperException : Exception
     {
     }
 
-    public OpperException(string message, Exception innerException) 
+    public OpperException(string message, Exception innerException)
         : base(message, innerException)
     {
     }
 
-    public OpperException(string message, int statusCode, string? responseContent = null) 
+    public OpperException(string message, int statusCode, string? responseContent = null)
         : base(message)
     {
         StatusCode = statusCode;

--- a/project-demos/opperai/Program.cs
+++ b/project-demos/opperai/Program.cs
@@ -1,4 +1,3 @@
-using OpperaiExample.Apps;
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 var server = new Server();
 #if DEBUG


### PR DESCRIPTION
## Changes

Added `.editorconfig` to the Ivy-Examples repo root with C# formatting rules (LF line endings, IDE0005 unnecessary using directive warnings). Ran `dotnet format` across all 37 solution files, fixing formatting in 118 files (254 insertions, 481 deletions — mostly removing unnecessary usings and fixing line endings). Added `DotnetFormat` verification to the Examples project in `config.yaml`.

## API Changes

None.

## Files Modified

- **Config:** `config.yaml` — added `DotnetFormat` verification to Examples project
- **New file:** `.editorconfig` — C# formatting rules at repo root
- **Formatted:** 118 `.cs` files across `packages-demos/` and `project-demos/` directories (unnecessary usings removed, line endings normalized)

## Commits

- `3f9022a`
- `cf9aa46`