### PR TITLE
[00087] Format agent-demos and add missing solution files

### DIFF
--- a/agent-demos/ascii-art-generator/Apps/ASCIIArtGenerator/AsciiArtService.cs
+++ b/agent-demos/ascii-art-generator/Apps/ASCIIArtGenerator/AsciiArtService.cs
@@ -23,7 +23,7 @@ public class AsciiArtService
 
         using var image = SixImage.Load<Rgba32>(imageData);
 
-        
+
         var aspectRatio = (double)image.Height / image.Width;
         var height = (int)(width * aspectRatio * 0.5);
 

--- a/agent-demos/ascii-art-generator/ascii-art-generator.sln
+++ b/agent-demos/ascii-art-generator/ascii-art-generator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ASCIIArtGenerator", "ASCIIArtGenerator.csproj", "{65C30C4A-42AB-43BF-8A97-5E63465A6856}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|x64.Build.0 = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Debug|x86.Build.0 = Debug|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|x64.ActiveCfg = Release|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|x64.Build.0 = Release|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|x86.ActiveCfg = Release|Any CPU
+		{65C30C4A-42AB-43BF-8A97-5E63465A6856}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/cat-facts/Apps/CatFacts/DailyFactView.cs
+++ b/agent-demos/cat-facts/Apps/CatFacts/DailyFactView.cs
@@ -48,7 +48,7 @@ public class DailyFactView : ViewBase
                                 var added = service.ToggleFavorite(fact);
                                 client.Toast(added ? "Added to favorites! ❤️" : "Removed from favorites");
                             }).Icon(isFav ? Icons.Heart : Icons.HeartOff)
-                              .Variant(isFav ? ButtonVariant.Primary: ButtonVariant.Outline))))
+                              .Variant(isFav ? ButtonVariant.Primary : ButtonVariant.Outline))))
                 | (Layout.Horizontal().Gap(6)
                     | (new Card()
                         | (Layout.Horizontal().Gap(2).Center()

--- a/agent-demos/cat-facts/cat-facts.sln
+++ b/agent-demos/cat-facts/cat-facts.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatFacts", "CatFacts.csproj", "{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|x64.Build.0 = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Debug|x86.Build.0 = Debug|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|x64.Build.0 = Release|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|x86.ActiveCfg = Release|Any CPU
+		{6EE850E7-A3D1-4E8D-A506-42D7BDF0C2C1}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/certificate-decoder/Apps/CertificateDecoderApp.cs
+++ b/agent-demos/certificate-decoder/Apps/CertificateDecoderApp.cs
@@ -1,6 +1,5 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using Ivy;
 
 namespace Certificate.Decoder.Apps;
@@ -187,7 +186,7 @@ public class CertificateDecoderApp : ViewBase
 
     static X509Certificate2 ParseCertificate(string input)
     {
-        
+
         var pem = input
             .Replace("-----BEGIN CERTIFICATE-----", "")
             .Replace("-----END CERTIFICATE-----", "")

--- a/agent-demos/certificate-decoder/Program.cs
+++ b/agent-demos/certificate-decoder/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using Certificate.Decoder.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("Certificate Decoder");

--- a/agent-demos/certificate-decoder/certificate-decoder.sln
+++ b/agent-demos/certificate-decoder/certificate-decoder.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Certificate.Decoder", "Certificate.Decoder.csproj", "{9713F6D7-C72D-4078-8403-FD9367FC1B04}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|x64.Build.0 = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Debug|x86.Build.0 = Debug|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|x64.ActiveCfg = Release|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|x64.Build.0 = Release|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|x86.ActiveCfg = Release|Any CPU
+		{9713F6D7-C72D-4078-8403-FD9367FC1B04}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/css-gradient-text-generator/Program.cs
+++ b/agent-demos/css-gradient-text-generator/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using CSSGradientTextGenerator.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("CSS Gradient Text Generator");

--- a/agent-demos/css-gradient-text-generator/css-gradient-text-generator.sln
+++ b/agent-demos/css-gradient-text-generator/css-gradient-text-generator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSSGradientTextGenerator", "CSSGradientTextGenerator.csproj", "{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|x64.Build.0 = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Debug|x86.Build.0 = Debug|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|Any CPU.Build.0 = Release|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|x64.ActiveCfg = Release|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|x64.Build.0 = Release|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|x86.ActiveCfg = Release|Any CPU
+		{818CA3C8-22EE-4A8F-93AA-FF1A2A479491}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/ctrf/Apps/ReportDashboardView.cs
+++ b/agent-demos/ctrf/Apps/ReportDashboardView.cs
@@ -152,7 +152,7 @@ public class ReportDashboardView : ViewBase
 
     private static string FormatInsightKey(string key)
     {
-        
+
         var result = System.Text.RegularExpressions.Regex.Replace(key, "([a-z])([A-Z])", "$1 $2");
         return char.ToUpper(result[0]) + result[1..];
     }

--- a/agent-demos/ctrf/Apps/TestDetailView.cs
+++ b/agent-demos/ctrf/Apps/TestDetailView.cs
@@ -13,13 +13,13 @@ public class TestDetailView : ViewBase
     {
         var sections = Layout.Vertical().Gap(3);
 
-        
+
         sections = sections | (Layout.Horizontal().Gap(3).AlignContent(Align.Center)
             | Text.H4(_test.Name)
             | StatusBadge(_test.Status)
             | (_test.Flaky == true ? new Badge("Flaky", icon: Icons.Shuffle).Warning() : (object)Layout.Vertical()));
 
-        
+
         if (!string.IsNullOrEmpty(_test.Message))
         {
             sections = sections | Callout.Error(_test.Message, "Error");
@@ -31,7 +31,7 @@ public class TestDetailView : ViewBase
                 Text.Monospaced(_test.Trace));
         }
 
-        
+
         if (_test.Stdout?.Count > 0)
         {
             sections = sections | new Expandable("Stdout",
@@ -44,7 +44,7 @@ public class TestDetailView : ViewBase
                 Text.Monospaced(string.Join("\n", _test.Stderr)));
         }
 
-        
+
         if (_test.RetryAttempts?.Count > 0)
         {
             var retryLayout = Layout.Vertical().Gap(2);
@@ -64,7 +64,7 @@ public class TestDetailView : ViewBase
             sections = sections | new Expandable("Retry Attempts", retryLayout).Open();
         }
 
-        
+
         if (_test.Attachments?.Count > 0)
         {
             var attachLayout = Layout.Vertical().Gap(1);
@@ -77,7 +77,7 @@ public class TestDetailView : ViewBase
             sections = sections | new Expandable("Attachments", attachLayout);
         }
 
-        
+
         if (_test.Steps?.Count > 0)
         {
             var stepsLayout = Layout.Vertical().Gap(1);
@@ -90,7 +90,7 @@ public class TestDetailView : ViewBase
             sections = sections | new Expandable("Steps", stepsLayout).Open();
         }
 
-        
+
         if (!string.IsNullOrEmpty(_test.FilePath))
         {
             var fileInfo = _test.FilePath;

--- a/agent-demos/ctrf/Program.cs
+++ b/agent-demos/ctrf/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using CTRF.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("CTRF Dashboard");

--- a/agent-demos/ctrf/ctrf.sln
+++ b/agent-demos/ctrf/ctrf.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CTRF", "CTRF.csproj", "{59375928-53AE-4250-950E-994DB54CC8B8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|x64.Build.0 = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Debug|x86.Build.0 = Debug|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|x64.ActiveCfg = Release|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|x64.Build.0 = Release|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|x86.ActiveCfg = Release|Any CPU
+		{59375928-53AE-4250-950E-994DB54CC8B8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/data-anonymizer/Program.cs
+++ b/agent-demos/data-anonymizer/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using Data.Anonymizer.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("Data Anonymizer");

--- a/agent-demos/data-anonymizer/data-anonymizer.sln
+++ b/agent-demos/data-anonymizer/data-anonymizer.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data.Anonymizer", "Data.Anonymizer.csproj", "{066D2B64-A927-40F8-A1D8-5F51C35EA082}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|x64.Build.0 = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Debug|x86.Build.0 = Debug|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|Any CPU.Build.0 = Release|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|x64.ActiveCfg = Release|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|x64.Build.0 = Release|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|x86.ActiveCfg = Release|Any CPU
+		{066D2B64-A927-40F8-A1D8-5F51C35EA082}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/emoji-voting-booth/Program.cs
+++ b/agent-demos/emoji-voting-booth/Program.cs
@@ -1,5 +1,4 @@
 using Ivy;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.UseCulture("en-US");

--- a/agent-demos/emoji-voting-booth/emoji-voting-booth.sln
+++ b/agent-demos/emoji-voting-booth/emoji-voting-booth.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.EmojiVotingBooth", "Test.EmojiVotingBooth.csproj", "{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|x64.Build.0 = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Debug|x86.Build.0 = Debug|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|x64.ActiveCfg = Release|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|x64.Build.0 = Release|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|x86.ActiveCfg = Release|Any CPU
+		{5FBEE4CE-7F71-42F1-BC8F-74D52E58DBC6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/excel-formula-explainer/Apps/FormulaParser.cs
+++ b/agent-demos/excel-formula-explainer/Apps/FormulaParser.cs
@@ -94,7 +94,7 @@ public static class FormulaParser
         var pos = 0;
         while (pos < expr.Length)
         {
-            
+
             var funcStart = FindNextFunction(expr, pos);
             if (funcStart < 0) break;
 
@@ -124,7 +124,7 @@ public static class FormulaParser
 
             functionsUsed.Add(funcName);
 
-            
+
             ParseExpression(innerArgs, steps, functionsUsed);
 
             var explanation = ExplainFunctionCall(funcName, innerArgs);
@@ -147,7 +147,7 @@ public static class FormulaParser
                 if (end < expr.Length && expr[end] == '(')
                 {
                     var name = expr[i..end];
-                    
+
                     if (!name.Contains('!'))
                         return i;
                 }

--- a/agent-demos/excel-formula-explainer/Program.cs
+++ b/agent-demos/excel-formula-explainer/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using Excel.Formula.Explainer.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("Excel Formula Explainer");

--- a/agent-demos/excel-formula-explainer/excel-formula-explainer.sln
+++ b/agent-demos/excel-formula-explainer/excel-formula-explainer.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Excel.Formula.Explainer", "Excel.Formula.Explainer.csproj", "{EC8B012D-857C-4312-A229-981CE1C684EB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|x64.Build.0 = Release|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC8B012D-857C-4312-A229-981CE1C684EB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/gradient-generator/Program.cs
+++ b/agent-demos/gradient-generator/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using GradientGenerator.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("Gradient Generator");

--- a/agent-demos/gradient-generator/gradient-generator.sln
+++ b/agent-demos/gradient-generator/gradient-generator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GradientGenerator", "GradientGenerator.csproj", "{9FD7BE3B-69B9-4CD0-9E76-99A020838135}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|x64.Build.0 = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Debug|x86.Build.0 = Debug|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|x64.ActiveCfg = Release|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|x64.Build.0 = Release|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|x86.ActiveCfg = Release|Any CPU
+		{9FD7BE3B-69B9-4CD0-9E76-99A020838135}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/hangfire-job-dashboard/Apps/JobDashboard/HangfireService.cs
+++ b/agent-demos/hangfire-job-dashboard/Apps/JobDashboard/HangfireService.cs
@@ -1,4 +1,3 @@
-using Hangfire;
 using Hangfire.Storage;
 using Hangfire.Storage.Monitoring;
 

--- a/agent-demos/hangfire-job-dashboard/Program.cs
+++ b/agent-demos/hangfire-job-dashboard/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using Hangfire;
-using Hangfire.InMemory;
 using Microsoft.Extensions.DependencyInjection;
 using Hangfire.Job.Dashboard.Apps;
 using Hangfire.Job.Dashboard.Apps.JobDashboard;

--- a/agent-demos/hangfire-job-dashboard/Services/HangfireService.cs
+++ b/agent-demos/hangfire-job-dashboard/Services/HangfireService.cs
@@ -1,4 +1,3 @@
-using Hangfire;
 using Hangfire.Storage;
 using Hangfire.Storage.Monitoring;
 

--- a/agent-demos/hangfire-job-dashboard/hangfire-job-dashboard.sln
+++ b/agent-demos/hangfire-job-dashboard/hangfire-job-dashboard.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.Job.Dashboard", "Hangfire.Job.Dashboard.csproj", "{36178879-C899-4991-AE58-9A99E3CC0FDB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Debug|x86.Build.0 = Debug|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|x64.Build.0 = Release|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{36178879-C899-4991-AE58-9A99E3CC0FDB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/html-agility-pack-scraper/Program.cs
+++ b/agent-demos/html-agility-pack-scraper/Program.cs
@@ -1,5 +1,4 @@
 using Ivy;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("HTML Agility Pack Scraper");

--- a/agent-demos/html-agility-pack-scraper/html-agility-pack-scraper.sln
+++ b/agent-demos/html-agility-pack-scraper/html-agility-pack-scraper.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Html.Agility.Pack.Scraper", "Html.Agility.Pack.Scraper.csproj", "{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|x64.Build.0 = Release|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{30CF5C4B-090C-404C-A4FD-9D5FB9BBEB4A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/lovable-event-planner/lovable-event-planner.sln
+++ b/agent-demos/lovable-event-planner/lovable-event-planner.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lovable.Event.Planner", "Lovable.Event.Planner.csproj", "{3EFF112A-3733-4723-AC9E-6472FC1B84C2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|x64.Build.0 = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Debug|x86.Build.0 = Debug|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|x64.ActiveCfg = Release|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|x64.Build.0 = Release|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|x86.ActiveCfg = Release|Any CPU
+		{3EFF112A-3733-4723-AC9E-6472FC1B84C2}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/lovable-travel-booking/Apps/TravelBookingApp.cs
+++ b/agent-demos/lovable-travel-booking/Apps/TravelBookingApp.cs
@@ -23,7 +23,7 @@ public class TravelBookingApp : ViewBase
                 p.Category.Contains(search.Value, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
-        
+
         var categoryFilter = Layout.Horizontal().Gap(2);
         foreach (var cat in categories)
         {
@@ -33,7 +33,7 @@ public class TravelBookingApp : ViewBase
                 : new Button(c, () => category.Set(c)).Outline().Small();
         }
 
-        
+
         var grid = Layout.Grid().Columns(3).Gap(6);
         foreach (var pkg in filtered)
         {
@@ -45,7 +45,7 @@ public class TravelBookingApp : ViewBase
             });
         }
 
-        
+
         var browseContent = Layout.Vertical()
             | (Layout.Vertical().Gap(2)
                 | Text.H1("✈️ Travel Booking")
@@ -56,16 +56,16 @@ public class TravelBookingApp : ViewBase
                 ? (object)grid
                 : Callout.Info("No packages found matching your search criteria."));
 
-        
+
         var historyContent = new BookingHistoryView();
 
-        
+
         var tabs = Layout.Tabs(
             new Tab("Browse Packages", browseContent).Icon(Icons.Search),
             new Tab("Booking History", historyContent).Icon(Icons.Clock)
         );
 
-        
+
         object? sheetView = null;
         if (selectedPackage.Value is { } selected)
         {

--- a/agent-demos/lovable-travel-booking/lovable-travel-booking.sln
+++ b/agent-demos/lovable-travel-booking/lovable-travel-booking.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LovableTravelBooking", "LovableTravelBooking.csproj", "{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|x64.Build.0 = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Debug|x86.Build.0 = Debug|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|x64.ActiveCfg = Release|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|x64.Build.0 = Release|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|x86.ActiveCfg = Release|Any CPU
+		{DA9F12DB-6A43-4E9A-903B-9B15A63E0B1F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/meeting-cost-calculator/Program.cs
+++ b/agent-demos/meeting-cost-calculator/Program.cs
@@ -1,6 +1,5 @@
 using Ivy;
 using MeetingCostCalculator.Apps;
-using Microsoft.Extensions.DependencyInjection;
 
 var server = new Server();
 server.SetMetaTitle("Meeting Cost Calculator");

--- a/agent-demos/meeting-cost-calculator/meeting-cost-calculator.sln
+++ b/agent-demos/meeting-cost-calculator/meeting-cost-calculator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MeetingCostCalculator", "MeetingCostCalculator.csproj", "{FE64AE5A-EF25-41E6-9742-71FDD0023C69}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|x64.Build.0 = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Debug|x86.Build.0 = Debug|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|x64.ActiveCfg = Release|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|x64.Build.0 = Release|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|x86.ActiveCfg = Release|Any CPU
+		{FE64AE5A-EF25-41E6-9742-71FDD0023C69}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/pdf-compressor/Program.cs
+++ b/agent-demos/pdf-compressor/Program.cs
@@ -1,5 +1,4 @@
 using Ivy;
-using Microsoft.Extensions.DependencyInjection;
 using PDF.Compressor.Apps;
 
 var server = new Server();

--- a/agent-demos/pdf-compressor/pdf-compressor.sln
+++ b/agent-demos/pdf-compressor/pdf-compressor.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PDF.Compressor", "PDF.Compressor.csproj", "{47435FCF-B231-4843-B2CD-F9FFB3F9350F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|x64.Build.0 = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Debug|x86.Build.0 = Debug|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|x64.ActiveCfg = Release|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|x64.Build.0 = Release|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|x86.ActiveCfg = Release|Any CPU
+		{47435FCF-B231-4843-B2CD-F9FFB3F9350F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/readability-score-calculator/Apps/ReadabilityAnalyzer.cs
+++ b/agent-demos/readability-score-calculator/Apps/ReadabilityAnalyzer.cs
@@ -41,27 +41,27 @@ public static partial class ReadabilityAnalyzer
         var avgWordsPerSentence = (double)wordCount / sentenceCount;
         var avgSyllablesPerWord = wordCount > 0 ? (double)totalSyllables / wordCount : 0;
 
-        
+
         var fleschEase = 206.835 - 1.015 * avgWordsPerSentence - 84.6 * avgSyllablesPerWord;
 
-        
+
         var fleschKincaid = 0.39 * avgWordsPerSentence + 11.8 * avgSyllablesPerWord - 15.59;
 
-        
+
         var complexRatio = wordCount > 0 ? (double)complexWordCount / wordCount : 0;
         var gunningFog = 0.4 * (avgWordsPerSentence + 100.0 * complexRatio);
 
-        
+
         var l = wordCount > 0 ? (double)characterCount / wordCount * 100 : 0;
         var s = wordCount > 0 ? (double)sentenceCount / wordCount * 100 : 0;
         var colemanLiau = 0.0588 * l - 0.296 * s - 15.8;
 
-        
+
         var smog = sentenceCount > 0
             ? 3.0 + Math.Sqrt((double)complexWordCount * 30.0 / sentenceCount)
             : 0;
 
-        
+
         var avgCharsPerWord = wordCount > 0 ? (double)characterCount / wordCount : 0;
         var ari = 4.71 * avgCharsPerWord + 0.5 * avgWordsPerSentence - 21.43;
 
@@ -113,7 +113,7 @@ public static partial class ReadabilityAnalyzer
             prevIsVowel = isVowel;
         }
 
-        
+
         if (word.EndsWith('e') && count > 1)
         {
             count--;

--- a/agent-demos/readability-score-calculator/Program.cs
+++ b/agent-demos/readability-score-calculator/Program.cs
@@ -1,5 +1,4 @@
 using Ivy;
-using Microsoft.Extensions.DependencyInjection;
 using Readability.Score.Calculator.Apps;
 
 var server = new Server();

--- a/agent-demos/readability-score-calculator/readability-score-calculator.sln
+++ b/agent-demos/readability-score-calculator/readability-score-calculator.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Readability.Score.Calculator", "Readability.Score.Calculator.csproj", "{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|x64.Build.0 = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Debug|x86.Build.0 = Debug|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|x64.ActiveCfg = Release|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|x64.Build.0 = Release|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|x86.ActiveCfg = Release|Any CPU
+		{8586986B-BB0F-4DDD-8304-BC4DBFBB48A4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/rick-and-morty-graphql/Apps/Characters/CharactersApp.cs
+++ b/agent-demos/rick-and-morty-graphql/Apps/Characters/CharactersApp.cs
@@ -33,14 +33,14 @@ public class CharactersApp : ViewBase
         var statusOptions = new[] { "", "Alive", "Dead", "unknown" }.ToOptions();
         var genderOptions = new[] { "", "Female", "Male", "Genderless", "unknown" }.ToOptions();
 
-        
+
         var filters = Layout.Horizontal().Gap(2)
             | name.ToTextInput().Placeholder("Search by name...").Width(Size.Units(60))
             | status.ToSelectInput(statusOptions).Placeholder("Status").Width(Size.Units(40))
             | species.ToTextInput().Placeholder("Species...").Width(Size.Units(40))
             | gender.ToSelectInput(genderOptions).Placeholder("Gender").Width(Size.Units(40));
 
-        
+
         object content;
         if (query.Loading)
         {
@@ -56,7 +56,7 @@ public class CharactersApp : ViewBase
             var totalPages = data?.Info.Pages ?? 1;
             var characters = data?.Results ?? [];
 
-            
+
             var grid = Layout.Grid().Columns(4);
             foreach (var c in characters)
             {
@@ -85,8 +85,8 @@ public class CharactersApp : ViewBase
                 grid |= card;
             }
 
-            
-            var pagination = Layout.Horizontal().AlignContent   (Align.Center).Gap(2)
+
+            var pagination = Layout.Horizontal().AlignContent(Align.Center).Gap(2)
                 | new Button("Previous", () => page.Set(Math.Max(1, page.Value - 1)))
                     .Outline()
                     .Disabled(page.Value <= 1)

--- a/agent-demos/rick-and-morty-graphql/rick-and-morty-graphql.sln
+++ b/agent-demos/rick-and-morty-graphql/rick-and-morty-graphql.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RickAndMortyGraphQL", "RickAndMortyGraphQL.csproj", "{74432230-2359-4F79-80F0-C7A47B386697}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|x64.Build.0 = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Debug|x86.Build.0 = Debug|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|x64.ActiveCfg = Release|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|x64.Build.0 = Release|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|x86.ActiveCfg = Release|Any CPU
+		{74432230-2359-4F79-80F0-C7A47B386697}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/swapi-graph-ql/Apps/Services/SwapiService.cs
+++ b/agent-demos/swapi-graph-ql/Apps/Services/SwapiService.cs
@@ -15,7 +15,7 @@ public class SwapiService
         _http = http;
     }
 
-    
+
     public async Task<T?> GetAsync<T>(string url, CancellationToken ct = default) where T : class
     {
         if (_cache.TryGetValue(url, out var cached)) return (T)cached;
@@ -27,12 +27,12 @@ public class SwapiService
         return result;
     }
 
-    
+
     public async Task<List<T>> GetAllAsync<T>(string resource, CancellationToken ct = default) where T : class
     {
         var cacheKey = $"all:{resource}";
         if (_cache.TryGetValue(cacheKey, out var cached)) return (List<T>)cached;
-        
+
         var all = new List<T>();
         string? url = $"https://swapi.dev/api/{resource}/";
         while (url != null)
@@ -46,14 +46,14 @@ public class SwapiService
         return all;
     }
 
-    
+
     public static string ExtractId(string url)
     {
         var parts = url.TrimEnd('/').Split('/');
         return parts[^1];
     }
 
-    
+
     public async Task<List<(string Name, string Url)>> ResolveNamesAsync<T>(
         List<string> urls, Func<T, string> nameSelector, CancellationToken ct = default) where T : class
     {

--- a/agent-demos/swapi-graph-ql/swapi-graph-ql.sln
+++ b/agent-demos/swapi-graph-ql/swapi-graph-ql.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SWAPI.Graph.QL", "SWAPI.Graph.QL.csproj", "{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|x64.Build.0 = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Debug|x86.Build.0 = Debug|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|x64.ActiveCfg = Release|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|x64.Build.0 = Release|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|x86.ActiveCfg = Release|Any CPU
+		{C445F6CC-B472-4FDA-969E-ACCB81A4CC20}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/todo/Apps/TodoApp.cs
+++ b/agent-demos/todo/Apps/TodoApp.cs
@@ -20,7 +20,7 @@ public class TodoApp : ViewBase
         void AddItem()
         {
             if (string.IsNullOrWhiteSpace(newItemText.Value)) return;
-            todos.Set([..todos.Value, new TodoItem(newItemText.Value)]);
+            todos.Set([.. todos.Value, new TodoItem(newItemText.Value)]);
             newItemText.Set("");
         }
 

--- a/agent-demos/todo/Program.cs
+++ b/agent-demos/todo/Program.cs
@@ -1,5 +1,4 @@
 using Ivy;
-using Microsoft.Extensions.DependencyInjection;
 using Todo.Apps;
 
 var server = new Server();

--- a/agent-demos/todo/todo.sln
+++ b/agent-demos/todo/todo.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Todo", "Todo.csproj", "{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|x64.Build.0 = Release|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFD34E7C-0D6A-483D-9F0B-C03459E32FCC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/agent-demos/trevor-blades-countries/Apps/ExploreView.cs
+++ b/agent-demos/trevor-blades-countries/Apps/ExploreView.cs
@@ -22,17 +22,17 @@ public class ExploreView : ViewBase
 
         var data = query.Value!;
 
-        
+
         var continentOptions = new IAnyOption[] { new Option<string>("All Continents", "") }
             .Concat(data.Continents.OrderBy(c => c.Name).Select(c => new Option<string>(c.Name, c.Code)))
             .ToArray();
 
-        
+
         var languageOptions = new IAnyOption[] { new Option<string>("All Languages", "") }
             .Concat(data.Languages.OrderBy(l => l.Name).Select(l => new Option<string>(l.Name, l.Code)))
             .ToArray();
 
-        
+
         var filtered = data.Countries.AsEnumerable();
 
         if (!string.IsNullOrEmpty(selectedContinent.Value))
@@ -47,12 +47,12 @@ public class ExploreView : ViewBase
 
         var countries = filtered.ToArray();
 
-        
+
         var continentSelect = selectedContinent.ToSelectInput(continentOptions, placeholder: "All Continents");
         var languageSelect = selectedLanguage.ToSelectInput(languageOptions, placeholder: "All Languages");
         var searchInput = searchText.ToTextInput().Placeholder("Search countries...");
 
-        
+
         var tableData = countries.Select(c => new
         {
             Flag = c.Emoji,

--- a/agent-demos/trevor-blades-countries/trevor-blades-countries.sln
+++ b/agent-demos/trevor-blades-countries/trevor-blades-countries.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trevor.Blades.Countries", "Trevor.Blades.Countries.csproj", "{B17CCE77-8011-4626-8C9A-123FD48B497A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|x64.Build.0 = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|x64.ActiveCfg = Release|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|x64.Build.0 = Release|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B17CCE77-8011-4626-8C9A-123FD48B497A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary

Added `.sln` solution files for all 20 agent-demos that previously only had standalone `.csproj` files. Ran `dotnet format` on each agent-demo using the `.editorconfig` from plan 00074, formatting 27 source files.

## API Changes

None.

## Files Modified

- **Solution files (20 new):** `agent-demos/*/[name].sln` — one per agent-demo directory
- **Formatted source files (27 modified):** Various `.cs` files across agent-demos including Program.cs files (removed unused usings), app files (whitespace/indentation fixes), and service files (consistent formatting)

## Commits

- be18330 [00087] Add .sln files for all 20 agent-demos
- aafe4d2 [00087] Format agent-demos code