### PR TITLE
[00103] Generate .sln files for packages-demos and project-demos

### DIFF
--- a/packages-demos/aspose-barcode/Apps/BarcodeApp.cs
+++ b/packages-demos/aspose-barcode/Apps/BarcodeApp.cs
@@ -3,109 +3,109 @@ namespace AsposeBarCodeExample.Apps;
 [App(icon: Icons.QrCode, title: "Aspose BarCode")]
 public class BarcodeApp : ViewBase
 {
-  private enum DemoSize
-  {
-    Small,
-    Medium,
-    Large
-  }
-
-  private static float GetXDimension(DemoSize size)
-  {
-    return size switch
+    private enum DemoSize
     {
-      DemoSize.Small => 5f,
-      DemoSize.Medium => 10f,
-      DemoSize.Large => 15f,
-      _ => 10f
-    };
-  }
+        Small,
+        Medium,
+        Large
+    }
 
-  private static byte[] GeneratePngBytes(string text, SymbologyEncodeType encodeType, float xDimension)
-  {
-    using var generator = new BarcodeGenerator(encodeType, text);
-    generator.Parameters.Barcode.XDimension.Pixels = xDimension;
-
-    using var ms = new MemoryStream();
-    generator.Save(ms, BarCodeImageFormat.Png);
-    return ms.ToArray();
-  }
-
-  public override object? Build()
-  {
-    var text = UseState("");
-    var encodeType = UseState(EncodeTypes.QR);
-    var size = UseState(DemoSize.Medium);
-    var previewUri = UseState("");
-
-    var downloadUrl = this.UseDownload(() =>
+    private static float GetXDimension(DemoSize size)
     {
-      if (string.IsNullOrWhiteSpace(text.Value)) return Array.Empty<byte>();
-      var xDimension = GetXDimension(size.Value);
-      return GeneratePngBytes(text.Value, encodeType.Value, xDimension);
-    }, "image/png", "barcode.png");
-
-    var typeDropDown = new Button(encodeType.Value.ToString()).Primary()
-      .Icon(Icons.ChevronDown)
-      .WithDropDown(
-        MenuItem.Default("QR").OnSelect(() => encodeType.Value = EncodeTypes.QR),
-        MenuItem.Default("Pdf417").OnSelect(() => encodeType.Value = EncodeTypes.Pdf417),
-        MenuItem.Default("Code128").OnSelect(() => encodeType.Value = EncodeTypes.Code128),
-        MenuItem.Default("DataMatrix").OnSelect(() => encodeType.Value = EncodeTypes.DataMatrix),
-        MenuItem.Default("DotCode").OnSelect(() => encodeType.Value = EncodeTypes.DotCode),
-        MenuItem.Default("ISBN").OnSelect(() => encodeType.Value = EncodeTypes.ISBN)
-      );
-
-    var sizeDropDown = new Button(size.Value.ToString()).Primary()
-      .Icon(Icons.ChevronDown)
-      .WithDropDown(
-        MenuItem.Default("Small").OnSelect(() => size.Value = DemoSize.Small),
-        MenuItem.Default("Medium").OnSelect(() => size.Value = DemoSize.Medium),
-        MenuItem.Default("Large").OnSelect(() => size.Value = DemoSize.Large)
-      );
-
-    var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
-      | typeDropDown
-      | sizeDropDown
-      | new Button("Preview").Primary().Icon(Icons.Eye)
-        .OnClick(() =>
+        return size switch
         {
-          if (string.IsNullOrWhiteSpace(text.Value))
-          {
-            previewUri.Value = "";
-            return;
-          }
+            DemoSize.Small => 5f,
+            DemoSize.Medium => 10f,
+            DemoSize.Large => 15f,
+            _ => 10f
+        };
+    }
 
-          var xDimension = GetXDimension(size.Value);
-          var bytes = GeneratePngBytes(text.Value, encodeType.Value, xDimension);
-          var base64 = Convert.ToBase64String(bytes);
-          previewUri.Value = $"data:image/png;base64,{base64}";
-        })
-      | new Button("Download").Primary().Url(downloadUrl.Value).Icon(Icons.Download)
-        .Disabled(string.IsNullOrEmpty(previewUri.Value));
+    private static byte[] GeneratePngBytes(string text, SymbologyEncodeType encodeType, float xDimension)
+    {
+        using var generator = new BarcodeGenerator(encodeType, text);
+        generator.Parameters.Barcode.XDimension.Pixels = xDimension;
 
-    var leftCard = new Card(
-      Layout.Vertical().Gap(6).Padding(3)
-      | Text.H2("Input")
-      | Text.Muted("Enter text and barcode options")
-      | text.ToCodeInput().Language(Languages.Text).Width(Size.Full()).Height(Size.Units(25)).Placeholder("Enter text...")
-      | controls
-      | Text.Block("This demo uses Aspose.BarCode for .NET to generate barcodes.")
-      | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Aspose.BarCode for .NET](https://products.aspose.com/barcode/net/)")
-    ).Width(Size.Fraction(0.45f)).Height(Size.Units(130));
+        using var ms = new MemoryStream();
+        generator.Save(ms, BarCodeImageFormat.Png);
+        return ms.ToArray();
+    }
 
-    var rightCardBody = Layout.Vertical().Gap(4)
-      | Text.H2("Barcode")
-      | Text.Muted("Preview")
-      | (Layout.Center()
-      | (previewUri.Value is string uri && !string.IsNullOrEmpty(uri)
-          ? new Image(uri) // Use intrinsic size to avoid scaling blur
-          : Text.Muted("No preview")));
+    public override object? Build()
+    {
+        var text = UseState("");
+        var encodeType = UseState(EncodeTypes.QR);
+        var size = UseState(DemoSize.Medium);
+        var previewUri = UseState("");
 
-    var rightCard = new Card(rightCardBody).Width(Size.Fraction(0.45f)).Height(Size.Units(130));
+        var downloadUrl = this.UseDownload(() =>
+        {
+            if (string.IsNullOrWhiteSpace(text.Value)) return Array.Empty<byte>();
+            var xDimension = GetXDimension(size.Value);
+            return GeneratePngBytes(text.Value, encodeType.Value, xDimension);
+        }, "image/png", "barcode.png");
 
-    return Layout.Horizontal().Gap(6).AlignContent(Align.Center)
-          | leftCard
-          | rightCard;
-  }
+        var typeDropDown = new Button(encodeType.Value.ToString()).Primary()
+          .Icon(Icons.ChevronDown)
+          .WithDropDown(
+            MenuItem.Default("QR").OnSelect(() => encodeType.Value = EncodeTypes.QR),
+            MenuItem.Default("Pdf417").OnSelect(() => encodeType.Value = EncodeTypes.Pdf417),
+            MenuItem.Default("Code128").OnSelect(() => encodeType.Value = EncodeTypes.Code128),
+            MenuItem.Default("DataMatrix").OnSelect(() => encodeType.Value = EncodeTypes.DataMatrix),
+            MenuItem.Default("DotCode").OnSelect(() => encodeType.Value = EncodeTypes.DotCode),
+            MenuItem.Default("ISBN").OnSelect(() => encodeType.Value = EncodeTypes.ISBN)
+          );
+
+        var sizeDropDown = new Button(size.Value.ToString()).Primary()
+          .Icon(Icons.ChevronDown)
+          .WithDropDown(
+            MenuItem.Default("Small").OnSelect(() => size.Value = DemoSize.Small),
+            MenuItem.Default("Medium").OnSelect(() => size.Value = DemoSize.Medium),
+            MenuItem.Default("Large").OnSelect(() => size.Value = DemoSize.Large)
+          );
+
+        var controls = Layout.Horizontal().Gap(2).AlignContent(Align.Center)
+          | typeDropDown
+          | sizeDropDown
+          | new Button("Preview").Primary().Icon(Icons.Eye)
+            .OnClick(() =>
+            {
+                if (string.IsNullOrWhiteSpace(text.Value))
+                {
+                    previewUri.Value = "";
+                    return;
+                }
+
+                var xDimension = GetXDimension(size.Value);
+                var bytes = GeneratePngBytes(text.Value, encodeType.Value, xDimension);
+                var base64 = Convert.ToBase64String(bytes);
+                previewUri.Value = $"data:image/png;base64,{base64}";
+            })
+          | new Button("Download").Primary().Url(downloadUrl.Value).Icon(Icons.Download)
+            .Disabled(string.IsNullOrEmpty(previewUri.Value));
+
+        var leftCard = new Card(
+          Layout.Vertical().Gap(6).Padding(3)
+          | Text.H2("Input")
+          | Text.Muted("Enter text and barcode options")
+          | text.ToCodeInput().Language(Languages.Text).Width(Size.Full()).Height(Size.Units(25)).Placeholder("Enter text...")
+          | controls
+          | Text.Block("This demo uses Aspose.BarCode for .NET to generate barcodes.")
+          | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Aspose.BarCode for .NET](https://products.aspose.com/barcode/net/)")
+        ).Width(Size.Fraction(0.45f)).Height(Size.Units(130));
+
+        var rightCardBody = Layout.Vertical().Gap(4)
+          | Text.H2("Barcode")
+          | Text.Muted("Preview")
+          | (Layout.Center()
+          | (previewUri.Value is string uri && !string.IsNullOrEmpty(uri)
+              ? new Image(uri) // Use intrinsic size to avoid scaling blur
+              : Text.Muted("No preview")));
+
+        var rightCard = new Card(rightCardBody).Width(Size.Fraction(0.45f)).Height(Size.Units(130));
+
+        return Layout.Horizontal().Gap(6).AlignContent(Align.Center)
+              | leftCard
+              | rightCard;
+    }
 }

--- a/packages-demos/aspose-barcode/GlobalUsings.cs
+++ b/packages-demos/aspose-barcode/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System;

--- a/packages-demos/aspose-barcode/Program.cs
+++ b/packages-demos/aspose-barcode/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Faspose-barcode%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Faspose-barcode%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<BarcodeApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/aspose-barcode/aspose-barcode.sln
+++ b/packages-demos/aspose-barcode/aspose-barcode.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsposeBarCodeExample", "AsposeBarCodeExample.csproj", "{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|x64.Build.0 = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Debug|x86.Build.0 = Debug|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|x64.ActiveCfg = Release|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|x64.Build.0 = Release|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|x86.ActiveCfg = Release|Any CPU
+		{78A3236F-324C-4FDE-AB3D-D5A6C20A8D4F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/cronos/GlobalUsings.cs
+++ b/packages-demos/cronos/GlobalUsings.cs
@@ -1,13 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/cronos/Program.cs
+++ b/packages-demos/cronos/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fcronos%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fcronos%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<CronosApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/cronos/cronos.sln
+++ b/packages-demos/cronos/cronos.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CronosExample", "CronosExample.csproj", "{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|x64.Build.0 = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Debug|x86.Build.0 = Debug|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|x64.ActiveCfg = Release|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|x64.Build.0 = Release|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|x86.ActiveCfg = Release|Any CPU
+		{01DC0C38-DB4F-49C0-93C7-B1DE0E84734B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/csvhelper/Apps/CsvHelperApp.cs
+++ b/packages-demos/csvhelper/Apps/CsvHelperApp.cs
@@ -4,25 +4,25 @@ public class CsvHelperApp : ViewBase
     public class ProductModel
     {
         public Guid Id { get; set; }
-        
+
         [Required]
         public string Name { get; set; } = string.Empty;
-        
+
         public string Description { get; set; } = string.Empty;
-        
+
         [Required]
         public decimal Price { get; set; }
-        
+
         [Required]
         public string Category { get; set; } = string.Empty;
-        
+
         public DateTime CreatedAt { get; set; }
     }
 
     public override object? Build()
     {
         var client = UseService<IClientProvider>();
-        
+
         // State for products list
         var products = UseState(() => new List<ProductModel>
         {
@@ -32,7 +32,7 @@ public class CsvHelperApp : ViewBase
             new() { Id = Guid.NewGuid(), Name = "USB-C Hub", Description = "7-in-1 hub with HDMI, USB 3.0 and card reader", Price = 34.95m, Category = "Peripherals", CreatedAt = DateTime.UtcNow },
             new() { Id = Guid.NewGuid(), Name = "Noise-Cancelling Headphones", Description = "Over-ear Bluetooth headphones with ANC", Price = 149.00m, Category = "Audio", CreatedAt = DateTime.UtcNow },
         });
-        
+
         // Export CSV download
         var downloadUrl = this.UseDownload(
             async () =>
@@ -111,7 +111,7 @@ public class CsvHelperApp : ViewBase
                 client.Toast($"Product '{product.Name}' deleted");
             }
         });
-        
+
         // Build the table with delete button
         var table = products.Value.Select(p => new
         {

--- a/packages-demos/csvhelper/GlobalUsings.cs
+++ b/packages-demos/csvhelper/GlobalUsings.cs
@@ -1,11 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;

--- a/packages-demos/csvhelper/Program.cs
+++ b/packages-demos/csvhelper/Program.cs
@@ -6,7 +6,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fcsvhelper%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fcsvhelper%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<CsvHelperApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/csvhelper/csvhelper.sln
+++ b/packages-demos/csvhelper/csvhelper.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CsvHelperExample", "CsvHelperExample.csproj", "{53D5C1B9-3599-466F-BCFA-9316344328AB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|x64.Build.0 = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Debug|x86.Build.0 = Debug|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|x64.ActiveCfg = Release|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|x64.Build.0 = Release|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{53D5C1B9-3599-466F-BCFA-9316344328AB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/diffplex/Apps/DiffPlexApp.cs
+++ b/packages-demos/diffplex/Apps/DiffPlexApp.cs
@@ -25,7 +25,7 @@ public class DiffPlexApp : ViewBase
         {
             var diffBuilder = new SideBySideDiffBuilder(new Differ());
             diffResult.Value = diffBuilder.BuildDiffModel(
-                leftText.Value ?? "", 
+                leftText.Value ?? "",
                 rightText.Value ?? "",
                 ignoreWhitespace.Value,
                 ignoreCase.Value
@@ -56,7 +56,7 @@ public class DiffPlexApp : ViewBase
         if (diffResult.Value != null)
         {
             var diffLines = new List<string>();
-            
+
             // Use the NewText pane which has all lines including imaginary ones
             foreach (var line in diffResult.Value.NewText.Lines)
             {
@@ -68,14 +68,14 @@ public class DiffPlexApp : ViewBase
                     ChangeType.Imaginary => "- ",  // Deleted lines from original (shown as empty in new)
                     _ => "  "
                 };
-                
+
                 var lineText = line.Type == ChangeType.Imaginary ? "" : (line.Text ?? "");
                 diffLines.Add(prefix + lineText);
             }
-            
+
             diffDisplayText.Value = string.Join("\n", diffLines);
         }
-        
+
         // Comparison results card
         var resultsCard = diffResult.Value != null
             ? (object)(Layout.Vertical().Gap(3).Padding(2)
@@ -102,7 +102,7 @@ public class DiffPlexApp : ViewBase
             | new Spacer()
             | Text.Block("This demo uses the DiffPlex NuGet package for text comparison.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [DiffPlex](https://github.com/mmanela/diffplex)");
-                
+
 
         // Outer card for consistent width
         return new Card(mainContent).Height(Size.Fit().Min(Size.Full()));

--- a/packages-demos/diffplex/GlobalUsings.cs
+++ b/packages-demos/diffplex/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/diffplex/Program.cs
+++ b/packages-demos/diffplex/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdiffplex%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdiffplex%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<DiffPlexApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/diffplex/diffplex.sln
+++ b/packages-demos/diffplex/diffplex.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiffPlexExample", "DiffPlexExample.csproj", "{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|x64.Build.0 = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Debug|x86.Build.0 = Debug|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|x64.ActiveCfg = Release|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|x64.Build.0 = Release|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|x86.ActiveCfg = Release|Any CPU
+		{DFA1BAC4-4A28-4482-9A61-E0FDFA63275F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/epplus/Apps/EPPlusApp.cs
+++ b/packages-demos/epplus/Apps/EPPlusApp.cs
@@ -69,7 +69,7 @@ public class EPPlusApp : ViewBase
                 .Icon(Icons.FileText)
                 .OnClick(_ => ExcelManipulation.WriteExcel(booksState));
 
-        
+
         var formBuilder = book.ToForm().Remove(x => x.ID)
             .Label(m => m.Title, "Title")
             .Builder(m => m.Title, s => s.ToTextInput().Placeholder("Insert title..."))
@@ -92,7 +92,7 @@ public class EPPlusApp : ViewBase
                 | downloadBtn
                 | deleteBtn
                 | generateBtn)
-                
+
         ).Width(Size.Fraction(0.55f)).Height(Size.Fit().Min(Size.Full()));
 
         var leftCard = new Card(

--- a/packages-demos/epplus/GlobalUsings.cs
+++ b/packages-demos/epplus/GlobalUsings.cs
@@ -1,7 +1,6 @@
 global using EPPlusExample.Entities;
 global using EPPlusExample.Helpers;
 global using Ivy;
-global using Ivy.Views.Builders;
 global using OfficeOpenXml;
 global using OfficeOpenXml.Style;
 global using System.ComponentModel.DataAnnotations;

--- a/packages-demos/epplus/Helpers/ExcelManipulation.cs
+++ b/packages-demos/epplus/Helpers/ExcelManipulation.cs
@@ -1,6 +1,4 @@
-﻿using Ivy.Core.Hooks;
-
-namespace EPPlusExample.Helpers;
+﻿namespace EPPlusExample.Helpers;
 
 public static class ExcelManipulation
 {

--- a/packages-demos/epplus/Program.cs
+++ b/packages-demos/epplus/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fepplus%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fepplus%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<EPPlusApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/epplus/epplus.sln
+++ b/packages-demos/epplus/epplus.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EPPlusExample", "EPPlusExample.csproj", "{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|x64.Build.0 = Release|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4EE2BA0-E40B-453D-B253-0F5612F55FCC}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/fastmember/GlobalUsings.cs
+++ b/packages-demos/fastmember/GlobalUsings.cs
@@ -1,18 +1,9 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.ComponentModel;
 global using System.Diagnostics;
 global using System.Dynamic;
-global using System.Reflection;
 global using System.Text.Json;
 global using FastMember;
 

--- a/packages-demos/fastmember/Program.cs
+++ b/packages-demos/fastmember/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffastmember%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffastmember%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<FastMemberApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/fastmember/fastmember.sln
+++ b/packages-demos/fastmember/fastmember.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastMemberExample", "FastMemberExample.csproj", "{D55AD769-FD70-473D-9FB7-2B5F39B19689}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|x64.Build.0 = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Debug|x86.Build.0 = Debug|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|x64.ActiveCfg = Release|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|x64.Build.0 = Release|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|x86.ActiveCfg = Release|Any CPU
+		{D55AD769-FD70-473D-9FB7-2B5F39B19689}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/fluentdatetime/Apps/FluentDateTimeApp.cs
+++ b/packages-demos/fluentdatetime/Apps/FluentDateTimeApp.cs
@@ -36,20 +36,21 @@ public class FluentDateTimeApp : ViewBase
                              .OnClick(() => showResult.Set(true))
                          | new Button("Clear")
                              .Secondary()
-                             .OnClick(() => {
+                             .OnClick(() =>
+                             {
                                  showResult.Set(false);
                                  operation.Set("Add");
                                  unit.Set("Days");
                                  amount.Set(30);
                                  baseDateTime.Set(DateTime.Now);
                              }))
-                          | (showResult.Value ? 
+                          | (showResult.Value ?
                               new Card(
                                   Layout.Vertical()
                                   | Text.H3("Result").Bold()
                                   | Text.Markdown($"**Computed date**: `{resultDate:yyyy-MM-dd HH:mm}`")
                                   | Text.Markdown($"**Difference**: `{(int)(resultDate - baseDateTime.Value).TotalDays} days`")
-                              ) : 
+                              ) :
                               Text.Muted("Click 'Calculate' to see the result")
                             )
                          | new Spacer()
@@ -75,12 +76,12 @@ public class FluentDateTimeApp : ViewBase
         new Option<string?>("Years", "Years"),
     ];
 
-    
+
 
     private static DateTime ComputeDate(DateTime baseDate, string? operation, string? unit, int amount)
     {
         var isSubtract = string.Equals(operation, "Subtract", StringComparison.OrdinalIgnoreCase);
-    if (unit == "Months") return baseDate.AddMonths(isSubtract ? -amount : amount);
+        if (unit == "Months") return baseDate.AddMonths(isSubtract ? -amount : amount);
         if (unit == "Years") return baseDate.AddYears(isSubtract ? -amount : amount);
 
         var span = unit switch

--- a/packages-demos/fluentdatetime/GlobalUsings.cs
+++ b/packages-demos/fluentdatetime/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using FluentDateTime;

--- a/packages-demos/fluentdatetime/Program.cs
+++ b/packages-demos/fluentdatetime/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffluentdatetime%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ffluentdatetime%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<FluentDateTimeApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/fluentdatetime/fluentdatetime.sln
+++ b/packages-demos/fluentdatetime/fluentdatetime.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentDateTimeExample", "FluentDateTimeExample.csproj", "{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|x64.Build.0 = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Debug|x86.Build.0 = Debug|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|x64.ActiveCfg = Release|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|x64.Build.0 = Release|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|x86.ActiveCfg = Release|Any CPU
+		{62370EC5-F87C-4C75-99EC-4D0A58E00E0F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/github/Apps/GitHubExampleApp.cs
+++ b/packages-demos/github/Apps/GitHubExampleApp.cs
@@ -1,242 +1,242 @@
 namespace GitHubExample;
 
 public record GitHubUserStats(
-	int TotalStars,
-	int TotalCommitsLastYear,
-	int TotalPullRequests,
-	int TotalIssues,
-	int ContributedReposLastYear
+    int TotalStars,
+    int TotalCommitsLastYear,
+    int TotalPullRequests,
+    int TotalIssues,
+    int ContributedReposLastYear
 );
 
 [App(icon: Icons.Github, title: "GitHub")]
 public class GitHubExampleApp : ViewBase
 {
-	public override object? Build()
-	{
-		var username = this.UseState<string?>(String.Empty);
-		var loading = this.UseState(false);
-		var user = this.UseState<GhUser?>();
-		var stats = this.UseState<GitHubUserStats?>();
-		var error = this.UseState<string?>();
-		var client = UseService<IClientProvider>();
+    public override object? Build()
+    {
+        var username = this.UseState<string?>(String.Empty);
+        var loading = this.UseState(false);
+        var user = this.UseState<GhUser?>();
+        var stats = this.UseState<GitHubUserStats?>();
+        var error = this.UseState<string?>();
+        var client = UseService<IClientProvider>();
 
-		async Task handleGetStats()
-		{
-			error.Set((string?)null);
-			user.Set((GhUser?)null);
-			stats.Set((GitHubUserStats?)null);
-			if (string.IsNullOrWhiteSpace(username.Value))
-			{
-				error.Set("Please enter a GitHub username.");
-				client.Toast("Please enter a GitHub username.");
-				return;
-			}
+        async Task handleGetStats()
+        {
+            error.Set((string?)null);
+            user.Set((GhUser?)null);
+            stats.Set((GitHubUserStats?)null);
+            if (string.IsNullOrWhiteSpace(username.Value))
+            {
+                error.Set("Please enter a GitHub username.");
+                client.Toast("Please enter a GitHub username.");
+                return;
+            }
 
-			loading.Set(true);
-			try
-			{
-				// Mock data for testing
-				if (username.Value.Trim().ToLower() == "example")
-				{
-					var mockUser = new GhUser
-					{
-						Login = "example",
-						Name = "Example User",
-						AvatarUrl = "https://avatars.githubusercontent.com/u/1?v=4",
-						PublicRepos = 15,
-						Followers = 42,
-						Following = 8
-					};
-					
-					var mockStats = new GitHubUserStats(
-						TotalStars: 128,
-						TotalCommitsLastYear: 156,
-						TotalPullRequests: 23,
-						TotalIssues: 7,
-						ContributedReposLastYear: 5
-					);
-					
-					user.Set(mockUser);
-					stats.Set(mockStats);
-					client.Toast($"Successfully loaded mock stats for {mockUser.Name}!");
-				}
-				else
-				{
-					using var httpClient = CreateConfiguredHttpClient();
-					var ghUser = await httpClient.GetFromJsonAsync<GhUser>($"https://api.github.com/users/{username.Value.Trim()}", JsonOptions);
-					if (ghUser is null) throw new Exception("User not found.");
-					user.Set(ghUser);
-					var computed = await ComputeStatsAsync(httpClient, ghUser);
-					stats.Set(computed);
-					client.Toast($"Successfully loaded stats for {ghUser.Name ?? ghUser.Login}!");
-				}
-			}
-			catch (Exception ex)
-			{
-				error.Set(ex.Message);
-				client.Toast(ex);
-			}
-			finally
-			{
-				loading.Set(false);
-			}
-		}
-		object? content = null;
-		if (user.Value != null && stats.Value != null)
-		{
-			var u = user.Value;
-			var s = stats.Value!;
+            loading.Set(true);
+            try
+            {
+                // Mock data for testing
+                if (username.Value.Trim().ToLower() == "example")
+                {
+                    var mockUser = new GhUser
+                    {
+                        Login = "example",
+                        Name = "Example User",
+                        AvatarUrl = "https://avatars.githubusercontent.com/u/1?v=4",
+                        PublicRepos = 15,
+                        Followers = 42,
+                        Following = 8
+                    };
 
-			var userDetails = new
-			{
-				Name = u.Name ?? u.Login,
-				Username = u.Login,
-				Avatar = u.AvatarUrl,
-				PublicRepos = u.PublicRepos,
-				Followers = u.Followers,
-				Following = u.Following,
-				TotalStars = s.TotalStars,
-				TotalCommitsLastYear = s.TotalCommitsLastYear,
-				TotalPullRequests = s.TotalPullRequests,
-				TotalIssues = s.TotalIssues,
-				ContributedReposLastYear = s.ContributedReposLastYear
-			};
+                    var mockStats = new GitHubUserStats(
+                        TotalStars: 128,
+                        TotalCommitsLastYear: 156,
+                        TotalPullRequests: 23,
+                        TotalIssues: 7,
+                        ContributedReposLastYear: 5
+                    );
 
-			var details = userDetails.ToDetails()
-				.Remove(x => x.Avatar) // Remove avatar from details since we show it separately
-				.Builder(x => x.Username, b => b.CopyToClipboard())
-				.Builder(x => x.Name, b => b.CopyToClipboard())
-				.Builder(x => x.Avatar, b => b.Link());
+                    user.Set(mockUser);
+                    stats.Set(mockStats);
+                    client.Toast($"Successfully loaded mock stats for {mockUser.Name}!");
+                }
+                else
+                {
+                    using var httpClient = CreateConfiguredHttpClient();
+                    var ghUser = await httpClient.GetFromJsonAsync<GhUser>($"https://api.github.com/users/{username.Value.Trim()}", JsonOptions);
+                    if (ghUser is null) throw new Exception("User not found.");
+                    user.Set(ghUser);
+                    var computed = await ComputeStatsAsync(httpClient, ghUser);
+                    stats.Set(computed);
+                    client.Toast($"Successfully loaded stats for {ghUser.Name ?? ghUser.Login}!");
+                }
+            }
+            catch (Exception ex)
+            {
+                error.Set(ex.Message);
+                client.Toast(ex);
+            }
+            finally
+            {
+                loading.Set(false);
+            }
+        }
+        object? content = null;
+        if (user.Value != null && stats.Value != null)
+        {
+            var u = user.Value;
+            var s = stats.Value!;
 
-			content = new Card(
-				Layout.Vertical().Gap(1)
-					| Layout.Horizontal().Gap(2)
-						| new Avatar(u.Name ?? u.Login, u.AvatarUrl)
-							.Height(Size.Units(60))
-							.Width(Size.Units(60))
-						| Text.H3($"{u.Name ?? u.Login}'s GitHub Stats")
-					| details
-			).Width(Size.Fraction(0.35f));
-		}
+            var userDetails = new
+            {
+                Name = u.Name ?? u.Login,
+                Username = u.Login,
+                Avatar = u.AvatarUrl,
+                PublicRepos = u.PublicRepos,
+                Followers = u.Followers,
+                Following = u.Following,
+                TotalStars = s.TotalStars,
+                TotalCommitsLastYear = s.TotalCommitsLastYear,
+                TotalPullRequests = s.TotalPullRequests,
+                TotalIssues = s.TotalIssues,
+                ContributedReposLastYear = s.ContributedReposLastYear
+            };
 
-		object? rightContent = null;
-		if (content != null)
-		{
-			rightContent = content;
-		}
+            var details = userDetails.ToDetails()
+                .Remove(x => x.Avatar) // Remove avatar from details since we show it separately
+                .Builder(x => x.Username, b => b.CopyToClipboard())
+                .Builder(x => x.Name, b => b.CopyToClipboard())
+                .Builder(x => x.Avatar, b => b.Link());
 
-		var leftCard = new Card(Layout.Vertical().Gap(2)
-			| Text.H1("GitHub Stats")
-			| Text.Muted("Type a username and click Get Stats. Use 'example' for mock data or real GitHub usernames for live data.")
-			| username.ToSearchInput(placeholder: "GitHub username (e.g. torvalds, example for mock data)")
-			| (Layout.Horizontal().Gap(2)
-				| new Button("Get Stats", onClick: () => { _ = handleGetStats(); })
-					.Icon(Icons.ChartBar)
-					.Loading(loading.Value)
-					.Disabled(loading.Value)
-				| new Button("Clear", onClick: () =>
-				{
-					username.Set("");
-					user.Set((GhUser?)null);
-					stats.Set((GitHubUserStats?)null);
-					error.Set((string?)null);
-				}).Secondary().Icon(Icons.Trash))
-				| new Spacer().Height(Size.Units(5))
-				| Text.Block("This demo integrates with the GitHub REST API to fetch user statistics and profile information.")
-			    | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [GitHub REST API](https://docs.github.com/en/rest)")
-				).Width(Size.Fraction(0.35f)).Height(Size.Fit());
+            content = new Card(
+                Layout.Vertical().Gap(1)
+                    | Layout.Horizontal().Gap(2)
+                        | new Avatar(u.Name ?? u.Login, u.AvatarUrl)
+                            .Height(Size.Units(60))
+                            .Width(Size.Units(60))
+                        | Text.H3($"{u.Name ?? u.Login}'s GitHub Stats")
+                    | details
+            ).Width(Size.Fraction(0.35f));
+        }
 
-		return rightContent != null 
-			? (Layout.Horizontal().Gap(20).AlignContent(Align.Center) | leftCard | rightContent)
-			: Layout.Center() | leftCard;
-	}
+        object? rightContent = null;
+        if (content != null)
+        {
+            rightContent = content;
+        }
 
-	private static async Task<GitHubUserStats> ComputeStatsAsync(HttpClient client, GhUser user)
-	{
-		var owner = user.Login;
+        var leftCard = new Card(Layout.Vertical().Gap(2)
+            | Text.H1("GitHub Stats")
+            | Text.Muted("Type a username and click Get Stats. Use 'example' for mock data or real GitHub usernames for live data.")
+            | username.ToSearchInput(placeholder: "GitHub username (e.g. torvalds, example for mock data)")
+            | (Layout.Horizontal().Gap(2)
+                | new Button("Get Stats", onClick: () => { _ = handleGetStats(); })
+                    .Icon(Icons.ChartBar)
+                    .Loading(loading.Value)
+                    .Disabled(loading.Value)
+                | new Button("Clear", onClick: () =>
+                {
+                    username.Set("");
+                    user.Set((GhUser?)null);
+                    stats.Set((GitHubUserStats?)null);
+                    error.Set((string?)null);
+                }).Secondary().Icon(Icons.Trash))
+                | new Spacer().Height(Size.Units(5))
+                | Text.Block("This demo integrates with the GitHub REST API to fetch user statistics and profile information.")
+                | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [GitHub REST API](https://docs.github.com/en/rest)")
+                ).Width(Size.Fraction(0.35f)).Height(Size.Fit());
 
-		var repos = new List<GhRepo>();
-		var page = 1;
-		while (true)
-		{
-			var pageItems = await client.GetFromJsonAsync<List<GhRepo>>($"https://api.github.com/users/{owner}/repos?per_page=100&page={page}", JsonOptions) ?? new List<GhRepo>();
-			if (pageItems.Count == 0) break;
-			repos.AddRange(pageItems);
-			page++;
-		}
+        return rightContent != null
+            ? (Layout.Horizontal().Gap(20).AlignContent(Align.Center) | leftCard | rightContent)
+            : Layout.Center() | leftCard;
+    }
 
-		var nonForkRepos = repos.Where(r => !r.Fork).ToList();
-		var totalStars = nonForkRepos.Sum(r => r.StargazersCount);
+    private static async Task<GitHubUserStats> ComputeStatsAsync(HttpClient client, GhUser user)
+    {
+        var owner = user.Login;
 
-		var prSearch = await client.GetFromJsonAsync<SearchIssuesResponse>($"https://api.github.com/search/issues?q=type:pr+author:{owner}&per_page=1", JsonOptions);
-		var totalPRs = prSearch?.TotalCount ?? 0;
+        var repos = new List<GhRepo>();
+        var page = 1;
+        while (true)
+        {
+            var pageItems = await client.GetFromJsonAsync<List<GhRepo>>($"https://api.github.com/users/{owner}/repos?per_page=100&page={page}", JsonOptions) ?? new List<GhRepo>();
+            if (pageItems.Count == 0) break;
+            repos.AddRange(pageItems);
+            page++;
+        }
 
-		var issueSearch = await client.GetFromJsonAsync<SearchIssuesResponse>($"https://api.github.com/search/issues?q=type:issue+author:{owner}&per_page=1", JsonOptions);
-		var totalIssues = issueSearch?.TotalCount ?? 0;
+        var nonForkRepos = repos.Where(r => !r.Fork).ToList();
+        var totalStars = nonForkRepos.Sum(r => r.StargazersCount);
 
-		var since = DateTimeOffset.UtcNow.AddYears(-1);
-		var until = DateTimeOffset.UtcNow;
-		var totalCommits = 0;
-		var contributedRepos = 0;
+        var prSearch = await client.GetFromJsonAsync<SearchIssuesResponse>($"https://api.github.com/search/issues?q=type:pr+author:{owner}&per_page=1", JsonOptions);
+        var totalPRs = prSearch?.TotalCount ?? 0;
 
-		return new GitHubUserStats(totalStars, totalCommits, totalPRs, totalIssues, contributedRepos);
-	}
+        var issueSearch = await client.GetFromJsonAsync<SearchIssuesResponse>($"https://api.github.com/search/issues?q=type:issue+author:{owner}&per_page=1", JsonOptions);
+        var totalIssues = issueSearch?.TotalCount ?? 0;
 
-	private static async Task<int> GetCommitCountForRepo(HttpClient client, string owner, string repoName, string authorLogin, DateTimeOffset since, DateTimeOffset until)
-	{
-		var count = 0;
-		var page = 1;
-		while (true)
-		{
-			var encodedRepoName = Uri.EscapeDataString(repoName);
-			var url = $"https://api.github.com/repos/{owner}/{encodedRepoName}/commits?author={authorLogin}&since={Uri.EscapeDataString(since.ToString("o"))}&until={Uri.EscapeDataString(until.ToString("o"))}&per_page=100&page={page}";
-			var commits = await client.GetFromJsonAsync<List<GhCommit>>(url, JsonOptions) ?? new List<GhCommit>();
-			if (commits.Count == 0) break;
-			count += commits.Count;
-			page++;
-		}
-		return count;
-	}
+        var since = DateTimeOffset.UtcNow.AddYears(-1);
+        var until = DateTimeOffset.UtcNow;
+        var totalCommits = 0;
+        var contributedRepos = 0;
 
-	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
-	{
-		PropertyNameCaseInsensitive = true
-	};
+        return new GitHubUserStats(totalStars, totalCommits, totalPRs, totalIssues, contributedRepos);
+    }
 
-	private static HttpClient CreateConfiguredHttpClient()
-	{
-		var client = new HttpClient();
-		client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("GitHubExample", "1.0"));
-		client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
-		var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
-		if (!string.IsNullOrWhiteSpace(token))
-		{
-			client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-		}
-		return client;
-	}
+    private static async Task<int> GetCommitCountForRepo(HttpClient client, string owner, string repoName, string authorLogin, DateTimeOffset since, DateTimeOffset until)
+    {
+        var count = 0;
+        var page = 1;
+        while (true)
+        {
+            var encodedRepoName = Uri.EscapeDataString(repoName);
+            var url = $"https://api.github.com/repos/{owner}/{encodedRepoName}/commits?author={authorLogin}&since={Uri.EscapeDataString(since.ToString("o"))}&until={Uri.EscapeDataString(until.ToString("o"))}&per_page=100&page={page}";
+            var commits = await client.GetFromJsonAsync<List<GhCommit>>(url, JsonOptions) ?? new List<GhCommit>();
+            if (commits.Count == 0) break;
+            count += commits.Count;
+            page++;
+        }
+        return count;
+    }
 
-	private sealed class GhUser
-	{
-		[JsonPropertyName("login")] public string Login { get; set; }
-		[JsonPropertyName("name")] public string? Name { get; set; }
-		[JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
-		[JsonPropertyName("public_repos")] public int PublicRepos { get; set; }
-		[JsonPropertyName("followers")] public int Followers { get; set; }
-		[JsonPropertyName("following")] public int Following { get; set; }
-	}
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
 
-	private sealed class GhRepo
-	{
-		[JsonPropertyName("name")] public string Name { get; set; }
-		[JsonPropertyName("fork")] public bool Fork { get; set; }
-		[JsonPropertyName("stargazers_count")] public int StargazersCount { get; set; }
-	}
+    private static HttpClient CreateConfiguredHttpClient()
+    {
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("GitHubExample", "1.0"));
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        return client;
+    }
 
-	private sealed class GhCommit { }
+    private sealed class GhUser
+    {
+        [JsonPropertyName("login")] public string Login { get; set; }
+        [JsonPropertyName("name")] public string? Name { get; set; }
+        [JsonPropertyName("avatar_url")] public string? AvatarUrl { get; set; }
+        [JsonPropertyName("public_repos")] public int PublicRepos { get; set; }
+        [JsonPropertyName("followers")] public int Followers { get; set; }
+        [JsonPropertyName("following")] public int Following { get; set; }
+    }
 
-	private sealed class SearchIssuesResponse
-	{
-		[JsonPropertyName("total_count")] public int TotalCount { get; set; }
-	}
+    private sealed class GhRepo
+    {
+        [JsonPropertyName("name")] public string Name { get; set; }
+        [JsonPropertyName("fork")] public bool Fork { get; set; }
+        [JsonPropertyName("stargazers_count")] public int StargazersCount { get; set; }
+    }
+
+    private sealed class GhCommit { }
+
+    private sealed class SearchIssuesResponse
+    {
+        [JsonPropertyName("total_count")] public int TotalCount { get; set; }
+    }
 }

--- a/packages-demos/github/GlobalUsings.cs
+++ b/packages-demos/github/GlobalUsings.cs
@@ -1,11 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Net.Http;

--- a/packages-demos/github/Program.cs
+++ b/packages-demos/github/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fgithub%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fgithub%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<GitHubExampleApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/github/github.sln
+++ b/packages-demos/github/github.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubExample", "GitHubExample.csproj", "{ADE72984-3013-4023-8CCD-6C08A3382692}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|x64.Build.0 = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Debug|x86.Build.0 = Debug|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|x64.ActiveCfg = Release|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|x64.Build.0 = Release|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|x86.ActiveCfg = Release|Any CPU
+		{ADE72984-3013-4023-8CCD-6C08A3382692}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/ibannet/Apps/IbanNetDemoApp.cs
+++ b/packages-demos/ibannet/Apps/IbanNetDemoApp.cs
@@ -8,7 +8,7 @@
         private readonly IbanRegistry _registry;
         private readonly SwiftRegistryProvider _swiftProvider = new();
         private readonly WikipediaRegistryProvider _wikiProvider = new();
-        
+
         /// <summary>Initialize components for IBAN parsing, validation, and registry</summary>
         public IbanNetDemoApp()
         {
@@ -58,7 +58,7 @@
                 | generateBtn
                 | new Spacer()
                 | Text.Block("This demo uses IbanNet library to validate and generate IBAN numbers.")
-			    | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [IbanNet](https://github.com/skwasjer/IbanNet)")
+                | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [IbanNet](https://github.com/skwasjer/IbanNet)")
                 ).Width(Size.Fraction(0.35f)).Height(Size.Fit().Min(Size.Full()));
 
             // Right Card - Results
@@ -66,7 +66,7 @@
                 Layout.Vertical()
                 | (hasValidIban
                     ? new IbanDetailsView(iban)
-                    :Layout.Vertical()
+                    : Layout.Vertical()
                     | Text.H3("IBAN Details")
                     | Layout.Vertical()
                         | Callout.Info("Enter a valid IBAN number in the left panel or generate a test IBAN to see detailed information here.", "Instructions")

--- a/packages-demos/ibannet/GlobalUsings.cs
+++ b/packages-demos/ibannet/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using IbanNet;

--- a/packages-demos/ibannet/Program.cs
+++ b/packages-demos/ibannet/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fibannet%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fibannet%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<IbanNetDemoApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/ibannet/ibannet.sln
+++ b/packages-demos/ibannet/ibannet.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IbanNetExample", "IbanNetExample.csproj", "{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|x64.Build.0 = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Debug|x86.Build.0 = Debug|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|x64.ActiveCfg = Release|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|x64.Build.0 = Release|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|x86.ActiveCfg = Release|Any CPU
+		{A809FED3-CC73-4BD1-AF6C-EC2D75FFBF3C}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/puppeteersharp/Apps/MemoryFileStore.cs
+++ b/packages-demos/puppeteersharp/Apps/MemoryFileStore.cs
@@ -14,7 +14,7 @@
         public static (byte[] Data, string ContentType, string FileName)? Get(string id)
         {
             if (_files.TryGetValue(id, out var file))
-                return new (file.Data, file.ContentType, file.FileName);
+                return new(file.Data, file.ContentType, file.FileName);
 
             _files.Remove(id);
             return null;

--- a/packages-demos/puppeteersharp/GlobalUsings.cs
+++ b/packages-demos/puppeteersharp/GlobalUsings.cs
@@ -1,19 +1,11 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.AspNetCore.Http;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
-global using System.Buffers.Text;
 global using PuppeteerSharp;
 global using PuppeteerSharp.Media;
 

--- a/packages-demos/puppeteersharp/Program.cs
+++ b/packages-demos/puppeteersharp/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fpuppeteersharp%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fpuppeteersharp%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<PuppeteerSharpApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/puppeteersharp/puppeteersharp.sln
+++ b/packages-demos/puppeteersharp/puppeteersharp.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PuppeteerSharpExample", "PuppeteerSharpExample.csproj", "{99489F67-8C27-4BBD-AA0D-22A6760A7288}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|x64.Build.0 = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Debug|x86.Build.0 = Debug|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|x64.ActiveCfg = Release|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|x64.Build.0 = Release|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|x86.ActiveCfg = Release|Any CPU
+		{99489F67-8C27-4BBD-AA0D-22A6760A7288}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/questpdf/Apps/QuestPdfApp.cs
+++ b/packages-demos/questpdf/Apps/QuestPdfApp.cs
@@ -3,132 +3,132 @@ namespace QuestPdfExample;
 [App(icon: Icons.FileDown, title: "QuestPDF")]
 public class QuestPdfApp : ViewBase
 {
-  private readonly PdfGenerationService _pdfService;
-  
-  public QuestPdfApp()
-  {
-    _pdfService = new PdfGenerationService();
-  }
+    private readonly PdfGenerationService _pdfService;
 
-  public override object? Build()
-  {
-    var title = UseState("Resume");
-    var body = UseState(() => LoadEmbedded("Assets.Resume.md"));
-    var pageSize = UseState("A4");
-    var landscape = UseState(false);
-    var margins = UseState(30);
-    var insertType = UseState("Heading 1");
-    
-    var downloadUrl = this.UseDownload(() => GeneratePdf(), "application/pdf", "report.pdf");
-
-    var previewBytes = UseState<byte[]?>(() => GeneratePdf());
-    this.UseEffect(async () =>
+    public QuestPdfApp()
     {
-      await Task.Delay(350);
-      previewBytes.Set(GeneratePdf());
-    }, title, body, pageSize, margins, landscape);
-    
-    void InsertSnippetByType(string type)
-    {
-      string snippet = type switch
-      {
-        "Heading 1" => "# ",
-        "Heading 2" => "## ",
-        "Heading 3" => "### ",
-        "Bullet" => "- ",
-        "Numbered" => "1. ",
-        "Quote" => "> ",
-        "Checkbox" => "- [ ] ",
-        "Table" => "|  |  |\n|  |  |",
-        _ => string.Empty
-      };
-      var current = body.Value ?? string.Empty;
-      var sep = current.EndsWith("\n") || current.Length == 0 ? "" : "\n";
-      body.Set(current + sep + snippet + "\n");
+        _pdfService = new PdfGenerationService();
     }
 
-    byte[] GeneratePdf()
+    public override object? Build()
     {
-      var settings = new PdfSettings
-      {
-        PageSize = pageSize.Value,
-        Landscape = landscape.Value,
-        Margins = margins.Value
-      };
+        var title = UseState("Resume");
+        var body = UseState(() => LoadEmbedded("Assets.Resume.md"));
+        var pageSize = UseState("A4");
+        var landscape = UseState(false);
+        var margins = UseState(30);
+        var insertType = UseState("Heading 1");
 
-      return _pdfService.GeneratePdf(title.Value, body.Value ?? string.Empty, settings);
+        var downloadUrl = this.UseDownload(() => GeneratePdf(), "application/pdf", "report.pdf");
+
+        var previewBytes = UseState<byte[]?>(() => GeneratePdf());
+        this.UseEffect(async () =>
+        {
+            await Task.Delay(350);
+            previewBytes.Set(GeneratePdf());
+        }, title, body, pageSize, margins, landscape);
+
+        void InsertSnippetByType(string type)
+        {
+            string snippet = type switch
+            {
+                "Heading 1" => "# ",
+                "Heading 2" => "## ",
+                "Heading 3" => "### ",
+                "Bullet" => "- ",
+                "Numbered" => "1. ",
+                "Quote" => "> ",
+                "Checkbox" => "- [ ] ",
+                "Table" => "|  |  |\n|  |  |",
+                _ => string.Empty
+            };
+            var current = body.Value ?? string.Empty;
+            var sep = current.EndsWith("\n") || current.Length == 0 ? "" : "\n";
+            body.Set(current + sep + snippet + "\n");
+        }
+
+        byte[] GeneratePdf()
+        {
+            var settings = new PdfSettings
+            {
+                PageSize = pageSize.Value,
+                Landscape = landscape.Value,
+                Margins = margins.Value
+            };
+
+            return _pdfService.GeneratePdf(title.Value, body.Value ?? string.Empty, settings);
+        }
+
+        var previewDataUrl = previewBytes.Value is null
+          ? string.Empty
+          : "data:application/pdf;base64," + Convert.ToBase64String(previewBytes.Value) + "#zoom=page-width&toolbar=0&navpanes=0";
+
+        long refreshToken = 0;
+        if (previewBytes.Value is not null)
+        {
+            var h = System.Security.Cryptography.SHA256.HashData(previewBytes.Value);
+            refreshToken = Math.Abs(BitConverter.ToInt64(h, 0));
+        }
+
+        var leftForm = new Card(
+              Layout.Vertical().Padding(3)
+              | Text.H2("QuestPDF Demo")
+              | Text.Muted("Generate a simple PDF document")
+              | title.ToInput(placeholder: "Title")
+                | (
+                  Layout.Horizontal().Gap(3)
+                  | new Button($"Page: {pageSize.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
+                        MenuItem.Default("A4").OnSelect(() => pageSize.Value = "A4"),
+                        MenuItem.Default("Letter").OnSelect(() => pageSize.Value = "Letter")
+                    )
+                  | new Button(landscape.Value ? "Landscape" : "Portrait").Outline().Icon(Icons.ChevronDown).WithDropDown(
+                        MenuItem.Default("Portrait").OnSelect(() => landscape.Value = false),
+                        MenuItem.Default("Landscape").OnSelect(() => landscape.Value = true)
+                    )
+                  | new Button($"Margins: {margins.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
+                        MenuItem.Default("15").OnSelect(() => margins.Value = 15),
+                        MenuItem.Default("30").OnSelect(() => margins.Value = 30),
+                        MenuItem.Default("50").OnSelect(() => margins.Value = 50)
+                    )
+                  | new Button($"Type: {insertType.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
+                        MenuItem.Default("Heading 1").OnSelect(() => { insertType.Value = "Heading 1"; InsertSnippetByType("Heading 1"); }),
+                        MenuItem.Default("Heading 2").OnSelect(() => { insertType.Value = "Heading 2"; InsertSnippetByType("Heading 2"); }),
+                        MenuItem.Default("Heading 3").OnSelect(() => { insertType.Value = "Heading 3"; InsertSnippetByType("Heading 3"); }),
+                        MenuItem.Default("Bullet").OnSelect(() => { insertType.Value = "Bullet"; InsertSnippetByType("Bullet"); }),
+                        MenuItem.Default("Numbered").OnSelect(() => { insertType.Value = "Numbered"; InsertSnippetByType("Numbered"); }),
+                        MenuItem.Default("Quote").OnSelect(() => { insertType.Value = "Quote"; InsertSnippetByType("Quote"); }),
+                        MenuItem.Default("Checkbox").OnSelect(() => { insertType.Value = "Checkbox"; InsertSnippetByType("Checkbox"); }),
+                        MenuItem.Default("Table").OnSelect(() => { insertType.Value = "Table"; InsertSnippetByType("Table"); })
+                    )
+                  | new Button("Download").Primary().Icon(Icons.Download).Url(downloadUrl.Value)
+                )
+              | body.ToCodeInput().Language(Languages.Markdown).Width(Ivy.Size.Full()).Height(Ivy.Size.Units(90)).Placeholder("Body (Markdown)")
+              | new Spacer()
+              | Text.Block("This demo uses the QuestPDF NuGet package to generate PDFs.")
+              | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [QuestPDF](https://github.com/QuestPDF/QuestPDF)")
+            ).Height(Ivy.Size.Full());
+
+        var rightPreview = new Card(
+              Layout.Vertical()
+              | (string.IsNullOrEmpty(previewDataUrl)
+                  ? Text.Muted("Generating preview...")
+                  : new Iframe(previewDataUrl, refreshToken).Height(Ivy.Size.Screen()))
+            );
+
+        return Layout.Horizontal().Gap(4).Padding(4)
+          | leftForm
+          | rightPreview;
     }
 
-    var previewDataUrl = previewBytes.Value is null
-      ? string.Empty
-      : "data:application/pdf;base64," + Convert.ToBase64String(previewBytes.Value) + "#zoom=page-width&toolbar=0&navpanes=0";
-
-    long refreshToken = 0;
-    if (previewBytes.Value is not null)
+    private string LoadEmbedded(string name)
     {
-      var h = System.Security.Cryptography.SHA256.HashData(previewBytes.Value);
-      refreshToken = Math.Abs(BitConverter.ToInt64(h, 0));
+        try
+        {
+            using var s = typeof(QuestPdfApp).Assembly.GetManifestResourceStream("QuestPdfExample." + name);
+            if (s == null) return string.Empty;
+            using var sr = new StreamReader(s);
+            return sr.ReadToEnd();
+        }
+        catch { return string.Empty; }
     }
-
-    var leftForm = new Card(
-          Layout.Vertical().Padding(3)
-          | Text.H2("QuestPDF Demo")
-          | Text.Muted("Generate a simple PDF document")
-          | title.ToInput(placeholder: "Title")
-            | (
-              Layout.Horizontal().Gap(3)
-              | new Button($"Page: {pageSize.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
-                    MenuItem.Default("A4").OnSelect(() => pageSize.Value = "A4"),
-                    MenuItem.Default("Letter").OnSelect(() => pageSize.Value = "Letter")
-                )
-              | new Button(landscape.Value ? "Landscape" : "Portrait").Outline().Icon(Icons.ChevronDown).WithDropDown(
-                    MenuItem.Default("Portrait").OnSelect(() => landscape.Value = false),
-                    MenuItem.Default("Landscape").OnSelect(() => landscape.Value = true)
-                )
-              | new Button($"Margins: {margins.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
-                    MenuItem.Default("15").OnSelect(() => margins.Value = 15),
-                    MenuItem.Default("30").OnSelect(() => margins.Value = 30),
-                    MenuItem.Default("50").OnSelect(() => margins.Value = 50)
-                )
-              | new Button($"Type: {insertType.Value}").Outline().Icon(Icons.ChevronDown).WithDropDown(
-                    MenuItem.Default("Heading 1").OnSelect(() => { insertType.Value = "Heading 1"; InsertSnippetByType("Heading 1"); }),
-                    MenuItem.Default("Heading 2").OnSelect(() => { insertType.Value = "Heading 2"; InsertSnippetByType("Heading 2"); }),
-                    MenuItem.Default("Heading 3").OnSelect(() => { insertType.Value = "Heading 3"; InsertSnippetByType("Heading 3"); }),
-                    MenuItem.Default("Bullet").OnSelect(() => { insertType.Value = "Bullet"; InsertSnippetByType("Bullet"); }),
-                    MenuItem.Default("Numbered").OnSelect(() => { insertType.Value = "Numbered"; InsertSnippetByType("Numbered"); }),
-                    MenuItem.Default("Quote").OnSelect(() => { insertType.Value = "Quote"; InsertSnippetByType("Quote"); }),
-                    MenuItem.Default("Checkbox").OnSelect(() => { insertType.Value = "Checkbox"; InsertSnippetByType("Checkbox"); }),
-                    MenuItem.Default("Table").OnSelect(() => { insertType.Value = "Table"; InsertSnippetByType("Table"); })
-                )
-              | new Button("Download").Primary().Icon(Icons.Download).Url(downloadUrl.Value)
-            )
-          | body.ToCodeInput().Language(Languages.Markdown).Width(Ivy.Size.Full()).Height(Ivy.Size.Units(90)).Placeholder("Body (Markdown)")
-          | new Spacer()
-          | Text.Block("This demo uses the QuestPDF NuGet package to generate PDFs.")
-          | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [QuestPDF](https://github.com/QuestPDF/QuestPDF)")
-        ).Height(Ivy.Size.Full());
-    
-    var rightPreview = new Card(
-          Layout.Vertical()
-          | (string.IsNullOrEmpty(previewDataUrl)
-              ? Text.Muted("Generating preview...")
-              : new Iframe(previewDataUrl, refreshToken).Height(Ivy.Size.Screen()))
-        );
-    
-    return Layout.Horizontal().Gap(4).Padding(4)
-      | leftForm
-      | rightPreview;
-  }
-  
-  private string LoadEmbedded(string name)
-  {
-    try
-    {
-      using var s = typeof(QuestPdfApp).Assembly.GetManifestResourceStream("QuestPdfExample." + name);
-      if (s == null) return string.Empty;
-      using var sr = new StreamReader(s);
-      return sr.ReadToEnd();
-    }
-    catch { return string.Empty; }
-  }
 }

--- a/packages-demos/questpdf/GlobalUsings.cs
+++ b/packages-demos/questpdf/GlobalUsings.cs
@@ -1,12 +1,4 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/questpdf/Helpers/MarkdownHelper.cs
+++ b/packages-demos/questpdf/Helpers/MarkdownHelper.cs
@@ -7,55 +7,55 @@ public static class MarkdownHelper
         var trimmed = line.TrimStart();
         return trimmed.StartsWith("#") && !trimmed.StartsWith("###");
     }
-    
+
     public static bool IsHeading2(string line)
     {
         var trimmed = line.TrimStart();
         return trimmed.StartsWith("##") && !trimmed.StartsWith("###");
     }
-    
+
     public static bool IsHeading3(string line)
     {
         var trimmed = line.TrimStart();
         return trimmed.StartsWith("###");
     }
-    
+
     public static bool IsCodeBlock(string line)
     {
         return line.Trim().StartsWith("```");
     }
-    
+
     public static bool IsTableRow(string line)
     {
         return line.TrimStart().StartsWith("|") && line.Contains('|');
     }
-    
+
     public static bool IsBulletList(string line)
     {
         var trimmed = line.TrimStart();
         return trimmed.StartsWith("- ") && !IsCheckbox(line);
     }
-    
+
     public static bool IsNumberedList(string line)
     {
         var trimmed = line.TrimStart();
-        return (trimmed.StartsWith("1. ") || 
-                trimmed.StartsWith("I. ") || 
+        return (trimmed.StartsWith("1. ") ||
+                trimmed.StartsWith("I. ") ||
                 trimmed.StartsWith("a. ")) && !IsCheckbox(line);
     }
-    
+
     public static bool IsQuote(string line)
     {
         var trimmed = line.TrimStart();
         return trimmed.StartsWith(">");
     }
-    
+
     public static bool IsCheckbox(string line)
     {
         var trimmed = line.TrimStart();
         return trimmed.StartsWith("- [") && trimmed.Contains("]");
     }
-    
+
     public static int CountIndent(string line)
     {
         int total = 0;
@@ -68,7 +68,7 @@ public static class MarkdownHelper
         }
         return total;
     }
-    
+
     public static bool IsSepCell(string cell)
     {
         cell = cell.Trim();
@@ -77,16 +77,16 @@ public static class MarkdownHelper
             if (ch != '-' && ch != ':' && ch != ' ') return false;
         return true;
     }
-    
+
     public static (string text, bool isBold, bool isItalic, bool isLink) ParseInlineFormatting(string text)
     {
         bool isBold = text.Contains("**") && text.IndexOf("**") != text.LastIndexOf("**");
         bool isItalic = text.Contains("*") && !text.Contains("**");
         bool isLink = text.Contains("[") && text.Contains("]") && text.Contains("(") && text.Contains(")");
-        
+
         return (text, isBold, isItalic, isLink);
     }
-    
+
     public static string ExtractLinkText(string text)
     {
         var start = text.IndexOf('[');
@@ -95,7 +95,7 @@ public static class MarkdownHelper
             return text.Substring(start + 1, end - start - 1);
         return text;
     }
-    
+
     public static string ExtractLinkUrl(string text)
     {
         var start = text.IndexOf('(');

--- a/packages-demos/questpdf/Models/PdfSettings.cs
+++ b/packages-demos/questpdf/Models/PdfSettings.cs
@@ -5,18 +5,18 @@ public class PdfSettings
     public string PageSize { get; set; } = "A4";
     public bool Landscape { get; set; } = false;
     public int Margins { get; set; } = 30;
-    
+
     public QuestPDF.Helpers.PageSize GetPageSize()
     {
-        var size = PageSize == "Letter" 
-            ? QuestPDF.Helpers.PageSizes.Letter 
+        var size = PageSize == "Letter"
+            ? QuestPDF.Helpers.PageSizes.Letter
             : QuestPDF.Helpers.PageSizes.A4;
-            
+
         if (Landscape)
         {
             size = new QuestPDF.Helpers.PageSize(size.Height, size.Width);
         }
-        
+
         return size;
     }
 }

--- a/packages-demos/questpdf/Program.cs
+++ b/packages-demos/questpdf/Program.cs
@@ -10,7 +10,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fquestpdf%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fquestpdf%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<QuestPdfApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/questpdf/Services/MarkdownParsingService.cs
+++ b/packages-demos/questpdf/Services/MarkdownParsingService.cs
@@ -6,19 +6,19 @@ public class MarkdownParsingService
     {
         var elements = new List<MarkdownElement>();
         var lines = text.Replace("\r\n", "\n").Split('\n');
-        
+
         for (int i = 0; i < lines.Length; i++)
         {
             var line = lines[i];
-            
+
             if (MarkdownHelper.IsHeading(line))
             {
-                var level = MarkdownHelper.IsHeading3(line) ? 3 : 
+                var level = MarkdownHelper.IsHeading3(line) ? 3 :
                            MarkdownHelper.IsHeading2(line) ? 2 : 1;
                 var content = line.TrimStart('#', ' ').Trim();
-                elements.Add(new HeadingElement 
-                { 
-                    Level = level, 
+                elements.Add(new HeadingElement
+                {
+                    Level = level,
                     Content = content,
                     IndentLevel = MarkdownHelper.CountIndent(line)
                 });
@@ -71,10 +71,10 @@ public class MarkdownParsingService
                 elements.Add(new ParagraphElement { Content = line });
             }
         }
-        
+
         return elements;
     }
-    
+
     public void RenderToQuestPdf(IContainer container, MarkdownElement element)
     {
         switch (element)
@@ -105,7 +105,7 @@ public class MarkdownParsingService
                 break;
         }
     }
-    
+
     private void RenderHeading(IContainer container, HeadingElement heading)
     {
         container.Text(t =>
@@ -117,18 +117,18 @@ public class MarkdownParsingService
                 3 => 14,
                 _ => 12
             };
-            
+
             t.Span(heading.Content)
              .FontSize(fontSize)
              .SemiBold();
         });
     }
-    
+
     private void RenderParagraph(IContainer container, ParagraphElement paragraph)
     {
         container.Text(t => RenderInline(t, paragraph.Content));
     }
-    
+
     private void RenderBulletList(IContainer container, BulletListElement list)
     {
         container.Column(c =>
@@ -139,17 +139,17 @@ public class MarkdownParsingService
             }
         });
     }
-    
+
     private void RenderNumberedList(IContainer container, NumberedListElement list)
     {
         container.Column(c =>
         {
             for (int i = 0; i < list.Items.Count; i++)
             {
-                var number = list.NumberingType == "I." ? 
-                    RomanNumerals(i + 1) : 
+                var number = list.NumberingType == "I." ?
+                    RomanNumerals(i + 1) :
                     (i + 1).ToString();
-                    
+
                 c.Item().PaddingLeft(8).Text(t =>
                 {
                     t.Span($"{number}. ").SemiBold();
@@ -158,7 +158,7 @@ public class MarkdownParsingService
             }
         });
     }
-    
+
     private void RenderQuote(IContainer container, QuoteElement quote)
     {
         container.PaddingLeft(16).Text(t =>
@@ -170,7 +170,7 @@ public class MarkdownParsingService
             }
         });
     }
-    
+
     private void RenderCodeBlock(IContainer container, CodeBlockElement code)
     {
         container.PaddingLeft(8).Text(t =>
@@ -182,23 +182,23 @@ public class MarkdownParsingService
             }
         });
     }
-    
+
     private void RenderTable(IContainer container, TableElement table)
     {
         container.Table(t =>
         {
-            t.ColumnsDefinition(c => 
+            t.ColumnsDefinition(c =>
             {
                 for (int i = 0; i < table.Headers.Length; i++)
                     c.RelativeColumn();
             });
-            
+
             t.Header(h =>
             {
                 foreach (var header in table.Headers)
                     h.Cell().Text(header).SemiBold();
             });
-            
+
             for (int ri = table.DataStartRow; ri < table.Rows.Count; ri++)
             {
                 var row = table.Rows[ri];
@@ -210,7 +210,7 @@ public class MarkdownParsingService
             }
         });
     }
-    
+
     private void RenderCheckbox(IContainer container, CheckboxElement checkbox)
     {
         container.PaddingLeft(8).Text(t =>
@@ -220,13 +220,13 @@ public class MarkdownParsingService
             RenderInline(t, checkbox.Text);
         });
     }
-    
+
     private void RenderInline(TextDescriptor t, string text)
     {
         // Simple inline formatting
         var parts = text.Split(new[] { "**", "*", "[", "]" }, StringSplitOptions.None);
         bool isBold = false, isItalic = false, isLink = false;
-        
+
         foreach (var part in parts)
         {
             if (part == "**")
@@ -239,19 +239,19 @@ public class MarkdownParsingService
                 isItalic = !isItalic;
                 continue;
             }
-            
+
             var span = t.Span(part);
             if (isBold) span.SemiBold();
             if (isItalic) span.Italic();
             if (isLink) span.Underline();
         }
     }
-    
+
     private TableElement? ParseTable(string[] lines, int startIndex, out int consumed)
     {
         var rows = new List<string[]>();
         var k = startIndex;
-        
+
         while (k < lines.Length && MarkdownHelper.IsTableRow(lines[k]))
         {
             var cells = lines[k].Trim();
@@ -261,15 +261,15 @@ public class MarkdownParsingService
             rows.Add(parts);
             k++;
         }
-        
+
         consumed = k - startIndex;
         if (rows.Count == 0) return null;
-        
+
         var headers = rows[0];
         int dataStart = 1;
         if (rows.Count > 1 && rows[1].All(MarkdownHelper.IsSepCell))
             dataStart = 2;
-            
+
         return new TableElement
         {
             Headers = headers,
@@ -277,29 +277,29 @@ public class MarkdownParsingService
             DataStartRow = dataStart
         };
     }
-    
+
     private BulletListElement ParseBulletList(string[] lines, int startIndex, out int consumed)
     {
         var items = new List<string>();
         var k = startIndex;
-        
+
         while (k < lines.Length && MarkdownHelper.IsBulletList(lines[k]))
         {
             var line = lines[k].TrimStart('-', ' ').Trim();
             items.Add(line);
             k++;
         }
-        
+
         consumed = k - startIndex;
         return new BulletListElement { Items = items };
     }
-    
+
     private NumberedListElement ParseNumberedList(string[] lines, int startIndex, out int consumed)
     {
         var items = new List<string>();
         var k = startIndex;
         string numberingType = "1.";
-        
+
         while (k < lines.Length && MarkdownHelper.IsNumberedList(lines[k]))
         {
             var line = lines[k].TrimStart();
@@ -308,51 +308,59 @@ public class MarkdownParsingService
                 if (line.StartsWith("I.")) numberingType = "I.";
                 else if (line.StartsWith("a.")) numberingType = "a.";
             }
-            
+
             var content = line.Substring(line.IndexOf(' ') + 1);
             items.Add(content);
             k++;
         }
-        
+
         consumed = k - startIndex;
         return new NumberedListElement { Items = items, NumberingType = numberingType };
     }
-    
+
     private QuoteElement ParseQuote(string[] lines, int startIndex, out int consumed)
     {
         var quoteLines = new List<string>();
         var k = startIndex;
-        
+
         while (k < lines.Length && MarkdownHelper.IsQuote(lines[k]))
         {
             var line = lines[k].TrimStart('>', ' ').Trim();
             quoteLines.Add(line);
             k++;
         }
-        
+
         consumed = k - startIndex;
         return new QuoteElement { Lines = quoteLines };
     }
-    
+
     private CheckboxElement ParseCheckbox(string line)
     {
         var trimmed = line.TrimStart('-', ' ').Trim();
         var isChecked = trimmed.StartsWith("[x]") || trimmed.StartsWith("[X]");
         var text = trimmed.Substring(3).Trim();
-        
+
         return new CheckboxElement
         {
             IsChecked = isChecked,
             Text = text
         };
     }
-    
+
     private static string RomanNumerals(int number)
     {
         return number switch
         {
-            1 => "I", 2 => "II", 3 => "III", 4 => "IV", 5 => "V",
-            6 => "VI", 7 => "VII", 8 => "VIII", 9 => "IX", 10 => "X",
+            1 => "I",
+            2 => "II",
+            3 => "III",
+            4 => "IV",
+            5 => "V",
+            6 => "VI",
+            7 => "VII",
+            8 => "VIII",
+            9 => "IX",
+            10 => "X",
             _ => number.ToString()
         };
     }

--- a/packages-demos/questpdf/Services/PdfGenerationService.cs
+++ b/packages-demos/questpdf/Services/PdfGenerationService.cs
@@ -2,11 +2,11 @@ namespace QuestPdfExample.Services;
 
 public class PdfGenerationService
 {
-    
+
     public byte[] GeneratePdf(string title, string markdown, PdfSettings settings)
     {
         using var ms = new MemoryStream();
-        
+
         Document.Create(container =>
         {
             container.Page(page =>
@@ -17,17 +17,17 @@ public class PdfGenerationService
                 AddFooter(page);
             });
         }).GeneratePdf(ms);
-        
+
         return ms.ToArray();
     }
-    
+
     private void ConfigurePage(PageDescriptor page, PdfSettings settings)
     {
         page.Size(settings.GetPageSize());
         page.Margin(settings.Margins);
         page.DefaultTextStyle(t => t.FontSize(12));
     }
-    
+
     private void AddHeader(PageDescriptor page)
     {
         page.Header()
@@ -35,16 +35,16 @@ public class PdfGenerationService
             .SemiBold()
             .FontSize(14);
     }
-    
+
     private void AddContent(PageDescriptor page, string title, string markdown)
     {
         page.Content().Column(col =>
         {
             col.Spacing(10);
-            
+
             // Title
             col.Item().Text(title).FontSize(20).SemiBold();
-            
+
             // Render Markdown content directly (temporary fix)
             col.Item().Column(md =>
             {
@@ -149,7 +149,7 @@ public class PdfGenerationService
                         var checkboxText = trimmed.Substring(5).Trim();
                         md.Item().PaddingVertical(2).PaddingLeft(basePadding).Row(row =>
                         {
-                            row.ConstantItem(14).Element(c => 
+                            row.ConstantItem(14).Element(c =>
                                 c.Border(1).Width(14).Height(14).MinWidth(14).MaxWidth(14).AlignCenter().Text(t => t.Span("✓").FontSize(10))
                             );
                             row.RelativeItem().PaddingLeft(4).Text(t => RenderInline(t, checkboxText));
@@ -160,7 +160,7 @@ public class PdfGenerationService
                         var checkboxText = trimmed.Substring(5).Trim();
                         md.Item().PaddingVertical(2).PaddingLeft(basePadding).Row(row =>
                         {
-                            row.ConstantItem(14).Element(c => 
+                            row.ConstantItem(14).Element(c =>
                                 c.Border(1).Width(14).Height(14).MinWidth(14).MaxWidth(14)
                             );
                             row.RelativeItem().PaddingLeft(4).Text(t => RenderInline(t, checkboxText));
@@ -171,7 +171,7 @@ public class PdfGenerationService
                         var checkboxText = trimmed.Substring(3).Trim();
                         md.Item().PaddingVertical(2).Row(row =>
                         {
-                            row.ConstantItem(14).Element(c => 
+                            row.ConstantItem(14).Element(c =>
                                 c.Border(1).Width(14).Height(14).MinWidth(14).MaxWidth(14).AlignCenter().Text(t => t.Span("✓").FontSize(10))
                             );
                             row.RelativeItem().PaddingLeft(4).Text(t => RenderInline(t, checkboxText));
@@ -182,7 +182,7 @@ public class PdfGenerationService
                         var checkboxText = trimmed.Substring(3).Trim();
                         md.Item().PaddingVertical(2).Row(row =>
                         {
-                            row.ConstantItem(14).Element(c => 
+                            row.ConstantItem(14).Element(c =>
                                 c.Border(1).Width(14).Height(14).MinWidth(14).MaxWidth(14)
                             );
                             row.RelativeItem().PaddingLeft(4).Text(t => RenderInline(t, checkboxText));
@@ -233,19 +233,19 @@ public class PdfGenerationService
                 {
                     var trimmed = line.TrimStart();
                     if (trimmed.Length < 3) return false;
-                    
+
                     // Must start with digit/letter followed by dot and space
                     if (char.IsDigit(trimmed[0]) && trimmed[1] == '.' && trimmed[2] == ' ')
                         return true;
-                    
+
                     // Roman numerals (I., II., III., etc.)
                     if (IsRomanNumeral(trimmed) && trimmed.Contains(". ") && trimmed.IndexOf(". ") == 1)
                         return true;
-                    
+
                     // Letter sequences (a., b., c., etc.)
                     if (char.IsLetter(trimmed[0]) && trimmed[1] == '.' && trimmed[2] == ' ')
                         return true;
-                    
+
                     return false;
                 }
 
@@ -275,27 +275,27 @@ public class PdfGenerationService
                 {
                     var dotIndex = line.IndexOf('.');
                     if (dotIndex < 0) return "1";
-                    
+
                     var numberPart = line.Substring(0, dotIndex).Trim();
-                    
+
                     // Arabic numerals (1, 2, 3, ...)
                     if (int.TryParse(numberPart, out int arabic))
                     {
                         return arabic.ToString();
                     }
-                    
+
                     // Roman numerals (I, II, III, IV, V, ...)
                     if (IsRomanNumeral(line))
                     {
                         return numberPart;
                     }
-                    
+
                     // Letter sequences (a, b, c, ... or A, B, C, ...)
                     if (IsLetterSequence(line))
                     {
                         return numberPart;
                     }
-                    
+
                     return "1";
                 }
 
@@ -359,7 +359,7 @@ public class PdfGenerationService
             });
         });
     }
-    
+
     private void AddFooter(PageDescriptor page)
     {
         page.Footer().AlignRight().Text(t =>

--- a/packages-demos/questpdf/questpdf.sln
+++ b/packages-demos/questpdf/questpdf.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QuestPdfExample", "QuestPdfExample.csproj", "{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|x64.Build.0 = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Debug|x86.Build.0 = Debug|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|x64.ActiveCfg = Release|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|x64.Build.0 = Release|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|x86.ActiveCfg = Release|Any CPU
+		{7673F114-DFE7-4E6A-8B8E-FC71E910EB78}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/scriban/Apps/ScribanApp.cs
+++ b/packages-demos/scriban/Apps/ScribanApp.cs
@@ -5,7 +5,7 @@ public class ScribanApp : ViewBase
 {
     private const string DefaultModel = "{\n  \"name\": \"Bob Smith\",\n  \"address\": \"1 Smith St, Smithville\",\n  \"orderId\": \"123455\",\n  \"total\": 23435.34,\n  \"items\": [\n    {\n      \"name\": \"1kg carrots\",\n      \"quantity\": 1,\n      \"total\": 4.99\n    },\n    {\n      \"name\": \"2L Milk\",\n      \"quantity\": 1,\n      \"total\": 3.5\n    }\n  ]\n}";
 
-	private const string DefaultTemplate = """
+    private const string DefaultTemplate = """
 	Dear {{ model.name }},
 
 	Your order, {{ model.orderId }}, is now ready to be collected.
@@ -26,10 +26,10 @@ public class ScribanApp : ViewBase
 
     public override object? Build()
     {
-		var state = UseState(() => new DemoState());
-		var modelState = this.UseState(state.Value.ModelJson);
-		var templateState = this.UseState(state.Value.TemplateText);
-		var outputState = this.UseState(state.Value.OutputText);
+        var state = UseState(() => new DemoState());
+        var modelState = this.UseState(state.Value.ModelJson);
+        var templateState = this.UseState(state.Value.TemplateText);
+        var outputState = this.UseState(state.Value.OutputText);
 
         string GenerateOutput(string modelJson, string templateText, out string errorMsg)
         {
@@ -53,10 +53,10 @@ public class ScribanApp : ViewBase
                 return "";
             }
 
-			var context = new global::Scriban.TemplateContext();
-			var globals = new global::Scriban.Runtime.ScriptObject();
-			globals.Add("model", model);
-			global::Scriban.Runtime.ScriptObjectExtensions.Import(globals, typeof(global::Scriban.Functions.MathFunctions));
+            var context = new global::Scriban.TemplateContext();
+            var globals = new global::Scriban.Runtime.ScriptObject();
+            globals.Add("model", model);
+            global::Scriban.Runtime.ScriptObjectExtensions.Import(globals, typeof(global::Scriban.Functions.MathFunctions));
             context.PushGlobal(globals);
 
             try
@@ -71,27 +71,27 @@ public class ScribanApp : ViewBase
             }
         }
 
-		var modelEditor = modelState.ToCodeInput().Language(Languages.Json).Height(Size.Fit());
-		var templateEditor = templateState.ToCodeInput().Language(Languages.Markdown).Height(Size.Fit());
-		var outputViewer = string.IsNullOrEmpty(outputState.Value)
-			? outputState.ToTextareaInput("Output will appear here after generation...").Disabled().Height(Size.Units(50))
-			: outputState.ToTextareaInput().Height(Size.Units(50));
-		
+        var modelEditor = modelState.ToCodeInput().Language(Languages.Json).Height(Size.Fit());
+        var templateEditor = templateState.ToCodeInput().Language(Languages.Markdown).Height(Size.Fit());
+        var outputViewer = string.IsNullOrEmpty(outputState.Value)
+            ? outputState.ToTextareaInput("Output will appear here after generation...").Disabled().Height(Size.Units(50))
+            : outputState.ToTextareaInput().Height(Size.Units(50));
+
 
         var generateBtn = new Button("Generate")
             .Primary()
             .OnClick(_ =>
             {
-				string error;
-				var output = GenerateOutput(modelState.Value, templateState.Value, out error);
-				state.Set(state.Value with { OutputText = output, Error = error });
-				outputState.Set(output);
+                string error;
+                var output = GenerateOutput(modelState.Value, templateState.Value, out error);
+                state.Set(state.Value with { OutputText = output, Error = error });
+                outputState.Set(output);
             });
 
-		// Header section with title and description
-		var headerSection = Layout.Vertical()
-			| Text.H2("Scriban Template Engine")
-			| Text.Muted("Scriban is a powerful, fast, and secure templating engine for .NET. Use this tool to create templates with JSON model support. Enter a model in JSON format and a Scriban template to generate the output.");
+        // Header section with title and description
+        var headerSection = Layout.Vertical()
+            | Text.H2("Scriban Template Engine")
+            | Text.Muted("Scriban is a powerful, fast, and secure templating engine for .NET. Use this tool to create templates with JSON model support. Enter a model in JSON format and a Scriban template to generate the output.");
 
         // Left card - Model input, Template input and Generate button
         var leftCardContent = Layout.Vertical()
@@ -102,9 +102,9 @@ public class ScribanApp : ViewBase
             | Text.Block("This demo uses Scriban to generate the output.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [Scriban](https://github.com/scriban/scriban)")
         ;
-			
 
-		var leftCard = new Card(leftCardContent).Width(Size.Fraction(0.45f));
+
+        var leftCard = new Card(leftCardContent).Width(Size.Fraction(0.45f));
 
         // Right card - Output (markdown/text)
         var rightCardContent = Layout.Vertical()
@@ -114,17 +114,17 @@ public class ScribanApp : ViewBase
             | Text.H4("Output")
             | outputViewer;
 
-		var rightCard = new Card(rightCardContent).Width(Size.Fraction(0.55f));
+        var rightCard = new Card(rightCardContent).Width(Size.Fraction(0.55f));
 
-		// Two horizontal cards
-		var cardsRow = Layout.Horizontal().Gap(6).Padding(3)
-			| leftCard
-			| rightCard;
+        // Two horizontal cards
+        var cardsRow = Layout.Horizontal().Gap(6).Padding(3)
+            | leftCard
+            | rightCard;
 
-		return Layout.Vertical()
-			.Gap(3)
-			| headerSection
-			| cardsRow;
+        return Layout.Vertical()
+            .Gap(3)
+            | headerSection
+            | cardsRow;
     }
 
     private static object ToScriptValue(System.Text.Json.JsonElement element)

--- a/packages-demos/scriban/GlobalUsings.cs
+++ b/packages-demos/scriban/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/scriban/Program.cs
+++ b/packages-demos/scriban/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fscriban%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fscriban%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ScribanApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/scriban/scriban.sln
+++ b/packages-demos/scriban/scriban.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScribanExample", "ScribanExample.csproj", "{547D50BB-9266-4F25-A383-C2221BF29773}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|x64.Build.0 = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Debug|x86.Build.0 = Debug|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|Any CPU.Build.0 = Release|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|x64.ActiveCfg = Release|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|x64.Build.0 = Release|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|x86.ActiveCfg = Release|Any CPU
+		{547D50BB-9266-4F25-A383-C2221BF29773}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/sharpyaml/Apps/SharpYamlApp.cs
+++ b/packages-demos/sharpyaml/Apps/SharpYamlApp.cs
@@ -100,8 +100,8 @@ public class SharpYamlApp : ViewBase
             .Gap(1)
             | Text.Block("This demo uses SharpYaml library for converting JSON to YAML.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [SharpYaml](https://github.com/xoofx/SharpYaml)")
-            ;       
-        
+            ;
+
         var convertBtn = new Button("Convert")
             .Primary()
             .OnClick(_ =>

--- a/packages-demos/sharpyaml/GlobalUsings.cs
+++ b/packages-demos/sharpyaml/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/sharpyaml/Program.cs
+++ b/packages-demos/sharpyaml/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsharpyaml%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsharpyaml%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SharpYamlApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/sharpyaml/sharpyaml.sln
+++ b/packages-demos/sharpyaml/sharpyaml.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpYamlExample", "SharpYamlExample.csproj", "{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|x64.Build.0 = Release|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A2BF5E7-6764-4B43-B3CC-96F5DF780A37}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/shopifysharp/GlobalUsings.cs
+++ b/packages-demos/shopifysharp/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using ShopifySharp;

--- a/packages-demos/shopifysharp/Program.cs
+++ b/packages-demos/shopifysharp/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fshopifysharp%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fshopifysharp%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<ShopifySharpApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/shopifysharp/shopifysharp.sln
+++ b/packages-demos/shopifysharp/shopifysharp.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShopifySharpExample", "ShopifySharpExample.csproj", "{4AB5CDA3-ED54-4C41-93FB-94120B83E197}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|x64.Build.0 = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Debug|x86.Build.0 = Debug|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|x64.ActiveCfg = Release|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|x64.Build.0 = Release|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|x86.ActiveCfg = Release|Any CPU
+		{4AB5CDA3-ED54-4C41-93FB-94120B83E197}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/smartformat-net/GlobalUsings.cs
+++ b/packages-demos/smartformat-net/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using SmartFormat;

--- a/packages-demos/smartformat-net/Program.cs
+++ b/packages-demos/smartformat-net/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsmartformat-net%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fsmartformat-net%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<SmartFormatNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/smartformat-net/smartformat-net.sln
+++ b/packages-demos/smartformat-net/smartformat-net.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartFormatNetExample", "SmartFormatNetExample.csproj", "{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|x64.Build.0 = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Debug|x86.Build.0 = Debug|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|x64.ActiveCfg = Release|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|x64.Build.0 = Release|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|x86.ActiveCfg = Release|Any CPU
+		{F2C3639D-DC1C-4623-A00A-6D379F6EBB9A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/stripe-net/Apps/StripeNetApp.cs
+++ b/packages-demos/stripe-net/Apps/StripeNetApp.cs
@@ -20,7 +20,7 @@
             var checkoutUrl = UseState(string.Empty);
             var isCreatingCheckout = UseState(false);
 
-            
+
             var apiKey = configuration["Stripe:SecretKey"]
                 ?? throw new InvalidOperationException("Stripe secret key is not configured.");
             var baseUrl = "http://localhost:5010/stripe-net-example";
@@ -54,8 +54,8 @@
                 {
                     var session = CreateCheckoutSession(productName.Value, currency.Value, amount.Value, quantity.Value, apiKey, baseUrl);
                     checkoutUrl.Value = session.Url ?? string.Empty;
-                    client.Toast(string.IsNullOrEmpty(checkoutUrl.Value) 
-                        ? "Stripe did not return a checkout URL." 
+                    client.Toast(string.IsNullOrEmpty(checkoutUrl.Value)
+                        ? "Stripe did not return a checkout URL."
                         : "Checkout session created. Complete it below.", "Stripe");
                 }
                 catch (Exception ex)
@@ -66,7 +66,7 @@
                 {
                     isCreatingCheckout.Value = false;
                 }
-            } 
+            }
 
             if (!string.IsNullOrEmpty(checkoutUrl.Value))
             {

--- a/packages-demos/stripe-net/GlobalUsings.cs
+++ b/packages-demos/stripe-net/GlobalUsings.cs
@@ -1,19 +1,12 @@
 global using Ivy;
 global using Microsoft.AspNetCore.Http;
-global using Microsoft.AspNetCore.Mvc.TagHelpers;
 global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System;
 global using System.Collections.Generic;
-global using System.Collections.Specialized;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using Stripe;
 global using Stripe.Checkout;
 global using System.Linq;
-global using System.Web;
 
 namespace StripeNetExample;

--- a/packages-demos/stripe-net/Program.cs
+++ b/packages-demos/stripe-net/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fstripe-net%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fstripe-net%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<StripeNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/stripe-net/stripe-net.sln
+++ b/packages-demos/stripe-net/stripe-net.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StripeNetExample", "StripeNetExample.csproj", "{C69922A6-32E4-4369-9249-F654236D3AE1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|x64.Build.0 = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Debug|x86.Build.0 = Debug|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|x64.ActiveCfg = Release|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|x64.Build.0 = Release|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|x86.ActiveCfg = Release|Any CPU
+		{C69922A6-32E4-4369-9249-F654236D3AE1}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/timezonenames/Apps/TImeZoneConverterApp.cs
+++ b/packages-demos/timezonenames/Apps/TImeZoneConverterApp.cs
@@ -82,7 +82,7 @@ public class TimeZoneConverterApp : ViewBase
                 var windowsZone = TZConvert.IanaToWindows(zone);
                 windowsZoneState.Set(windowsZone);
                 windowsSearchTerm.Set(windowsZone);
-                
+
                 var railsZones = TZConvert.IanaToRails(zone);
                 if (railsZones.Any())
                 {
@@ -102,7 +102,7 @@ public class TimeZoneConverterApp : ViewBase
                 var ianaZone = TZConvert.WindowsToIana(zone);
                 ianaZoneState.Set(ianaZone);
                 ianaSearchTerm.Set(ianaZone);
-                
+
                 var railsZones = TZConvert.WindowsToRails(zone);
                 if (railsZones.Any())
                 {
@@ -122,7 +122,7 @@ public class TimeZoneConverterApp : ViewBase
                 var ianaZone = TZConvert.RailsToIana(zone);
                 ianaZoneState.Set(ianaZone);
                 ianaSearchTerm.Set(ianaZone);
-                
+
                 var windowsZone = TZConvert.RailsToWindows(zone);
                 windowsZoneState.Set(windowsZone);
                 windowsSearchTerm.Set(windowsZone);
@@ -142,21 +142,21 @@ public class TimeZoneConverterApp : ViewBase
                         .WithField()
                         .Label("Search IANA Time Zones")
                     | Layout.Vertical(new List(ianaListItems.ToArray())).Height(Size.Units(70)),
-                
+
                 "Windows" => Layout.Vertical().Gap(4)
                     | windowsSearchTerm.ToTextInput(windowsZoneState.Value)
                         .Variant(TextInputVariant.Search)
                         .WithField()
                         .Label("Search Windows Time Zones")
                     | Layout.Vertical(new List(windowsListItems.ToArray())).Height(Size.Units(70)),
-                
+
                 "Rails" => Layout.Vertical().Gap(4)
                     | railsSearchTerm.ToTextInput(railsZoneState.Value)
                         .Variant(TextInputVariant.Search)
                         .WithField()
                         .Label("Search Rails Time Zones")
                     | Layout.Vertical(new List(railsListItems.ToArray())).Height(Size.Units(70)),
-                
+
                 _ => Layout.Vertical().Gap(4)
                     | Text.Muted("Select a time zone type")
             };
@@ -199,7 +199,7 @@ public class TimeZoneConverterApp : ViewBase
                 | resultCard)
             | Text.Block("This demo uses TimeZoneNames library to convert between IANA, Windows, and Rails time zone formats.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [TimeZoneNames](https://github.com/mattjohnsonpint/TimeZoneNames)")
-        
+
         ;
     }
 }

--- a/packages-demos/timezonenames/GlobalUsings.cs
+++ b/packages-demos/timezonenames/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/packages-demos/timezonenames/Program.cs
+++ b/packages-demos/timezonenames/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ftimezonenames%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Ftimezonenames%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<TimeZoneConverterApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/timezonenames/timezonenames.sln
+++ b/packages-demos/timezonenames/timezonenames.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TimeZoneConverterExample", "TimeZoneConverterExample.csproj", "{E79C9DBA-2717-422B-BE8A-792DE0249807}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|x64.Build.0 = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Debug|x86.Build.0 = Debug|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|x64.ActiveCfg = Release|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|x64.Build.0 = Release|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|x86.ActiveCfg = Release|Any CPU
+		{E79C9DBA-2717-422B-BE8A-792DE0249807}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/packages-demos/unitsnet/Apps/UnitsNetApp.cs
+++ b/packages-demos/unitsnet/Apps/UnitsNetApp.cs
@@ -39,7 +39,7 @@ public class UnitsNetApp : ViewBase
             Layout.Vertical().Gap(1)
             | Text.Block("This demo uses UnitsNet library to convert between different units of measurement.")
             | Text.Markdown("Built with [Ivy Framework](https://github.com/Ivy-Interactive/Ivy-Framework) and [UnitsNet](https://github.com/angularsen/UnitsNet)")
-                
+
         );
 
         // Get filtered quantity list items
@@ -49,7 +49,7 @@ public class UnitsNetApp : ViewBase
             : allQuantities
                 .Where(q => q.Name.Contains(quantitySearchTerm.Value, StringComparison.OrdinalIgnoreCase))
                 .ToArray();
-        
+
         var quantityListItems = filteredQuantities
             .Select(q => new ListItem(
                 title: q.Name,
@@ -57,7 +57,7 @@ public class UnitsNetApp : ViewBase
                 onClick: () => quantity.Set(q.Name)
             ))
             .ToArray();
-        
+
         // Quantity Selection Card
         var quantityCard = new Card(
             Layout.Vertical().Gap(2)
@@ -73,7 +73,7 @@ public class UnitsNetApp : ViewBase
         // Get unit list items
         var qInfo = Quantity.Infos.FirstOrDefault(q => q.Name.Equals(quantity.Value, StringComparison.OrdinalIgnoreCase))
                    ?? Quantity.Infos.First();
-        
+
         var fromUnitListItems = qInfo.UnitInfos
             .OrderBy(u => u.Name)
             .Select(u => new ListItem(
@@ -82,7 +82,7 @@ public class UnitsNetApp : ViewBase
                 onClick: () => fromUnit.Set(u.Name)
             ))
             .ToArray();
-        
+
         var toUnitListItems = qInfo.UnitInfos
             .OrderBy(u => u.Name)
             .Select(u => new ListItem(
@@ -104,7 +104,7 @@ public class UnitsNetApp : ViewBase
             | valueText.ToInput(placeholder: "e.g. 25")
             | (Layout.Vertical().Gap(2).Height(Size.Fit().Max(Size.Units(30)))
             | new List(fromUnitListItems))
-            
+
         );
 
         // To Unit Card
@@ -120,7 +120,7 @@ public class UnitsNetApp : ViewBase
                 : Text.Code("Select both units to see the result"))
             | (Layout.Vertical().Gap(2).Height(Size.Fit().Max(Size.Units(30)))
             | new List(toUnitListItems))
-            
+
         );
 
         // Horizontal layout for unit cards
@@ -132,13 +132,13 @@ public class UnitsNetApp : ViewBase
         // Input Card
         var inputCard = new Card(
             Layout.Vertical().Gap(3)
-            
+
         ).Title("Input");
 
         // Result Card
         var resultCard = new Card(
             Layout.Vertical().Gap(3)
-            
+
         ).Title("Result");
 
         // Conversion Cards Row

--- a/packages-demos/unitsnet/GlobalUsings.cs
+++ b/packages-demos/unitsnet/GlobalUsings.cs
@@ -1,9 +1,4 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using UnitsNet;

--- a/packages-demos/unitsnet/Program.cs
+++ b/packages-demos/unitsnet/Program.cs
@@ -8,7 +8,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Funitsnet%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Funitsnet%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<UnitsNetApp>()
     .UseTabs(preventDuplicates: true)

--- a/packages-demos/unitsnet/unitsnet.sln
+++ b/packages-demos/unitsnet/unitsnet.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitsNetExample", "UnitsNetExample.csproj", "{0D4E0480-D438-442A-85FE-7B4E627BDEF6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Debug|x86.Build.0 = Debug|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|x64.Build.0 = Release|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D4E0480-D438-442A-85FE-7B4E627BDEF6}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/QueryParamIdApp/QueryParamIdApp.sln
+++ b/project-demos/QueryParamIdApp/QueryParamIdApp.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueryParamIdApp", "QueryParamIdApp.csproj", "{00C18715-A93D-415D-ABA1-85C128652258}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|x64.Build.0 = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Debug|x86.Build.0 = Debug|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|x64.ActiveCfg = Release|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|x64.Build.0 = Release|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|x86.ActiveCfg = Release|Any CPU
+		{00C18715-A93D-415D-ABA1-85C128652258}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/auth-github-test/Apps/TestAuthApp.cs
+++ b/project-demos/auth-github-test/Apps/TestAuthApp.cs
@@ -1,7 +1,6 @@
 namespace Auth.GitHub.Test.Apps;
 
 using System.Text.Json;
-using Microsoft.Extensions.Http;
 
 public record GitHubRepo(
     string Name,
@@ -19,15 +18,15 @@ public class TestAuthApp : ViewBase
     {
         var auth = this.UseService<IAuthService>();
         var httpClientFactory = this.UseService<IHttpClientFactory>();
-        
+
         var userInfo = this.UseState<UserInfo?>();
         var repositories = this.UseState<List<GitHubRepo>?>();
         var loading = this.UseState<bool>(true);
-        
+
         var client = this.UseService<IClientProvider>();
         var isSheetOpen = this.UseState<bool>(false);
         var searchText = this.UseState<string>("");
-        
+
         this.UseEffect(async () =>
         {
             try
@@ -119,11 +118,11 @@ public class TestAuthApp : ViewBase
                 Updated = updatedText,
             }.ToDetails()
                 .RemoveEmpty();
-            
+
             var content = Layout.Vertical().AlignContent(Align.Center)
                 | Text.Block(repo.Name).Italic().Bold()
                 | details;
-            
+
             return new Card(content)
                 .OnClick(_ => client.OpenUrl(repo.HtmlUrl));
         });

--- a/project-demos/auth-github-test/GlobalUsings.cs
+++ b/project-demos/auth-github-test/GlobalUsings.cs
@@ -1,15 +1,6 @@
 global using Ivy;
-global using Ivy.Auth;
 global using Ivy.Auth.GitHub;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/project-demos/auth-github-test/auth-github-test.sln
+++ b/project-demos/auth-github-test/auth-github-test.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auth.GitHub.Test", "Auth.GitHub.Test.csproj", "{310CB963-4D29-4B83-8C35-09F4E600FCEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|x64.Build.0 = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Debug|x86.Build.0 = Debug|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|x64.ActiveCfg = Release|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|x64.Build.0 = Release|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|x86.ActiveCfg = Release|Any CPU
+		{310CB963-4D29-4B83-8C35-09F4E600FCEB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/autodealer-crm/Apps/DashboardApp.cs
+++ b/project-demos/autodealer-crm/Apps/DashboardApp.cs
@@ -12,23 +12,23 @@ public class DashboardApp : ViewBase
             var initialDate = new DateTime(2025, 11, 1);
             return (fromDate: initialDate, toDate: initialDate.AddDays(30));
         });
-        
+
         var header = Layout.Horizontal().AlignContent(Align.Right)
                     | range.ToDateRangeInput();
-        
+
         var fromDate = range.Value.fromDate;
         var toDate = range.Value.toDate;
-        
+
         var metrics =
                 Layout.Grid().Columns(4)
-| new TotalSalesRevenueMetricView(fromDate, toDate).Key(fromDate, toDate)| new NumberOfLeadsMetricView(fromDate, toDate).Key(fromDate, toDate)| new ConversionRateMetricView(fromDate, toDate).Key(fromDate, toDate)| new AverageLeadResponseTimeMetricView(fromDate, toDate).Key(fromDate, toDate)| new NumberOfTasksCompletedMetricView(fromDate, toDate).Key(fromDate, toDate)| new CustomerRetentionRateMetricView(fromDate, toDate).Key(fromDate, toDate)| new TotalMessagesSentMetricView(fromDate, toDate).Key(fromDate, toDate)| new AverageVehiclePriceMetricView(fromDate, toDate).Key(fromDate, toDate)            ;
+| new TotalSalesRevenueMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfLeadsMetricView(fromDate, toDate).Key(fromDate, toDate) | new ConversionRateMetricView(fromDate, toDate).Key(fromDate, toDate) | new AverageLeadResponseTimeMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfTasksCompletedMetricView(fromDate, toDate).Key(fromDate, toDate) | new CustomerRetentionRateMetricView(fromDate, toDate).Key(fromDate, toDate) | new TotalMessagesSentMetricView(fromDate, toDate).Key(fromDate, toDate) | new AverageVehiclePriceMetricView(fromDate, toDate).Key(fromDate, toDate);
 
         var charts =
                 Layout.Grid().Columns(3)
-| new DailyLeadsCreatedLineChartView(fromDate, toDate).Key(fromDate, toDate)| new DailyMessagesSentLineChartView(fromDate, toDate).Key(fromDate, toDate)| new LeadConversionBySourcePieChartView(fromDate, toDate).Key(fromDate, toDate)| new DailyCallDurationsLineChartView(fromDate, toDate).Key(fromDate, toDate)| new TaskCompletionRateLineChartView(fromDate, toDate).Key(fromDate, toDate)| new VehicleStatusDistributionPieChartView(fromDate, toDate).Key(fromDate, toDate)            ;
+| new DailyLeadsCreatedLineChartView(fromDate, toDate).Key(fromDate, toDate) | new DailyMessagesSentLineChartView(fromDate, toDate).Key(fromDate, toDate) | new LeadConversionBySourcePieChartView(fromDate, toDate).Key(fromDate, toDate) | new DailyCallDurationsLineChartView(fromDate, toDate).Key(fromDate, toDate) | new TaskCompletionRateLineChartView(fromDate, toDate).Key(fromDate, toDate) | new VehicleStatusDistributionPieChartView(fromDate, toDate).Key(fromDate, toDate);
 
-        return Layout.Horizontal().AlignContent(Align.Center) | 
-               new HeaderLayout(header, Layout.Vertical() 
+        return Layout.Horizontal().AlignContent(Align.Center) |
+               new HeaderLayout(header, Layout.Vertical()
                             | metrics
                             | charts
                 ).Width(Size.Full().Max(300));

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/AutodealerCrmContext.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/AutodealerCrmContext.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
-
-namespace AutodealerCrm.Connections.AutodealerCrm;
+﻿namespace AutodealerCrm.Connections.AutodealerCrm;
 
 public partial class AutodealerCrmContext : DbContext
 {

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/AutodealerCrmContextFactory.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/AutodealerCrmContextFactory.cs
@@ -1,7 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using System.Threading;
-
 namespace AutodealerCrm.Connections.AutodealerCrm;
 
 public sealed class AutodealerCrmContextFactory : IDbContextFactory<AutodealerCrmContext>

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/CallDirection.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/CallDirection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/CallRecord.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/CallRecord.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Customer.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Customer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/EfmigrationsLock.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/EfmigrationsLock.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Lead.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Lead.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/LeadIntent.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/LeadIntent.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/LeadStage.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/LeadStage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Medium.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Medium.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Message.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Message.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageChannel.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageChannel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageDirection.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageDirection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageType.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/MessageType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/SourceChannel.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/SourceChannel.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Task.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Task.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/User.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/User.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/UserRole.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/UserRole.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/Vehicle.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/Vehicle.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/Connections/AutodealerCrm/VehicleStatus.cs
+++ b/project-demos/autodealer-crm/Connections/AutodealerCrm/VehicleStatus.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutodealerCrm.Connections.AutodealerCrm;
 

--- a/project-demos/autodealer-crm/GlobalUsings.cs
+++ b/project-demos/autodealer-crm/GlobalUsings.cs
@@ -1,13 +1,9 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;

--- a/project-demos/autodealer-crm/Program.cs
+++ b/project-demos/autodealer-crm/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fautodealer-crm%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fautodealer-crm%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<DashboardApp>()
     .UseTabs(preventDuplicates: true)

--- a/project-demos/autodealer-crm/autodealer-crm.sln
+++ b/project-demos/autodealer-crm/autodealer-crm.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutodealerCrm", "AutodealerCrm.csproj", "{0A7B25B6-362C-403A-A03D-8138873C8F96}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|x64.Build.0 = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Debug|x86.Build.0 = Debug|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|x64.ActiveCfg = Release|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|x64.Build.0 = Release|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|x86.ActiveCfg = Release|Any CPU
+		{0A7B25B6-362C-403A-A03D-8138873C8F96}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/book-library/Apps/DashboardApp.cs
+++ b/project-demos/book-library/Apps/DashboardApp.cs
@@ -5,8 +5,8 @@ public class DashboardApp : ViewBase
 {
     public override object? Build()
     {
-        var volume       = UseService<IVolume>();
-        var books        = UseState<List<Book>>(() => []);
+        var volume = UseService<IVolume>();
+        var books = UseState<List<Book>>(() => []);
         var refreshToken = UseRefreshToken();
 
         UseEffect(async () =>
@@ -20,17 +20,17 @@ public class DashboardApp : ViewBase
             BookStore.DataChanged += OnChanged;
         }, [EffectTrigger.OnMount()]);
 
-        var all               = books.Value;
-        var total             = all.Count;
-        var reading           = all.Count(b => b.Status == BookStatus.Reading);
-        var completed         = all.Count(b => b.Status == BookStatus.Completed);
-        var wantToRead        = all.Count(b => b.Status == BookStatus.WantToRead);
-        var paused            = all.Count(b => b.Status == BookStatus.Paused);
+        var all = books.Value;
+        var total = all.Count;
+        var reading = all.Count(b => b.Status == BookStatus.Reading);
+        var completed = all.Count(b => b.Status == BookStatus.Completed);
+        var wantToRead = all.Count(b => b.Status == BookStatus.WantToRead);
+        var paused = all.Count(b => b.Status == BookStatus.Paused);
         var completedThisYear = all.Count(b => b.Status == BookStatus.Completed && b.FinishedAt?.Year == DateTime.UtcNow.Year);
-        var avgRating         = all.Where(b => b.Rating.HasValue).Select(b => (double)b.Rating!.Value).DefaultIfEmpty(0).Average();
+        var avgRating = all.Where(b => b.Rating.HasValue).Select(b => (double)b.Rating!.Value).DefaultIfEmpty(0).Average();
 
         // Books by genre — pie chart
-        var genreData  = all.GroupBy(b => b.Genre)
+        var genreData = all.GroupBy(b => b.Genre)
                             .Select(g => new { Genre = g.Key, Count = g.Count() })
                             .OrderByDescending(x => x.Count)
                             .ToList();
@@ -38,18 +38,18 @@ public class DashboardApp : ViewBase
         var genreChart = genreData.Count > 0
             ? (object)genreData.ToPieChart(
                 dimension: x => x.Genre,
-                measure:   x => x.Sum(f => f.Count),
+                measure: x => x.Sum(f => f.Count),
                 PieChartStyles.Dashboard,
                 new PieChartTotal(total.ToString(), "Books"))
             : Text.Muted("No data yet");
 
         // Library overview — bar chart
-        var statusData  = all.GroupBy(b => BookStore.StatusLabel(b.Status))
+        var statusData = all.GroupBy(b => BookStore.StatusLabel(b.Status))
                              .Select(g => new { Status = g.Key, Count = g.Count() })
                              .ToList();
         var statusChart = statusData.ToBarChart()
                                     .Dimension("Status", x => x.Status)
-                                    .Measure("Books",    x => x.Sum(f => f.Count));
+                                    .Measure("Books", x => x.Sum(f => f.Count));
 
         // Currently reading — progress cards
         var readingBooks = all.Where(b => b.Status == BookStatus.Reading).ToList();

--- a/project-demos/book-library/Apps/Views/BooksApp.BookCreateDialog.cs
+++ b/project-demos/book-library/Apps/Views/BooksApp.BookCreateDialog.cs
@@ -4,12 +4,12 @@ public class BookCreateDialog(IState<bool> isOpen, RefreshToken refreshToken) : 
 {
     private record BookCreateRequest
     {
-        [Required] public string Title  { get; init; } = "";
+        [Required] public string Title { get; init; } = "";
         [Required] public string Author { get; init; } = "";
-        public string     Genre      { get; init; } = "Fiction";
-        public BookStatus Status     { get; init; } = BookStatus.WantToRead;
-        public int?       TotalPages { get; init; }
-        public string?    Notes      { get; init; }
+        public string Genre { get; init; } = "Fiction";
+        public BookStatus Status { get; init; } = BookStatus.WantToRead;
+        public int? TotalPages { get; init; }
+        public string? Notes { get; init; }
     }
 
     private static readonly Option<string>[] GenreOptions =
@@ -37,16 +37,16 @@ public class BookCreateDialog(IState<bool> isOpen, RefreshToken refreshToken) : 
     public override object? Build()
     {
         var volume = UseService<IVolume>();
-        var form   = UseState(() => new BookCreateRequest());
+        var form = UseState(() => new BookCreateRequest());
 
         return form
             .ToForm()
-            .Builder(f => f.Title,      e => e.ToTextInput().Placeholder("e.g. The Great Gatsby"))
-            .Builder(f => f.Author,     e => e.ToTextInput().Placeholder("e.g. F. Scott Fitzgerald"))
-            .Builder(f => f.Genre,      e => e.ToSelectInput(GenreOptions))
-            .Builder(f => f.Status,     e => e.ToSelectInput(StatusOptions))
+            .Builder(f => f.Title, e => e.ToTextInput().Placeholder("e.g. The Great Gatsby"))
+            .Builder(f => f.Author, e => e.ToTextInput().Placeholder("e.g. F. Scott Fitzgerald"))
+            .Builder(f => f.Genre, e => e.ToSelectInput(GenreOptions))
+            .Builder(f => f.Status, e => e.ToSelectInput(StatusOptions))
             .Builder(f => f.TotalPages, e => e.ToNumberInput().Placeholder("Total pages (optional)"))
-            .Builder(f => f.Notes,      e => e.ToTextareaInput().Placeholder("Your thoughts…"))
+            .Builder(f => f.Notes, e => e.ToTextareaInput().Placeholder("Your thoughts…"))
             .OnSubmit(OnSubmit)
             .ToDialog(isOpen, title: "Add Book", submitTitle: "Add");
 
@@ -54,14 +54,14 @@ public class BookCreateDialog(IState<bool> isOpen, RefreshToken refreshToken) : 
         {
             await BookStore.AddAsync(volume, new Book
             {
-                Id         = Guid.NewGuid(),
-                Title      = req.Title.Trim(),
-                Author     = req.Author.Trim(),
-                Genre      = req.Genre,
-                Status     = req.Status,
+                Id = Guid.NewGuid(),
+                Title = req.Title.Trim(),
+                Author = req.Author.Trim(),
+                Genre = req.Genre,
+                Status = req.Status,
                 TotalPages = req.TotalPages,
-                Notes      = req.Notes?.Trim(),
-                AddedAt    = DateTime.UtcNow,
+                Notes = req.Notes?.Trim(),
+                AddedAt = DateTime.UtcNow,
                 FinishedAt = req.Status == BookStatus.Completed ? DateTime.UtcNow : null
             });
             refreshToken.Refresh();

--- a/project-demos/book-library/Apps/Views/BooksApp.BookDetailsBlade.cs
+++ b/project-demos/book-library/Apps/Views/BooksApp.BookDetailsBlade.cs
@@ -4,9 +4,9 @@ public class BookDetailsBlade(Guid bookId, RefreshToken token) : ViewBase
 {
     public override object? Build()
     {
-        var volume       = UseService<IVolume>();
-        var blades       = UseContext<IBladeService>();
-        var book         = UseState<Book?>(() => null);
+        var volume = UseService<IVolume>();
+        var blades = UseContext<IBladeService>();
+        var book = UseState<Book?>(() => null);
         var progressState = UseState(0);
         var (alertView, showAlert) = this.UseAlert();
 
@@ -56,14 +56,14 @@ public class BookDetailsBlade(Guid bookId, RefreshToken token) : ViewBase
             content: Layout.Vertical().Gap(4)
                 | new
                 {
-                    Author   = b.Author,
-                    Genre    = b.Genre,
-                    Status   = BookStore.StatusLabel(b.Status),
-                    Rating   = BookStore.RatingStars(b.Rating),
-                    Pages    = pagesText,
-                    Added    = b.AddedAt.ToString("MMM d, yyyy"),
+                    Author = b.Author,
+                    Genre = b.Genre,
+                    Status = BookStore.StatusLabel(b.Status),
+                    Rating = BookStore.RatingStars(b.Rating),
+                    Pages = pagesText,
+                    Added = b.AddedAt.ToString("MMM d, yyyy"),
                     Finished = b.FinishedAt.HasValue ? b.FinishedAt.Value.ToString("MMM d, yyyy") : null,
-                    Notes    = b.Notes
+                    Notes = b.Notes
                 }
                 .ToDetails()
                 .RemoveEmpty()

--- a/project-demos/book-library/Apps/Views/BooksApp.BookEditSheet.cs
+++ b/project-demos/book-library/Apps/Views/BooksApp.BookEditSheet.cs
@@ -36,7 +36,7 @@ public class BookEditSheet(IState<bool> isOpen, RefreshToken refreshToken, Guid 
 
     public override object? Build()
     {
-        var volume    = UseService<IVolume>();
+        var volume = UseService<IVolume>();
         var bookState = UseState<Book?>(() => null);
         var prevStatus = UseState(BookStatus.WantToRead);
 
@@ -52,14 +52,14 @@ public class BookEditSheet(IState<bool> isOpen, RefreshToken refreshToken, Guid 
 
         return bookState
             .ToForm()
-            .Builder(b => b!.Title,      e => e.ToTextInput())
-            .Builder(b => b!.Author,     e => e.ToTextInput())
-            .Builder(b => b!.Genre,      e => e.ToSelectInput(GenreOptions))
-            .Builder(b => b!.Status,     e => e.ToSelectInput(StatusOptions))
-            .Builder(b => b!.Rating,     e => e.ToSelectInput(RatingOptions))
+            .Builder(b => b!.Title, e => e.ToTextInput())
+            .Builder(b => b!.Author, e => e.ToTextInput())
+            .Builder(b => b!.Genre, e => e.ToSelectInput(GenreOptions))
+            .Builder(b => b!.Status, e => e.ToSelectInput(StatusOptions))
+            .Builder(b => b!.Rating, e => e.ToSelectInput(RatingOptions))
             .Builder(b => b!.TotalPages, e => e.ToNumberInput())
-            .Builder(b => b!.PagesRead,  e => e.ToNumberInput())
-            .Builder(b => b!.Notes,      e => e.ToTextareaInput())
+            .Builder(b => b!.PagesRead, e => e.ToNumberInput())
+            .Builder(b => b!.Notes, e => e.ToTextareaInput())
             .Remove(b => b!.Id, b => b!.AddedAt, b => b!.FinishedAt)
             .OnSubmit(OnSubmit)
             .ToSheet(isOpen, "Edit Book");

--- a/project-demos/book-library/Apps/Views/BooksApp.BookListBlade.cs
+++ b/project-demos/book-library/Apps/Views/BooksApp.BookListBlade.cs
@@ -4,10 +4,10 @@ public class BookListBlade : ViewBase
 {
     public override object? Build()
     {
-        var volume       = UseService<IVolume>();
-        var blades       = UseContext<IBladeService>();
+        var volume = UseService<IVolume>();
+        var blades = UseContext<IBladeService>();
         var refreshToken = UseRefreshToken();
-        var refreshKey   = UseState(0);
+        var refreshKey = UseState(0);
 
         UseEffect(() =>
         {
@@ -25,10 +25,10 @@ public class BookListBlade : ViewBase
             var subtitle = $"{book.Author}  ·  {BookStore.StatusLabel(book.Status)}";
             Icons icon = book.Status switch
             {
-                BookStatus.Reading   => Icons.BookMarked,
+                BookStatus.Reading => Icons.BookMarked,
                 BookStatus.Completed => Icons.BookCheck,
-                BookStatus.Paused    => Icons.BookDashed,
-                _                   => Icons.BookOpen
+                BookStatus.Paused => Icons.BookDashed,
+                _ => Icons.BookOpen
             };
             return new ListItem(title: book.Title, subtitle: subtitle, onClick: onItemClick, tag: book, icon: icon);
         }

--- a/project-demos/book-library/Services/BookStore.cs
+++ b/project-demos/book-library/Services/BookStore.cs
@@ -4,16 +4,16 @@ public enum BookStatus { WantToRead, Reading, Completed, Paused }
 
 public record Book
 {
-    public Guid      Id         { get; init; }
-    public string    Title      { get; init; } = "";
-    public string    Author     { get; init; } = "";
-    public string    Genre      { get; init; } = "";
-    public BookStatus Status    { get; init; } = BookStatus.WantToRead;
-    public int?      Rating     { get; init; }
-    public int?      TotalPages { get; init; }
-    public int?      PagesRead  { get; init; }
-    public string?   Notes      { get; init; }
-    public DateTime  AddedAt    { get; init; } = DateTime.UtcNow;
+    public Guid Id { get; init; }
+    public string Title { get; init; } = "";
+    public string Author { get; init; } = "";
+    public string Genre { get; init; } = "";
+    public BookStatus Status { get; init; } = BookStatus.WantToRead;
+    public int? Rating { get; init; }
+    public int? TotalPages { get; init; }
+    public int? PagesRead { get; init; }
+    public string? Notes { get; init; }
+    public DateTime AddedAt { get; init; } = DateTime.UtcNow;
     public DateTime? FinishedAt { get; init; }
 }
 
@@ -63,7 +63,7 @@ public static class BookStore
         await using var conn = await OpenAsync(volume);
         await using var tx = conn.BeginTransaction();
         var authorId = await GetOrCreateAuthorIdAsync(conn, tx, book.Author);
-        var genreId  = await GetOrCreateGenreIdAsync(conn, tx, book.Genre);
+        var genreId = await GetOrCreateGenreIdAsync(conn, tx, book.Genre);
         const string sql = """
             INSERT INTO Books
                 (Id, Title, AuthorId, GenreId, Status, Rating, TotalPages, PagesRead, Notes, AddedAt, FinishedAt)
@@ -71,16 +71,16 @@ public static class BookStore
                 (@Id, @Title, @AuthorId, @GenreId, @Status, @Rating, @TotalPages, @PagesRead, @Notes, @AddedAt, @FinishedAt)
             """;
         await using var cmd = new SqliteCommand(sql, conn, tx);
-        cmd.Parameters.AddWithValue("@Id",         book.Id.ToString());
-        cmd.Parameters.AddWithValue("@Title",      book.Title);
-        cmd.Parameters.AddWithValue("@AuthorId",   authorId);
-        cmd.Parameters.AddWithValue("@GenreId",    genreId);
-        cmd.Parameters.AddWithValue("@Status",     book.Status.ToString());
-        cmd.Parameters.AddWithValue("@Rating",     book.Rating     is not null ? book.Rating     : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Id", book.Id.ToString());
+        cmd.Parameters.AddWithValue("@Title", book.Title);
+        cmd.Parameters.AddWithValue("@AuthorId", authorId);
+        cmd.Parameters.AddWithValue("@GenreId", genreId);
+        cmd.Parameters.AddWithValue("@Status", book.Status.ToString());
+        cmd.Parameters.AddWithValue("@Rating", book.Rating is not null ? book.Rating : DBNull.Value);
         cmd.Parameters.AddWithValue("@TotalPages", book.TotalPages is not null ? book.TotalPages : DBNull.Value);
-        cmd.Parameters.AddWithValue("@PagesRead",  book.PagesRead  is not null ? book.PagesRead  : DBNull.Value);
-        cmd.Parameters.AddWithValue("@Notes",      book.Notes      is not null ? book.Notes      : DBNull.Value);
-        cmd.Parameters.AddWithValue("@AddedAt",    book.AddedAt.ToString("O"));
+        cmd.Parameters.AddWithValue("@PagesRead", book.PagesRead is not null ? book.PagesRead : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Notes", book.Notes is not null ? book.Notes : DBNull.Value);
+        cmd.Parameters.AddWithValue("@AddedAt", book.AddedAt.ToString("O"));
         cmd.Parameters.AddWithValue("@FinishedAt", book.FinishedAt is not null ? book.FinishedAt.Value.ToString("O") : DBNull.Value);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
@@ -92,7 +92,7 @@ public static class BookStore
         await using var conn = await OpenAsync(volume);
         await using var tx = conn.BeginTransaction();
         var authorId = await GetOrCreateAuthorIdAsync(conn, tx, book.Author);
-        var genreId  = await GetOrCreateGenreIdAsync(conn, tx, book.Genre);
+        var genreId = await GetOrCreateGenreIdAsync(conn, tx, book.Genre);
         const string sql = """
             UPDATE Books SET
                 Title      = @Title,
@@ -107,15 +107,15 @@ public static class BookStore
             WHERE Id = @Id
             """;
         await using var cmd = new SqliteCommand(sql, conn, tx);
-        cmd.Parameters.AddWithValue("@Id",         book.Id.ToString());
-        cmd.Parameters.AddWithValue("@Title",      book.Title);
-        cmd.Parameters.AddWithValue("@AuthorId",   authorId);
-        cmd.Parameters.AddWithValue("@GenreId",    genreId);
-        cmd.Parameters.AddWithValue("@Status",     book.Status.ToString());
-        cmd.Parameters.AddWithValue("@Rating",     book.Rating     is not null ? book.Rating     : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Id", book.Id.ToString());
+        cmd.Parameters.AddWithValue("@Title", book.Title);
+        cmd.Parameters.AddWithValue("@AuthorId", authorId);
+        cmd.Parameters.AddWithValue("@GenreId", genreId);
+        cmd.Parameters.AddWithValue("@Status", book.Status.ToString());
+        cmd.Parameters.AddWithValue("@Rating", book.Rating is not null ? book.Rating : DBNull.Value);
         cmd.Parameters.AddWithValue("@TotalPages", book.TotalPages is not null ? book.TotalPages : DBNull.Value);
-        cmd.Parameters.AddWithValue("@PagesRead",  book.PagesRead  is not null ? book.PagesRead  : DBNull.Value);
-        cmd.Parameters.AddWithValue("@Notes",      book.Notes      is not null ? book.Notes      : DBNull.Value);
+        cmd.Parameters.AddWithValue("@PagesRead", book.PagesRead is not null ? book.PagesRead : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Notes", book.Notes is not null ? book.Notes : DBNull.Value);
         cmd.Parameters.AddWithValue("@FinishedAt", book.FinishedAt is not null ? book.FinishedAt.Value.ToString("O") : DBNull.Value);
         await cmd.ExecuteNonQueryAsync();
         await tx.CommitAsync();
@@ -134,10 +134,10 @@ public static class BookStore
     public static string StatusLabel(BookStatus s) => s switch
     {
         BookStatus.WantToRead => "Want to Read",
-        BookStatus.Reading    => "Reading",
-        BookStatus.Completed  => "Completed",
-        BookStatus.Paused     => "Paused",
-        _                     => s.ToString()
+        BookStatus.Reading => "Reading",
+        BookStatus.Completed => "Completed",
+        BookStatus.Paused => "Paused",
+        _ => s.ToString()
     };
 
     public static string RatingStars(int? rating) =>
@@ -210,16 +210,16 @@ public static class BookStore
 
     private static Book Map(SqliteDataReader r) => new()
     {
-        Id         = Guid.Parse(r.GetString(r.GetOrdinal("Id"))),
-        Title      = r.GetString(r.GetOrdinal("Title")),
-        Author     = r.GetString(r.GetOrdinal("Author")),
-        Genre      = r.GetString(r.GetOrdinal("Genre")),
-        Status     = Enum.Parse<BookStatus>(r.GetString(r.GetOrdinal("Status"))),
-        Rating     = r.IsDBNull(r.GetOrdinal("Rating"))     ? null : r.GetInt32(r.GetOrdinal("Rating")),
+        Id = Guid.Parse(r.GetString(r.GetOrdinal("Id"))),
+        Title = r.GetString(r.GetOrdinal("Title")),
+        Author = r.GetString(r.GetOrdinal("Author")),
+        Genre = r.GetString(r.GetOrdinal("Genre")),
+        Status = Enum.Parse<BookStatus>(r.GetString(r.GetOrdinal("Status"))),
+        Rating = r.IsDBNull(r.GetOrdinal("Rating")) ? null : r.GetInt32(r.GetOrdinal("Rating")),
         TotalPages = r.IsDBNull(r.GetOrdinal("TotalPages")) ? null : r.GetInt32(r.GetOrdinal("TotalPages")),
-        PagesRead  = r.IsDBNull(r.GetOrdinal("PagesRead"))  ? null : r.GetInt32(r.GetOrdinal("PagesRead")),
-        Notes      = r.IsDBNull(r.GetOrdinal("Notes"))      ? null : r.GetString(r.GetOrdinal("Notes")),
-        AddedAt    = DateTime.Parse(r.GetString(r.GetOrdinal("AddedAt"))),
+        PagesRead = r.IsDBNull(r.GetOrdinal("PagesRead")) ? null : r.GetInt32(r.GetOrdinal("PagesRead")),
+        Notes = r.IsDBNull(r.GetOrdinal("Notes")) ? null : r.GetString(r.GetOrdinal("Notes")),
+        AddedAt = DateTime.Parse(r.GetString(r.GetOrdinal("AddedAt"))),
         FinishedAt = r.IsDBNull(r.GetOrdinal("FinishedAt")) ? null : DateTime.Parse(r.GetString(r.GetOrdinal("FinishedAt"))),
     };
 }

--- a/project-demos/book-library/book-library.sln
+++ b/project-demos/book-library/book-library.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BookLibrary", "BookLibrary.csproj", "{CB17393A-8A51-4D62-A779-84C2C8D5C533}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|x64.Build.0 = Release|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB17393A-8A51-4D62-A779-84C2C8D5C533}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/course-template/GlobalUsings.cs
+++ b/project-demos/course-template/GlobalUsings.cs
@@ -1,4 +1,3 @@
 global using System.Globalization;
 global using Ivy;
-global using Ivy.Views;
 global using CourseTemplate.Helpers;

--- a/project-demos/course-template/Helpers/UseLinks.cs
+++ b/project-demos/course-template/Helpers/UseLinks.cs
@@ -1,5 +1,3 @@
-using Ivy;
-
 namespace CourseTemplate.Helpers;
 
 public static class Hooks

--- a/project-demos/course-template/course-template.sln
+++ b/project-demos/course-template/course-template.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CourseTemplate", "CourseTemplate.csproj", "{20B7F835-D018-4EE9-9668-A70E77B66592}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|x64.Build.0 = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Debug|x86.Build.0 = Debug|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|x64.ActiveCfg = Release|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|x64.Build.0 = Release|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|x86.ActiveCfg = Release|Any CPU
+		{20B7F835-D018-4EE9-9668-A70E77B66592}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/crm-vc/Apps/DashboardApp.cs
+++ b/project-demos/crm-vc/Apps/DashboardApp.cs
@@ -7,25 +7,25 @@ public class DashboardApp : ViewBase
 {
     public override object? Build()
     {
-        var range = this.UseState(() => (fromDate:DateTime.Today.Date.AddDays(-30), toDate:DateTime.Today.Date));
+        var range = this.UseState(() => (fromDate: DateTime.Today.Date.AddDays(-30), toDate: DateTime.Today.Date));
 
         var header = Layout.Horizontal().AlignContent(Align.Right) | range.ToDateRangeInput();
-        
+
         var fromDate = range.Value.fromDate;
         var toDate = range.Value.toDate;
-        
+
         var metrics =
                 Layout.Grid().Columns(4)
-                | new TotalInvestmentAmountMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfDealsClosedMetricView(fromDate, toDate).Key(fromDate, toDate) | new AverageDealSizeMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfActiveStartupsMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfFoundersEngagedMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfPartnersEngagedMetricView(fromDate, toDate).Key(fromDate, toDate) 
-            ;
-            
-        var charts = 
-                Layout.Grid().Columns(3)
-                | new DailyDealAmountsLineChartView(fromDate, toDate).Key(fromDate, toDate) | new IndustryDistributionOfStartupsPieChartView(fromDate, toDate).Key(fromDate, toDate) | new GenderDistributionOfFoundersPieChartView(fromDate, toDate).Key(fromDate, toDate) 
+                | new TotalInvestmentAmountMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfDealsClosedMetricView(fromDate, toDate).Key(fromDate, toDate) | new AverageDealSizeMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfActiveStartupsMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfFoundersEngagedMetricView(fromDate, toDate).Key(fromDate, toDate) | new NumberOfPartnersEngagedMetricView(fromDate, toDate).Key(fromDate, toDate)
             ;
 
-        return Layout.Horizontal().AlignContent(Align.Center) | 
-               new HeaderLayout(header, Layout.Vertical() 
+        var charts =
+                Layout.Grid().Columns(3)
+                | new DailyDealAmountsLineChartView(fromDate, toDate).Key(fromDate, toDate) | new IndustryDistributionOfStartupsPieChartView(fromDate, toDate).Key(fromDate, toDate) | new GenderDistributionOfFoundersPieChartView(fromDate, toDate).Key(fromDate, toDate)
+            ;
+
+        return Layout.Horizontal().AlignContent(Align.Center) |
+               new HeaderLayout(header, Layout.Vertical()
                             | metrics
                             | charts
                 ).Width(Size.Full().Max(300));

--- a/project-demos/crm-vc/Connections/Vc/Deal.cs
+++ b/project-demos/crm-vc/Connections/Vc/Deal.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/Founder.cs
+++ b/project-demos/crm-vc/Connections/Vc/Founder.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/Gender.cs
+++ b/project-demos/crm-vc/Connections/Vc/Gender.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/Industry.cs
+++ b/project-demos/crm-vc/Connections/Vc/Industry.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/Partner.cs
+++ b/project-demos/crm-vc/Connections/Vc/Partner.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/Startup.cs
+++ b/project-demos/crm-vc/Connections/Vc/Startup.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Vc.Connections.Vc;
 

--- a/project-demos/crm-vc/Connections/Vc/VcConnection.cs
+++ b/project-demos/crm-vc/Connections/Vc/VcConnection.cs
@@ -16,9 +16,9 @@ public class VcConnection : IConnection
     public string GetName() => nameof(Vc);
 
     public string GetNamespace() => typeof(VcConnection).Namespace;
-    
+
     public string GetConnectionType() => "EntityFramework.Sqlite";
-    
+
     public ConnectionEntity[] GetEntities()
     {
         return typeof(VcContext)

--- a/project-demos/crm-vc/Connections/Vc/VcContext.cs
+++ b/project-demos/crm-vc/Connections/Vc/VcContext.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
-
-namespace Vc.Connections.Vc;
+﻿namespace Vc.Connections.Vc;
 
 public partial class VcContext : DbContext
 {

--- a/project-demos/crm-vc/Connections/Vc/VcContextFactory.cs
+++ b/project-demos/crm-vc/Connections/Vc/VcContextFactory.cs
@@ -1,7 +1,3 @@
-using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using System.Threading;
 using Path = System.IO.Path;
 
 namespace Vc.Connections.Vc;

--- a/project-demos/crm-vc/GlobalUsings.cs
+++ b/project-demos/crm-vc/GlobalUsings.cs
@@ -3,7 +3,6 @@ global using Ivy;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;

--- a/project-demos/crm-vc/crm-vc.sln
+++ b/project-demos/crm-vc/crm-vc.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vc", "Vc.csproj", "{CD6E27D8-02FA-4B89-A249-839BBDD559F0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|x64.Build.0 = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Debug|x86.Build.0 = Debug|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|x64.ActiveCfg = Release|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|x64.Build.0 = Release|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{CD6E27D8-02FA-4B89-A249-839BBDD559F0}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/github-wrapped/GlobalUsings.cs
+++ b/project-demos/github-wrapped/GlobalUsings.cs
@@ -1,16 +1,8 @@
 global using Ivy;
-global using Ivy.Auth;
 global using Ivy.Auth.GitHub;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
-global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Http;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text.Json;

--- a/project-demos/github-wrapped/github-wrapped.sln
+++ b/project-demos/github-wrapped/github-wrapped.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitHubWrapped", "GitHubWrapped.csproj", "{8F5333FB-F4E5-441D-8B2E-156E746B8739}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|x64.Build.0 = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Debug|x86.Build.0 = Debug|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|x64.ActiveCfg = Release|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|x64.Build.0 = Release|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|x86.ActiveCfg = Release|Any CPU
+		{8F5333FB-F4E5-441D-8B2E-156E746B8739}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/ivy-ask-statistics/Apps/DashboardApp.cs
+++ b/project-demos/ivy-ask-statistics/Apps/DashboardApp.cs
@@ -12,17 +12,17 @@ public class DashboardApp : ViewBase
 
     public override object? Build()
     {
-        var factory        = UseService<AppDbContextFactory>();
-        var client         = UseService<IClientProvider>();
-        var navigation     = Context.UseNavigation();
-        var selectedRunId  = UseState<Guid?>(null);
-        var runDialogOpen  = UseState(false);
-        var editSheetOpen     = UseState(false);
-        var editQuestionId    = UseState(Guid.Empty);
+        var factory = UseService<AppDbContextFactory>();
+        var client = UseService<IClientProvider>();
+        var navigation = Context.UseNavigation();
+        var selectedRunId = UseState<Guid?>(null);
+        var runDialogOpen = UseState(false);
+        var editSheetOpen = UseState(false);
+        var editQuestionId = UseState(Guid.Empty);
         var editPreviewResultId = UseState<Guid?>(null);
-        var envOverride    = UseState("production");
+        var envOverride = UseState("production");
         var dashboardFocusVersion = UseState<string?>(null);
-        var versionSheetOpen      = UseState(false);
+        var versionSheetOpen = UseState(false);
 
         var dashQuery = UseQuery<DashboardPageModel?, string>(
             key: DashboardQueryKey(dashboardFocusVersion.Value),
@@ -72,12 +72,12 @@ public class DashboardApp : ViewBase
             ? page.Detail : page.PeerDetail;
         var stgData = string.Equals(page.PrimaryEnvironment, "staging", StringComparison.OrdinalIgnoreCase)
             ? page.Detail : page.PeerDetail;
-        var hasStagingData    = stgData  != null;
+        var hasStagingData = stgData != null;
         var hasProductionData = prodData != null;
 
         // Respect the user's toggle; fall back gracefully when an env has no data.
         var showEnv = envOverride.Value;
-        if (showEnv == "staging"    && !hasStagingData)    showEnv = "production";
+        if (showEnv == "staging" && !hasStagingData) showEnv = "production";
         if (showEnv == "production" && !hasProductionData) showEnv = "staging";
 
         DashboardData data;
@@ -85,14 +85,14 @@ public class DashboardApp : ViewBase
         string envPrimary;
         if (showEnv == "staging" && stgData != null)
         {
-            data      = stgData;
-            peer      = prodData;
+            data = stgData;
+            peer = prodData;
             envPrimary = "Staging";
         }
         else
         {
-            data      = prodData ?? page.Detail;
-            peer      = stgData;
+            data = prodData ?? page.Detail;
+            peer = stgData;
             envPrimary = "Production";
         }
         var hasPeerCompare = peer != null;
@@ -230,28 +230,28 @@ public class DashboardApp : ViewBase
             .ToDataTable(r => r.Id)
             .Height(Size.Units(120))
             .Key($"all-test-runs|{dashQueryKey}")
-            .Header(r => r.IvyVersion,      "Ivy version")
-            .Header(r => r.Environment,     "Environment")
+            .Header(r => r.IvyVersion, "Ivy version")
+            .Header(r => r.Environment, "Environment")
             .Header(r => r.DifficultyFilter, "Difficulty")
-            .Header(r => r.TotalQuestions,  "Total")
-            .Header(r => r.SuccessCount,    "Answered")
-            .Header(r => r.NoAnswerCount,   "No answer")
-            .Header(r => r.ErrorCount,      "Errors")
-            .Header(r => r.AnswerRate,      "Rate %")
-            .Header(r => r.AvgMs,           "Avg ms")
-            .Header(r => r.StartedAt,       "Started")
-            .Header(r => r.CompletedAt,     "Completed")
-            .Width(r => r.IvyVersion,       Size.Px(120))
-            .Width(r => r.Environment,      Size.Px(100))
+            .Header(r => r.TotalQuestions, "Total")
+            .Header(r => r.SuccessCount, "Answered")
+            .Header(r => r.NoAnswerCount, "No answer")
+            .Header(r => r.ErrorCount, "Errors")
+            .Header(r => r.AnswerRate, "Rate %")
+            .Header(r => r.AvgMs, "Avg ms")
+            .Header(r => r.StartedAt, "Started")
+            .Header(r => r.CompletedAt, "Completed")
+            .Width(r => r.IvyVersion, Size.Px(120))
+            .Width(r => r.Environment, Size.Px(100))
             .Width(r => r.DifficultyFilter, Size.Px(80))
-            .Width(r => r.TotalQuestions,   Size.Px(60))
-            .Width(r => r.SuccessCount,     Size.Px(80))
-            .Width(r => r.NoAnswerCount,    Size.Px(80))
-            .Width(r => r.ErrorCount,       Size.Px(60))
-            .Width(r => r.AnswerRate,       Size.Px(70))
-            .Width(r => r.AvgMs,            Size.Px(70))
-            .Width(r => r.StartedAt,        Size.Px(160))
-            .Width(r => r.CompletedAt,      Size.Px(160))
+            .Width(r => r.TotalQuestions, Size.Px(60))
+            .Width(r => r.SuccessCount, Size.Px(80))
+            .Width(r => r.NoAnswerCount, Size.Px(80))
+            .Width(r => r.ErrorCount, Size.Px(60))
+            .Width(r => r.AnswerRate, Size.Px(70))
+            .Width(r => r.AvgMs, Size.Px(70))
+            .Width(r => r.StartedAt, Size.Px(160))
+            .Width(r => r.CompletedAt, Size.Px(160))
             .Hidden(r => r.Id)
             .RowActions(
                 MenuItem.Default(Icons.Eye, "view").Label("View results").Tag("view"))
@@ -267,9 +267,9 @@ public class DashboardApp : ViewBase
             })
             .Config(c =>
             {
-                c.AllowSorting    = true;
-                c.AllowFiltering  = true;
-                c.ShowSearch      = true;
+                c.AllowSorting = true;
+                c.AllowFiltering = true;
+                c.ShowSearch = true;
                 c.ShowIndexColumn = false;
             });
         var tableRuns = Layout.Vertical() | new Card(runsTable).Title("Test runs");
@@ -278,7 +278,7 @@ public class DashboardApp : ViewBase
                | kpiRow
                | versionChartsRow
                | chartsRow
-               | tableRuns ;
+               | tableRuns;
 
         return new Fragment(
             mainLayout,
@@ -565,9 +565,9 @@ public class DashboardApp : ViewBase
 
         var allRuns = runs.Select(r =>
         {
-            var t    = r.TotalQuestions;
+            var t = r.TotalQuestions;
             var rate = t > 0 ? Math.Round(r.SuccessCount * 100.0 / t, 1) : 0.0;
-            var avg  = avgMsByRunId.TryGetValue(r.Id, out var a) ? (int)Math.Round(a) : 0;
+            var avg = avgMsByRunId.TryGetValue(r.Id, out var a) ? (int)Math.Round(a) : 0;
             return new TestRunRow(
                 r.Id,
                 r.IvyVersion ?? "",

--- a/project-demos/ivy-ask-statistics/Apps/QuestionEditSheet.cs
+++ b/project-demos/ivy-ask-statistics/Apps/QuestionEditSheet.cs
@@ -38,9 +38,9 @@ internal sealed class QuestionEditSheet(
 
     public override object? Build()
     {
-        var factory      = UseService<AppDbContextFactory>();
+        var factory = UseService<AppDbContextFactory>();
         var queryService = UseService<IQueryService>();
-        var isSaving     = UseState(false);
+        var isSaving = UseState(false);
 
         var questionQuery = UseQuery<QuestionEditPayload?, (Guid QuestionId, Guid? PreviewResultId)>(
             key: (questionId, previewResultId.Value),
@@ -99,16 +99,16 @@ internal sealed class QuestionEditSheet(
                 .Height(Size.Full());
 
         var payload = questionQuery.Value;
-        var q       = payload.Question;
-        var answer  = payload.AnswerText;
+        var q = payload.Question;
+        var answer = payload.AnswerText;
         var preview = payload.PreviewSource;
 
         var form = new EditRequest
         {
             QuestionText = q.QuestionText ?? "",
-            Difficulty   = q.Difficulty,
-            Category     = q.Category,
-            IsActive     = q.IsActive,
+            Difficulty = q.Difficulty,
+            Category = q.Category,
+            IsActive = q.IsActive,
         };
 
         var difficulties = new[] { "easy", "medium", "hard" }.ToOptions();
@@ -116,9 +116,9 @@ internal sealed class QuestionEditSheet(
         var formBuilder = form
             .ToForm()
             .Builder(f => f.QuestionText, f => f.ToTextareaInput())
-            .Builder(f => f.Difficulty,   f => f.ToSelectInput(difficulties))
-            .Builder(f => f.Category,     f => f.ToTextInput())
-            .Builder(f => f.IsActive,     f => f.ToSwitchInput())
+            .Builder(f => f.Difficulty, f => f.ToSelectInput(difficulties))
+            .Builder(f => f.Category, f => f.ToTextInput())
+            .Builder(f => f.IsActive, f => f.ToSwitchInput())
             .OnSubmit(OnSubmit);
 
         var (onSubmit, formView, validationView, loading) = formBuilder.UseForm(Context);
@@ -192,9 +192,9 @@ internal sealed class QuestionEditSheet(
             var entity = await ctx.Questions.FirstOrDefaultAsync(e => e.Id == questionId);
             if (entity == null) return;
             entity.QuestionText = request.QuestionText.Trim();
-            entity.Difficulty   = request.Difficulty;
-            entity.Category     = request.Category.Trim();
-            entity.IsActive     = request.IsActive;
+            entity.Difficulty = request.Difficulty;
+            entity.Category = request.Category.Trim();
+            entity.IsActive = request.IsActive;
             await ctx.SaveChangesAsync();
             queryService.RevalidateByTag(("widget-questions", entity.Widget));
             queryService.RevalidateByTag("widget-summary");

--- a/project-demos/ivy-ask-statistics/Apps/QuestionsApp.cs
+++ b/project-demos/ivy-ask-statistics/Apps/QuestionsApp.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Threading;
 
 namespace IvyAskStatistics.Apps;
 
@@ -23,20 +22,20 @@ public class QuestionsApp : ViewBase
 
     public override object? Build()
     {
-        var factory       = UseService<AppDbContextFactory>();
+        var factory = UseService<AppDbContextFactory>();
         var configuration = UseService<IConfiguration>();
-        var client        = UseService<IClientProvider>();
-        var queryService  = UseService<IQueryService>();
+        var client = UseService<IClientProvider>();
+        var queryService = UseService<IQueryService>();
 
         var generatingWidgets = UseState(ImmutableHashSet<string>.Empty);
-        var deleteRequest     = UseState<string?>(null);
-        var viewDialogOpen    = UseState(false);
-        var viewDialogWidget  = UseState("");
-        var editSheetOpen       = UseState(false);
-        var editQuestionId      = UseState(Guid.Empty);
+        var deleteRequest = UseState<string?>(null);
+        var viewDialogOpen = UseState(false);
+        var viewDialogWidget = UseState("");
+        var editSheetOpen = UseState(false);
+        var editQuestionId = UseState(Guid.Empty);
         var editPreviewResultId = UseState<Guid?>(null);
-        var refreshToken      = UseRefreshToken();
-        var genProgress       = UseState<GenProgress?>(null);
+        var refreshToken = UseRefreshToken();
+        var genProgress = UseState<GenProgress?>(null);
         var (alertView, showAlert) = UseAlert();
 
         var tableQuery = UseQuery<WidgetTableData, string>(
@@ -97,7 +96,7 @@ public class QuestionsApp : ViewBase
 
         async Task GenerateOneAsync(IvyWidget widget)
         {
-            var apiKey  = configuration[QuestionGeneratorService.ApiKeyConfigKey]!.Trim();
+            var apiKey = configuration[QuestionGeneratorService.ApiKeyConfigKey]!.Trim();
             var baseUrl = configuration[QuestionGeneratorService.BaseUrlConfigKey]!.Trim();
             await QuestionGeneratorService.GenerateAndSaveAsync(widget, factory, apiKey, baseUrl, configuration);
         }
@@ -147,7 +146,7 @@ public class QuestionsApp : ViewBase
                     var d = Volatile.Read(ref completed);
                     List<string> failedCopy;
                     lock (failedLock)
-                        failedCopy = [..failed];
+                        failedCopy = [.. failed];
                     genProgress.Set(new GenProgress("", d, widgets.Count, failedCopy, true, maxParallel));
                     var fresh = await LoadWidgetTableDataAsync(factory, TableQueryKey, CancellationToken.None);
                     tableQuery.Mutator.Mutate(fresh, revalidate: false);
@@ -251,7 +250,7 @@ public class QuestionsApp : ViewBase
                 generatingWidgets.Set(_ => ImmutableHashSet<string>.Empty);
                 List<string> failedCopy;
                 lock (failedLock)
-                    failedCopy = [..failed];
+                    failedCopy = [.. failed];
                 genProgress.Set(new GenProgress(
                     "",
                     Volatile.Read(ref completed),
@@ -334,11 +333,11 @@ public class QuestionsApp : ViewBase
         }
 
         var generating = generatingWidgets.Value;
-        var baseRows   = tableQuery.Value?.Rows ?? [];
-        var catalog    = tableQuery.Value?.Catalog ?? [];
+        var baseRows = tableQuery.Value?.Rows ?? [];
+        var catalog = tableQuery.Value?.Catalog ?? [];
         var isDeleting = !string.IsNullOrEmpty(deleteRequest.Value);
-        var firstLoad  = tableQuery.Loading && tableQuery.Value == null;
-        var progress   = genProgress.Value;
+        var firstLoad = tableQuery.Loading && tableQuery.Value == null;
+        var progress = genProgress.Value;
         var isGenerating = generating.Count > 0;
 
         static string IdleStatus(WidgetRow r)
@@ -396,20 +395,20 @@ public class QuestionsApp : ViewBase
             .RefreshToken(refreshToken)
             .Key("questions-widgets")
             .Height(Size.Full())
-            .Header(r => r.Widget,      "Widget")
-            .Header(r => r.Category,    "Category")
-            .Header(r => r.Easy,        "Easy")
-            .Header(r => r.Medium,      "Medium")
-            .Header(r => r.Hard,        "Hard")
+            .Header(r => r.Widget, "Widget")
+            .Header(r => r.Category, "Category")
+            .Header(r => r.Easy, "Easy")
+            .Header(r => r.Medium, "Medium")
+            .Header(r => r.Hard, "Hard")
             .Header(r => r.LastUpdated, "Last Generated")
-            .Header(r => r.Status,      "Status")
-            .Width(r => r.Widget,       Size.Px(160))
-            .Width(r => r.Category,     Size.Px(120))
-            .Width(r => r.Easy,         Size.Px(60))
-            .Width(r => r.Medium,       Size.Px(70))
-            .Width(r => r.Hard,         Size.Px(60))
-            .Width(r => r.LastUpdated,  Size.Px(170))
-            .Width(r => r.Status,       Size.Px(280))
+            .Header(r => r.Status, "Status")
+            .Width(r => r.Widget, Size.Px(160))
+            .Width(r => r.Category, Size.Px(120))
+            .Width(r => r.Easy, Size.Px(60))
+            .Width(r => r.Medium, Size.Px(70))
+            .Width(r => r.Hard, Size.Px(60))
+            .Width(r => r.LastUpdated, Size.Px(170))
+            .Width(r => r.Status, Size.Px(280))
             .RowActions(
                 MenuItem.Default(Icons.List, "questions").Label("View questions").Tag("questions"),
                 MenuItem.Default(Icons.Sparkles, "generate").Label("Generate questions").Tag("generate"),
@@ -417,7 +416,7 @@ public class QuestionsApp : ViewBase
             .OnRowAction(e =>
             {
                 var args = e.Value;
-                var tag  = args?.Tag?.ToString();
+                var tag = args?.Tag?.ToString();
                 if (string.IsNullOrEmpty(tag)) return ValueTask.CompletedTask;
 
                 if (tag == "questions")
@@ -467,7 +466,7 @@ public class QuestionsApp : ViewBase
                     if (generating.Contains(delName)) return ValueTask.CompletedTask;
 
                     var row = rows.FirstOrDefault(r => r.Widget == delName);
-                    var n   = row == null ? 0 : row.Easy + row.Medium + row.Hard;
+                    var n = row == null ? 0 : row.Easy + row.Medium + row.Hard;
                     if (n == 0) return ValueTask.CompletedTask;
 
                     showAlert(
@@ -486,9 +485,9 @@ public class QuestionsApp : ViewBase
             })
             .Config(config =>
             {
-                config.AllowSorting    = true;
-                config.AllowFiltering  = true;
-                config.ShowSearch      = true;
+                config.AllowSorting = true;
+                config.AllowFiltering = true;
+                config.ShowSearch = true;
                 config.ShowIndexColumn = false;
             });
 
@@ -528,7 +527,7 @@ public class QuestionsApp : ViewBase
                 g.Key.Widget,
                 g.Key.Category,
                 g.Key.Difficulty,
-                Count   = g.Count(),
+                Count = g.Count(),
                 MaxDate = g.Max(x => x.CreatedAt)
             })
             .ToListAsync(ct);
@@ -538,10 +537,10 @@ public class QuestionsApp : ViewBase
             .ToDictionary(
                 g => g.Key,
                 g => (
-                    category:  g.Select(x => x.Category).FirstOrDefault() ?? "",
-                    easy:      g.FirstOrDefault(x => x.Difficulty == "easy")?.Count   ?? 0,
-                    medium:    g.FirstOrDefault(x => x.Difficulty == "medium")?.Count ?? 0,
-                    hard:      g.FirstOrDefault(x => x.Difficulty == "hard")?.Count   ?? 0,
+                    category: g.Select(x => x.Category).FirstOrDefault() ?? "",
+                    easy: g.FirstOrDefault(x => x.Difficulty == "easy")?.Count ?? 0,
+                    medium: g.FirstOrDefault(x => x.Difficulty == "medium")?.Count ?? 0,
+                    hard: g.FirstOrDefault(x => x.Difficulty == "hard")?.Count ?? 0,
                     updatedAt: g.Max(x => x.MaxDate)
                 ));
 
@@ -559,9 +558,9 @@ public class QuestionsApp : ViewBase
             .ThenBy(w => w.Name)
             .Select(w =>
             {
-                var c        = countsByWidget.GetValueOrDefault(w.Name);
+                var c = countsByWidget.GetValueOrDefault(w.Name);
                 var category = string.IsNullOrEmpty(w.Category) ? "Unclassified" : w.Category;
-                var updated  = c.updatedAt == default
+                var updated = c.updatedAt == default
                     ? "—"
                     : c.updatedAt.ToLocalTime().ToString("dd MMM yyyy, HH:mm");
                 return new WidgetRow(w.Name, category, c.easy, c.medium, c.hard, updated, "");

--- a/project-demos/ivy-ask-statistics/Apps/RunApp.cs
+++ b/project-demos/ivy-ask-statistics/Apps/RunApp.cs
@@ -685,16 +685,16 @@ public class RunApp : ViewBase
 
             var run = new TestRunEntity
             {
-                IvyVersion       = ivyVersion,
-                Environment    = mcpEnvironment.Trim().ToLowerInvariant() is "staging" ? "staging" : "production",
+                IvyVersion = ivyVersion,
+                Environment = mcpEnvironment.Trim().ToLowerInvariant() is "staging" ? "staging" : "production",
                 DifficultyFilter = string.IsNullOrEmpty(difficultyFilter) ? "all" : difficultyFilter,
-                Concurrency    = concurrency ?? "",
+                Concurrency = concurrency ?? "",
                 TotalQuestions = snapshot.Count,
-                StartedAt      = startedAtUtc,
-                SuccessCount   = ordered.Count(r => r.Status == "success"),
-                NoAnswerCount  = ordered.Count(r => r.Status == "no_answer"),
-                ErrorCount     = ordered.Count(r => r.Status == "error"),
-                CompletedAt    = DateTime.UtcNow
+                StartedAt = startedAtUtc,
+                SuccessCount = ordered.Count(r => r.Status == "success"),
+                NoAnswerCount = ordered.Count(r => r.Status == "no_answer"),
+                ErrorCount = ordered.Count(r => r.Status == "error"),
+                CompletedAt = DateTime.UtcNow
             };
             ctx.TestRuns.Add(run);
 

--- a/project-demos/ivy-ask-statistics/Apps/TestRunResultsDialog.cs
+++ b/project-demos/ivy-ask-statistics/Apps/TestRunResultsDialog.cs
@@ -10,8 +10,8 @@ internal sealed class TestRunResultsDialog(
 {
     public override object? Build()
     {
-        var factory      = UseService<AppDbContextFactory>();
-        var client       = UseService<IClientProvider>();
+        var factory = UseService<AppDbContextFactory>();
+        var client = UseService<IClientProvider>();
         var queryService = UseService<IQueryService>();
         var refreshToken = UseRefreshToken();
 
@@ -29,8 +29,8 @@ internal sealed class TestRunResultsDialog(
             tags: [("run-results", runId.ToString())]);
 
         var firstLoad = resultsQuery.Loading && resultsQuery.Value == null;
-        var rows      = resultsQuery.Value?.Results ?? [];
-        var runInfo   = resultsQuery.Value?.RunInfo;
+        var rows = resultsQuery.Value?.Results ?? [];
+        var runInfo = resultsQuery.Value?.RunInfo;
 
         void Close() => isOpen.Set(false);
 
@@ -52,9 +52,9 @@ internal sealed class TestRunResultsDialog(
                             .Where(r => r.TestRunId == runId)
                             .ToListAsync();
                         run.TotalQuestions = remaining.Count;
-                        run.SuccessCount   = remaining.Count(r => r.IsSuccess);
-                        run.NoAnswerCount  = remaining.Count(r => !r.IsSuccess && r.HttpStatus == 404);
-                        run.ErrorCount     = remaining.Count(r => !r.IsSuccess && r.HttpStatus != 404);
+                        run.SuccessCount = remaining.Count(r => r.IsSuccess);
+                        run.NoAnswerCount = remaining.Count(r => !r.IsSuccess && r.HttpStatus == 404);
+                        run.ErrorCount = remaining.Count(r => !r.IsSuccess && r.HttpStatus != 404);
                         await ctx.SaveChangesAsync();
                     }
                 }
@@ -82,17 +82,17 @@ internal sealed class TestRunResultsDialog(
                 .Key($"run-results-tbl-{runId}")
                 .Height(Size.Units(120))
                 .RefreshToken(refreshToken)
-                .Header(r => r.Widget,        "Widget")
-                .Header(r => r.Difficulty,    "Difficulty")
-                .Header(r => r.Question,      "Question")
-                .Header(r => r.Status,        "Status")
-                .Header(r => r.Response,      "Response")
+                .Header(r => r.Widget, "Widget")
+                .Header(r => r.Difficulty, "Difficulty")
+                .Header(r => r.Question, "Question")
+                .Header(r => r.Status, "Status")
+                .Header(r => r.Response, "Response")
                 .Header(r => r.ResponseTimeMs, "Time (ms)")
-                .Width(r => r.Widget,         Size.Px(130))
-                .Width(r => r.Difficulty,     Size.Px(80))
-                .Width(r => r.Status,         Size.Px(90))
+                .Width(r => r.Widget, Size.Px(130))
+                .Width(r => r.Difficulty, Size.Px(80))
+                .Width(r => r.Status, Size.Px(90))
                 .Width(r => r.ResponseTimeMs, Size.Px(80))
-                .Width(r => r.Response,       Size.Px(300))
+                .Width(r => r.Response, Size.Px(300))
                 .Hidden(r => r.ResultId)
                 .Hidden(r => r.QuestionId)
                 .AlignContent(r => r.ResponseTimeMs, Align.Left)
@@ -102,7 +102,7 @@ internal sealed class TestRunResultsDialog(
                 .OnRowAction(e =>
                 {
                     var args = e.Value;
-                    var tag  = args?.Tag?.ToString();
+                    var tag = args?.Tag?.ToString();
                     if (!Guid.TryParse(args?.Id?.ToString(), out var resultId))
                         return ValueTask.CompletedTask;
 
@@ -133,9 +133,9 @@ internal sealed class TestRunResultsDialog(
                 })
                 .Config(c =>
                 {
-                    c.AllowSorting    = true;
-                    c.AllowFiltering  = true;
-                    c.ShowSearch      = true;
+                    c.AllowSorting = true;
+                    c.AllowFiltering = true;
+                    c.ShowSearch = true;
                     c.ShowIndexColumn = false;
                 });
         }
@@ -161,7 +161,7 @@ internal sealed class TestRunResultsDialog(
     {
         await using var ctx = factory.CreateDbContext();
 
-        var run     = await ctx.TestRuns.AsNoTracking().FirstOrDefaultAsync(r => r.Id == runId, ct);
+        var run = await ctx.TestRuns.AsNoTracking().FirstOrDefaultAsync(r => r.Id == runId, ct);
         var runInfo = run == null ? null : new RunInfo(run.IvyVersion ?? "", run.Environment ?? "production");
 
         var results = await ctx.TestResults.AsNoTracking()

--- a/project-demos/ivy-ask-statistics/Apps/WidgetQuestionsDialog.cs
+++ b/project-demos/ivy-ask-statistics/Apps/WidgetQuestionsDialog.cs
@@ -10,10 +10,10 @@ internal sealed class WidgetQuestionsDialog(
 {
     public override object? Build()
     {
-        var factory       = UseService<AppDbContextFactory>();
-        var client        = UseService<IClientProvider>();
-        var queryService  = UseService<IQueryService>();
-        var refreshToken  = UseRefreshToken();
+        var factory = UseService<AppDbContextFactory>();
+        var client = UseService<IClientProvider>();
+        var queryService = UseService<IQueryService>();
+        var refreshToken = UseRefreshToken();
 
         var (alertView, showAlert) = UseAlert();
 
@@ -29,7 +29,7 @@ internal sealed class WidgetQuestionsDialog(
             tags: [("widget-questions", widgetName)]);
 
         var firstLoad = tableQuery.Loading && tableQuery.Value == null;
-        var rows      = tableQuery.Value ?? [];
+        var rows = tableQuery.Value ?? [];
 
         void Close() => isOpen.Set(false);
 
@@ -72,15 +72,15 @@ internal sealed class WidgetQuestionsDialog(
                 .Key($"widget-questions-{widgetName}")
                 .Height(Size.Units(120))
                 .RefreshToken(refreshToken)
-                .Header(r => r.Difficulty,   "Difficulty")
-                .Header(r => r.Category,     "Category")
+                .Header(r => r.Difficulty, "Difficulty")
+                .Header(r => r.Category, "Category")
                 .Header(r => r.QuestionText, "Question")
-                .Header(r => r.Source,       "Source")
-                .Header(r => r.CreatedAt,    "Created")
-                .Width(r => r.Difficulty,    Size.Px(80))
-                .Width(r => r.QuestionText,  Size.Px(340))
-                .Width(r => r.Source,        Size.Px(100))
-                .Width(r => r.CreatedAt,     Size.Px(170))
+                .Header(r => r.Source, "Source")
+                .Header(r => r.CreatedAt, "Created")
+                .Width(r => r.Difficulty, Size.Px(80))
+                .Width(r => r.QuestionText, Size.Px(340))
+                .Width(r => r.Source, Size.Px(100))
+                .Width(r => r.CreatedAt, Size.Px(170))
                 .Hidden(r => r.Id)
                 .RowActions(
                     MenuItem.Default(Icons.Pencil, "edit").Label("Edit").Tag("edit"),
@@ -88,7 +88,7 @@ internal sealed class WidgetQuestionsDialog(
                 .OnRowAction(e =>
                 {
                     var args = e.Value;
-                    var tag  = args?.Tag?.ToString();
+                    var tag = args?.Tag?.ToString();
                     if (!Guid.TryParse(args?.Id?.ToString(), out var id)) return ValueTask.CompletedTask;
 
                     if (tag == "edit")
@@ -99,7 +99,7 @@ internal sealed class WidgetQuestionsDialog(
                     }
                     else if (tag == "delete")
                     {
-                        var text    = rows.FirstOrDefault(r => r.Id == id)?.QuestionText ?? "";
+                        var text = rows.FirstOrDefault(r => r.Id == id)?.QuestionText ?? "";
                         var preview = text.Length > 60 ? text[..60] + "…" : text;
                         showAlert(
                             $"Delete this question?\n\n\"{preview}\"",
@@ -116,9 +116,9 @@ internal sealed class WidgetQuestionsDialog(
                 })
                 .Config(c =>
                 {
-                    c.AllowSorting    = true;
-                    c.AllowFiltering  = true;
-                    c.ShowSearch      = true;
+                    c.AllowSorting = true;
+                    c.AllowFiltering = true;
+                    c.ShowSearch = true;
                     c.ShowIndexColumn = false;
                 });
         }

--- a/project-demos/ivy-ask-statistics/Connections/AppConnection.cs
+++ b/project-demos/ivy-ask-statistics/Connections/AppConnection.cs
@@ -1,6 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-
 namespace IvyAskStatistics.Connections;
 
 public class AppConnection : IConnection

--- a/project-demos/ivy-ask-statistics/Connections/AppDbContext.cs
+++ b/project-demos/ivy-ask-statistics/Connections/AppDbContext.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-
 namespace IvyAskStatistics.Connections;
 
 public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)

--- a/project-demos/ivy-ask-statistics/Connections/AppDbContextFactory.cs
+++ b/project-demos/ivy-ask-statistics/Connections/AppDbContextFactory.cs
@@ -1,6 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-
 namespace IvyAskStatistics.Connections;
 
 public sealed class AppDbContextFactory : IDbContextFactory<AppDbContext>

--- a/project-demos/ivy-ask-statistics/Connections/Auth/BasicAuthConnection.cs
+++ b/project-demos/ivy-ask-statistics/Connections/Auth/BasicAuthConnection.cs
@@ -1,6 +1,3 @@
-using Ivy;
-using Microsoft.Extensions.Configuration;
-
 namespace IvyAskStatistics.Connections.Auth;
 
 public class BasicAuthConnection : IConnection, IHaveSecrets

--- a/project-demos/ivy-ask-statistics/Connections/QuestionEntity.cs
+++ b/project-demos/ivy-ask-statistics/Connections/QuestionEntity.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace IvyAskStatistics.Connections;

--- a/project-demos/ivy-ask-statistics/Connections/TestRunEntity.cs
+++ b/project-demos/ivy-ask-statistics/Connections/TestRunEntity.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace IvyAskStatistics.Connections;

--- a/project-demos/ivy-ask-statistics/Connections/TestRunResultEntity.cs
+++ b/project-demos/ivy-ask-statistics/Connections/TestRunResultEntity.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace IvyAskStatistics.Connections;

--- a/project-demos/ivy-ask-statistics/Services/IvyAskService.cs
+++ b/project-demos/ivy-ask-statistics/Services/IvyAskService.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using IvyAskStatistics.Connections;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 
 namespace IvyAskStatistics.Services;
 

--- a/project-demos/ivy-ask-statistics/Services/QuestionGeneratorService.cs
+++ b/project-demos/ivy-ask-statistics/Services/QuestionGeneratorService.cs
@@ -1,6 +1,3 @@
-using IvyAskStatistics.Connections;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using OpenAI;
 using OpenAI.Chat;
 using System.ClientModel;
@@ -76,12 +73,12 @@ public static class QuestionGeneratorService
 
             ctx.Questions.AddRange(questions.Select(q => new QuestionEntity
             {
-                Widget     = widget.Name,
-                Category   = widget.Category,
+                Widget = widget.Name,
+                Category = widget.Category,
                 Difficulty = difficulty,
                 QuestionText = q,
-                Source     = "openai_docs",
-                CreatedAt  = DateTime.UtcNow
+                Source = "openai_docs",
+                CreatedAt = DateTime.UtcNow
             }));
 
             await ctx.SaveChangesAsync(ct);
@@ -118,9 +115,9 @@ public static class QuestionGeneratorService
     {
         var difficultyHint = difficulty switch
         {
-            "easy"   => "basic usage, creating the widget, simple properties",
+            "easy" => "basic usage, creating the widget, simple properties",
             "medium" => "events, styling, configuration, common patterns",
-            _        => "advanced composition, edge cases, integration with other Ivy widgets"
+            _ => "advanced composition, edge cases, integration with other Ivy widgets"
         };
 
         var system = new SystemChatMessage("""

--- a/project-demos/ivy-ask-statistics/ivy-ask-statistics.sln
+++ b/project-demos/ivy-ask-statistics/ivy-ask-statistics.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IvyAskStatistics", "IvyAskStatistics.csproj", "{749F362C-0241-41C7-8020-A8C5030FC5C5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|x64.Build.0 = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Debug|x86.Build.0 = Debug|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|x64.ActiveCfg = Release|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|x64.Build.0 = Release|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|x86.ActiveCfg = Release|Any CPU
+		{749F362C-0241-41C7-8020-A8C5030FC5C5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/llm-tornado-ollama/Apps/AgentChatBlade.cs
+++ b/project-demos/llm-tornado-ollama/Apps/AgentChatBlade.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Linq;
 using LlmTornado.Agents.DataModels;
 
 namespace LlmTornadoExample.Apps;

--- a/project-demos/llm-tornado-ollama/GlobalUsings.cs
+++ b/project-demos/llm-tornado-ollama/GlobalUsings.cs
@@ -1,16 +1,10 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text;
 global using LlmTornado;
 global using LlmTornado.Chat;
-global using LlmTornado.ChatFunctions;
-global using LlmTornado.Code;
 global using LlmTornado.Agents;
 global using Chat = Ivy.Chat;
 global using ChatMessage = Ivy.ChatMessage;

--- a/project-demos/llm-tornado-ollama/llm-tornado-ollama.sln
+++ b/project-demos/llm-tornado-ollama/llm-tornado-ollama.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LlmTornadoExample", "LlmTornadoExample.csproj", "{BFDB3D09-8627-4C08-861C-23BAF6796029}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|x64.Build.0 = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Debug|x86.Build.0 = Debug|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|x64.ActiveCfg = Release|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|x64.Build.0 = Release|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|x86.ActiveCfg = Release|Any CPU
+		{BFDB3D09-8627-4C08-861C-23BAF6796029}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/llm-tornado-openai/Apps/AgentChatBlade.cs
+++ b/project-demos/llm-tornado-openai/Apps/AgentChatBlade.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Linq;
 using LlmTornado.Agents.DataModels;
 
 namespace LlmTornadoExample.Apps;

--- a/project-demos/llm-tornado-openai/GlobalUsings.cs
+++ b/project-demos/llm-tornado-openai/GlobalUsings.cs
@@ -1,16 +1,11 @@
 global using Ivy;
 global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using System.Text;
 global using LlmTornado;
 global using LlmTornado.Chat;
-global using LlmTornado.ChatFunctions;
-global using LlmTornado.Code;
 global using LlmTornado.Agents;
 global using Chat = Ivy.Chat;
 global using ChatMessage = Ivy.ChatMessage;

--- a/project-demos/llm-tornado-openai/llm-tornado-openai.sln
+++ b/project-demos/llm-tornado-openai/llm-tornado-openai.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LlmTornadoExample", "LlmTornadoExample.csproj", "{A379986A-E794-4E6A-8C33-DE78DA1AABCA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|x64.Build.0 = Release|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{A379986A-E794-4E6A-8C33-DE78DA1AABCA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/microsoft-agent-framework/Apps/AgentWorkspaceExample.cs
+++ b/project-demos/microsoft-agent-framework/Apps/AgentWorkspaceExample.cs
@@ -1,7 +1,3 @@
-using MicrosoftAgentFramework.Models;
-using MicrosoftAgentFramework.Views;
-using OllamaSharp;
-
 namespace MicrosoftAgentFramework.Apps;
 
 [App(icon: Icons.Bot, title: "Microsoft Agent Framework")]
@@ -11,7 +7,7 @@ public class AgentWorkspaceExample : ViewBase
     {
         // State for agents list (including presets)
         var agents = UseState(GetPresetAgents());
-        
+
         // Ollama configuration state
         var ollamaUrl = UseState<string?>(Environment.GetEnvironmentVariable("OLLAMA_URL") ?? "http://localhost:11434");
         var ollamaModel = UseState<string?>(Environment.GetEnvironmentVariable("OLLAMA_MODEL") ?? "llama2");

--- a/project-demos/microsoft-agent-framework/GlobalUsings.cs
+++ b/project-demos/microsoft-agent-framework/GlobalUsings.cs
@@ -1,14 +1,9 @@
 global using Ivy;
-global using Microsoft.Extensions.Configuration;
-global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
 global using System.Collections.Immutable;
 global using System.ComponentModel;
 global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
-global using System.Text.Json;
-global using System.Text.Json.Serialization;
 global using MicrosoftAgentFramework.Models;
 global using MicrosoftAgentFramework.Views;
 global using MicrosoftAgentFramework.Services;

--- a/project-demos/microsoft-agent-framework/Models/AgentConfiguration.cs
+++ b/project-demos/microsoft-agent-framework/Models/AgentConfiguration.cs
@@ -11,7 +11,7 @@ public class AgentConfiguration
     public string Instructions { get; set; } = "You are a helpful AI assistant.";
     public string OllamaModel { get; set; } = "llama2";
     public bool IsPreset { get; set; } = false;
-    
+
     public AgentConfiguration Clone()
     {
         return new AgentConfiguration
@@ -34,16 +34,16 @@ public record AgentFormModel
     [Required]
     [StringLength(50, MinimumLength = 1)]
     public string Name { get; set; } = "New Agent";
-    
+
     [StringLength(200)]
     public string Description { get; set; } = string.Empty;
-    
+
     [Required]
     public string OllamaModel { get; set; } = "llama2";
-    
+
     [Required]
     public string Instructions { get; set; } = "You are a helpful AI assistant.";
-    
+
     public static AgentFormModel FromConfiguration(AgentConfiguration config)
     {
         return new AgentFormModel
@@ -54,7 +54,7 @@ public record AgentFormModel
             Instructions = config.Instructions
         };
     }
-    
+
     public AgentConfiguration ToConfiguration(string? existingId = null)
     {
         return new AgentConfiguration
@@ -67,7 +67,7 @@ public record AgentFormModel
             IsPreset = false
         };
     }
-    
+
     public void ApplyTo(AgentConfiguration config)
     {
         config.Name = Name;
@@ -83,9 +83,9 @@ public record AgentFormModel
 public record ApiSettingsModel
 {
     public string OllamaUrl { get; set; } = "http://localhost:11434";
-    
+
     public string OllamaModel { get; set; } = "llama2";
-    
+
     public string BingApiKey { get; set; } = string.Empty;
 }
 

--- a/project-demos/microsoft-agent-framework/Program.cs
+++ b/project-demos/microsoft-agent-framework/Program.cs
@@ -7,7 +7,7 @@ server.UseHotReload();
 server.AddAppsFromAssembly();
 server.AddConnectionsFromAssembly();
 var customHeader = Layout.Vertical().Gap(2)
-    |new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmicrosoft_agent_framework%2Fdevcontainer.json&location=EuropeWest");
+    | new Embed("https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=Ivy-Interactive%2FIvy-Examples&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fmicrosoft_agent_framework%2Fdevcontainer.json&location=EuropeWest");
 var appShellSettings = new AppShellSettings()
     .DefaultApp<AgentWorkspaceExample>()
     .UseTabs(preventDuplicates: true)

--- a/project-demos/microsoft-agent-framework/Services/AgentManager.cs
+++ b/project-demos/microsoft-agent-framework/Services/AgentManager.cs
@@ -1,7 +1,5 @@
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
-using OllamaSharp;
-using MicrosoftAgentFramework.Models;
 
 namespace MicrosoftAgentFramework.Services;
 
@@ -30,12 +28,12 @@ public class AgentManager : IDisposable
     public void ConfigureAgent(AgentConfiguration config)
     {
         _currentConfig = config;
-        
+
         // Use model from agent configuration, fallback to constructor model if not set
-        var modelToUse = !string.IsNullOrWhiteSpace(config.OllamaModel) 
-            ? config.OllamaModel 
+        var modelToUse = !string.IsNullOrWhiteSpace(config.OllamaModel)
+            ? config.OllamaModel
             : _ollamaModel;
-        
+
         // Create OllamaApiClient which implements IChatClient
         var ollamaClient = new OllamaApiClient(new Uri(_ollamaUrl), modelToUse);
 
@@ -71,7 +69,7 @@ public class AgentManager : IDisposable
             // Run agent using Microsoft Agent Framework
             // Tools are not used for now
             var response = await _agent.RunAsync(userMessage);
-            
+
             return response.Text ?? response.ToString() ?? "I couldn't generate a response.";
         }
         catch (Exception ex)

--- a/project-demos/microsoft-agent-framework/Services/AgentTools.cs
+++ b/project-demos/microsoft-agent-framework/Services/AgentTools.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 namespace MicrosoftAgentFramework.Services;
 
 /// <summary>
@@ -12,11 +10,11 @@ public static class AgentTools
     /// </summary>
     [Description("Get the current date and time. Useful for answering questions about what day it is, what time it is, or scheduling-related queries.")]
     public static string GetCurrentTime(
-        [Description("The timezone to get the time for (optional, defaults to local time). Examples: 'UTC', 'America/New_York', 'Europe/London'.")] 
+        [Description("The timezone to get the time for (optional, defaults to local time). Examples: 'UTC', 'America/New_York', 'Europe/London'.")]
         string? timezone = null)
     {
         var now = DateTime.Now;
-        
+
         if (!string.IsNullOrWhiteSpace(timezone))
         {
             try
@@ -29,7 +27,7 @@ public static class AgentTools
                 // If timezone is invalid, use local time
             }
         }
-        
+
         return $"Current date and time: {now:yyyy-MM-dd HH:mm:ss} ({now:dddd})";
     }
 
@@ -38,14 +36,14 @@ public static class AgentTools
     /// </summary>
     [Description("Perform mathematical calculations. Can handle basic arithmetic (+, -, *, /), powers (^), and common functions like sqrt, sin, cos, etc. Use this when the user asks to calculate something, solve a math problem, or perform computations.")]
     public static string Calculate(
-        [Description("The mathematical expression to evaluate. Examples: '2 + 2', '10 * 5', 'sqrt(16)', '2^3', '(10 + 5) / 3'.")] 
+        [Description("The mathematical expression to evaluate. Examples: '2 + 2', '10 * 5', 'sqrt(16)', '2^3', '(10 + 5) / 3'.")]
         string expression)
     {
         try
         {
             // Simple calculation using DataTable.Compute for safety
             var dataTable = new System.Data.DataTable();
-            
+
             // Replace common math functions
             expression = expression.Replace("sqrt", "Math.Sqrt", StringComparison.OrdinalIgnoreCase);
             expression = expression.Replace("sin", "Math.Sin", StringComparison.OrdinalIgnoreCase);
@@ -53,10 +51,10 @@ public static class AgentTools
             expression = expression.Replace("tan", "Math.Tan", StringComparison.OrdinalIgnoreCase);
             expression = expression.Replace("log", "Math.Log", StringComparison.OrdinalIgnoreCase);
             expression = expression.Replace("^", "Pow", StringComparison.OrdinalIgnoreCase);
-            
+
             // For simple expressions, use DataTable.Compute
             // For more complex expressions with functions, use a simple evaluator
-            if (expression.Contains("Math.", StringComparison.OrdinalIgnoreCase) || 
+            if (expression.Contains("Math.", StringComparison.OrdinalIgnoreCase) ||
                 expression.Contains("Pow", StringComparison.OrdinalIgnoreCase))
             {
                 // Use C# expression evaluator for complex math
@@ -88,24 +86,24 @@ public static class AgentTools
                     return " + expression + @"; 
                 } 
             }";
-        
+
         // For now, use a simpler approach
         // Replace Math functions with actual values
         expression = System.Text.RegularExpressions.Regex.Replace(
-            expression, 
-            @"Math\.Sqrt\(([^)]+)\)", 
+            expression,
+            @"Math\.Sqrt\(([^)]+)\)",
             m => Math.Sqrt(double.Parse(m.Groups[1].Value)).ToString());
-        
+
         expression = System.Text.RegularExpressions.Regex.Replace(
-            expression, 
-            @"Math\.Sin\(([^)]+)\)", 
+            expression,
+            @"Math\.Sin\(([^)]+)\)",
             m => Math.Sin(double.Parse(m.Groups[1].Value)).ToString());
-        
+
         expression = System.Text.RegularExpressions.Regex.Replace(
-            expression, 
-            @"Math\.Cos\(([^)]+)\)", 
+            expression,
+            @"Math\.Cos\(([^)]+)\)",
             m => Math.Cos(double.Parse(m.Groups[1].Value)).ToString());
-        
+
         var dataTable = new System.Data.DataTable();
         return Convert.ToDouble(dataTable.Compute(expression, null));
     }
@@ -126,10 +124,10 @@ public static class AgentTools
             {
                 using var httpClient = new HttpClient();
                 httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", bingApiKey);
-                
+
                 var searchUrl = $"https://api.bing.microsoft.com/v7.0/search?q={Uri.EscapeDataString(query)}&count=5";
                 var response = await httpClient.GetStringAsync(searchUrl);
-                
+
                 // Parse JSON response (simplified - in production use proper JSON parsing)
                 // For now, return a simple message
                 return $"Web search results for '{query}': Search completed. (Note: Full results parsing requires JSON deserialization. This is a simplified implementation.)";
@@ -159,7 +157,7 @@ public class SearchWebTool
     /// </summary>
     [Description("Search the web for current information, news, or facts. Use this when the user asks about recent events, current information, or anything that requires up-to-date data from the internet. Requires Bing Search API key to be configured.")]
     public async Task<string> SearchWeb(
-        [Description("The search query to look up on the web.")] 
+        [Description("The search query to look up on the web.")]
         string query)
     {
         if (string.IsNullOrWhiteSpace(_bingApiKey))
@@ -171,10 +169,10 @@ public class SearchWebTool
         {
             using var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", _bingApiKey);
-            
+
             var searchUrl = $"https://api.bing.microsoft.com/v7.0/search?q={Uri.EscapeDataString(query)}&count=5";
             var response = await httpClient.GetStringAsync(searchUrl);
-            
+
             // Parse JSON response (simplified - in production use proper JSON parsing)
             // For now, return a simple message
             return $"Web search results for '{query}': Search completed. (Note: Full results parsing requires JSON deserialization. This is a simplified implementation.)";

--- a/project-demos/microsoft-agent-framework/Views/AgentChatView.cs
+++ b/project-demos/microsoft-agent-framework/Views/AgentChatView.cs
@@ -1,5 +1,3 @@
-using OllamaSharp;
-
 namespace MicrosoftAgentFramework.Views;
 
 /// <summary>
@@ -144,17 +142,17 @@ public class AgentChatView : ViewBase
                     if (!string.IsNullOrEmpty(textUpdate))
                     {
                         streamingText.Append(textUpdate);
-                        
+
                         // If this is the first word, replace waiting status with actual text
                         if (isWaitingForFirstWord)
                         {
                             isWaitingForFirstWord = false;
                         }
-                        
+
                         // Update the assistant message with accumulated text
                         var currentMessagesList = messages.Value.ToList();
                         currentMessagesList[assistantMessageIndex] = new Ivy.ChatMessage(
-                            ChatSender.Assistant, 
+                            ChatSender.Assistant,
                             Text.Markdown(streamingText.ToString())
                         );
                         messages.Set(currentMessagesList.ToImmutableArray());
@@ -166,7 +164,7 @@ public class AgentChatView : ViewBase
                 // Replace streaming message with error
                 var currentMessagesList = messages.Value.ToList();
                 currentMessagesList[assistantMessageIndex] = new Ivy.ChatMessage(
-                    ChatSender.Assistant, 
+                    ChatSender.Assistant,
                     $"Error: {ex.Message}"
                 );
                 messages.Set(currentMessagesList.ToImmutableArray());
@@ -181,11 +179,11 @@ public class AgentChatView : ViewBase
                 {
                     var models = availableModels.Value;
                     if (models.IsEmpty) return Task.FromResult(Array.Empty<Option<string>>());
-                    
-                    var filtered = string.IsNullOrEmpty(query) 
-                        ? models.Take(10) 
+
+                    var filtered = string.IsNullOrEmpty(query)
+                        ? models.Take(10)
                         : models.Where(m => m.Contains(query, StringComparison.OrdinalIgnoreCase));
-                    
+
                     return Task.FromResult(filtered.Select(m => new Option<string>(m)).ToArray());
                 });
         }
@@ -213,15 +211,15 @@ public class AgentChatView : ViewBase
                 isEditDialogOpen.Set(true);
             }).Ghost().Tooltip("Edit agent settings");
 
-         
-        
+
+
         var editDialog = isEditDialogOpen.Value
             ? editForm.ToForm()
                 .Builder(e => e.Name, e => e.ToTextInput(placeholder: "Agent name..."))
                 .Label(e => e.Name, "Name")
                 .Builder(e => e.Description, e => e.ToTextInput(placeholder: "Short description..."))
                 .Label(e => e.Description, "Description")
-                .Builder(e => e.OllamaModel,e => modelState.ToAsyncSelectInput<string>(QueryModels, LookupModel, placeholder: "Search models..."))
+                .Builder(e => e.OllamaModel, e => modelState.ToAsyncSelectInput<string>(QueryModels, LookupModel, placeholder: "Search models..."))
                 .Label(e => e.OllamaModel, "Ollama Model")
                 .Builder(e => e.Instructions, e => e.ToTextareaInput(placeholder: "Instructions for the AI agent...")
                     .Height(Size.Units(50)))

--- a/project-demos/microsoft-agent-framework/Views/AgentListView.cs
+++ b/project-demos/microsoft-agent-framework/Views/AgentListView.cs
@@ -63,12 +63,12 @@ public class AgentListView : ViewBase
                 isSettingsOpen.Set(true);
                 return;
             }
-            
+
             // Use agent's model if set, otherwise fall back to global model
-            var modelToUse = !string.IsNullOrWhiteSpace(agent.OllamaModel) 
-                ? agent.OllamaModel 
+            var modelToUse = !string.IsNullOrWhiteSpace(agent.OllamaModel)
+                ? agent.OllamaModel
                 : (_ollamaModel.Value ?? "llama2");
-            
+
             blades.Push(this, new AgentChatView(agent, _agents, _ollamaUrl.Value!, modelToUse, _bingApiKey.Value), agent.Name, Size.Units(220));
         }
 
@@ -89,14 +89,14 @@ public class AgentListView : ViewBase
         async Task<AgentConfiguration[]> FetchAgents(string filter)
         {
             await Task.CompletedTask; // Make it async for FilteredListView
-            
+
             var allAgents = _agents.Value?.ToList() ?? new List<AgentConfiguration>();
-            
+
             if (!string.IsNullOrWhiteSpace(filter))
             {
                 filter = filter.Trim();
                 allAgents = allAgents
-                    .Where(a => a != null && 
+                    .Where(a => a != null &&
                                (a.Name?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false) ||
                                (a.Description?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false))
                     .ToList();

--- a/project-demos/microsoft-agent-framework/Views/AgentSettingsView.cs
+++ b/project-demos/microsoft-agent-framework/Views/AgentSettingsView.cs
@@ -70,11 +70,11 @@ public class AgentSettingsView : ViewBase
                 {
                     var models = availableModels.Value;
                     if (models.IsEmpty) return Task.FromResult(Array.Empty<Option<string>>());
-                    
-                    var filtered = string.IsNullOrEmpty(query) 
-                        ? models.Take(10) 
+
+                    var filtered = string.IsNullOrEmpty(query)
+                        ? models.Take(10)
                         : models.Where(m => m.Contains(query, StringComparison.OrdinalIgnoreCase));
-                    
+
                     return Task.FromResult(filtered.Select(m => new Option<string>(m)).ToArray());
                 });
         }
@@ -132,7 +132,7 @@ public class AgentSettingsView : ViewBase
 
         // Model selector using AsyncSelectInput or TextInput as fallback
         var modelInput = modelState.ToAsyncSelectInput<string>(QueryModels, LookupModel, placeholder: "Search models...").Disabled(isReadOnly);
-        
+
 
         var formContent = new Card(Layout.Vertical().Gap(3).Padding(2)
             | (Layout.Vertical().Gap(1)

--- a/project-demos/microsoft-agent-framework/microsoft-agent-framework.sln
+++ b/project-demos/microsoft-agent-framework/microsoft-agent-framework.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MicrosoftAgentFramework", "MicrosoftAgentFramework.csproj", "{62AAF65A-842A-4230-8335-90DD24F6EBF7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|x64.Build.0 = Release|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{62AAF65A-842A-4230-8335-90DD24F6EBF7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/pr-staging-deploy/Connections/Auth/BasicAuthConnection.cs
+++ b/project-demos/pr-staging-deploy/Connections/Auth/BasicAuthConnection.cs
@@ -1,6 +1,3 @@
-using Ivy;
-using Microsoft.Extensions.Configuration;
-
 namespace PrStagingDeploy.Connections.Auth;
 
 public class BasicAuthConnection : IConnection, IHaveSecrets

--- a/project-demos/pr-staging-deploy/GlobalUsings.cs
+++ b/project-demos/pr-staging-deploy/GlobalUsings.cs
@@ -1,8 +1,5 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Logging;

--- a/project-demos/pr-staging-deploy/Program.cs
+++ b/project-demos/pr-staging-deploy/Program.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using PrStagingDeploy.Apps;
 using PrStagingDeploy.Services;
-using Ivy;
 
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 

--- a/project-demos/pr-staging-deploy/Services/GitHubWebhookHandler.cs
+++ b/project-demos/pr-staging-deploy/Services/GitHubWebhookHandler.cs
@@ -2,7 +2,6 @@ namespace PrStagingDeploy.Services;
 
 using System.Security.Cryptography;
 using System.Text;
-using PrStagingDeploy.Models;
 
 /// <summary>
 /// Handles GitHub webhooks: pull_request (opened/reopened/synchronize → deploy; closed → delete staging), issue_comment (/deploy).

--- a/project-demos/pr-staging-deploy/pr-staging-deploy.sln
+++ b/project-demos/pr-staging-deploy/pr-staging-deploy.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrStagingDeploy", "PrStagingDeploy.csproj", "{382CD712-FD17-41A3-B8BA-D894E1820DB0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|x64.Build.0 = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Debug|x86.Build.0 = Debug|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|x64.ActiveCfg = Release|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|x64.Build.0 = Release|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|x86.ActiveCfg = Release|Any CPU
+		{382CD712-FD17-41A3-B8BA-D894E1820DB0}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyDetailsBlade.cs
+++ b/project-demos/showcase-crm/Apps/Views/CompaniesApp.CompanyDetailsBlade.cs
@@ -102,7 +102,7 @@ public class CompanyDetailsBlade(int companyId) : ViewBase
                 .RemoveEmpty()
                 .Builder(e => e.Id, e => e.CopyToClipboard()),
             footer: Layout.Horizontal().Gap(2).AlignContent(Align.Right)
-                    | deleteBtn 
+                    | deleteBtn
                     | editBtn
         ).Title("Company Details").Width(Size.Units(100));
 

--- a/project-demos/showcase-crm/Connections/Company.cs
+++ b/project-demos/showcase-crm/Connections/Company.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/Contact.cs
+++ b/project-demos/showcase-crm/Connections/Contact.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/Deal.cs
+++ b/project-demos/showcase-crm/Connections/Deal.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/DealStage.cs
+++ b/project-demos/showcase-crm/Connections/DealStage.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/EfmigrationsLock.cs
+++ b/project-demos/showcase-crm/Connections/EfmigrationsLock.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/Lead.cs
+++ b/project-demos/showcase-crm/Connections/Lead.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/LeadStatus.cs
+++ b/project-demos/showcase-crm/Connections/LeadStatus.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/Connections/Migrations/20260220084928_InitialCreate.cs
+++ b/project-demos/showcase-crm/Connections/Migrations/20260220084928_InitialCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/project-demos/showcase-crm/Connections/ShowcaseCrmContext.cs
+++ b/project-demos/showcase-crm/Connections/ShowcaseCrmContext.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore;
-
-namespace ShowcaseCrm.Connections.ShowcaseCrm;
+﻿namespace ShowcaseCrm.Connections.ShowcaseCrm;
 
 public partial class ShowcaseCrmContext : DbContext
 {

--- a/project-demos/showcase-crm/Connections/ShowcaseCrmContextFactory.cs
+++ b/project-demos/showcase-crm/Connections/ShowcaseCrmContextFactory.cs
@@ -1,10 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using System.Threading;
-using System.Reflection;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 
 public sealed class ShowcaseCrmContextFactory : IDbContextFactory<ShowcaseCrmContext>

--- a/project-demos/showcase-crm/Connections/User.cs
+++ b/project-demos/showcase-crm/Connections/User.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.EntityFrameworkCore;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ShowcaseCrm.Connections.ShowcaseCrm;
 

--- a/project-demos/showcase-crm/GlobalUsings.cs
+++ b/project-demos/showcase-crm/GlobalUsings.cs
@@ -1,8 +1,5 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;

--- a/project-demos/showcase-crm/showcase-crm.sln
+++ b/project-demos/showcase-crm/showcase-crm.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShowcaseCrm", "ShowcaseCrm.csproj", "{E07BF30A-F848-4870-8577-ABFBAC20EAE7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|x64.Build.0 = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Debug|x86.Build.0 = Debug|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|x64.ActiveCfg = Release|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|x64.Build.0 = Release|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|x86.ActiveCfg = Release|Any CPU
+		{E07BF30A-F848-4870-8577-ABFBAC20EAE7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployStatusView.cs
@@ -95,9 +95,9 @@ public class DeployStatusView : ViewBase
         if (last == null) return DeployStatus.Unknown;
         return last.Type switch
         {
-            "service_deploy_success"                           => DeployStatus.Success,
+            "service_deploy_success" => DeployStatus.Success,
             "service_deploy_failed" or "service_build_failed" => DeployStatus.Failed,
-            _                                                  => DeployStatus.Deploying,
+            _ => DeployStatus.Deploying,
         };
     }
 

--- a/project-demos/sliplane-deploy/sliplane-deploy.sln
+++ b/project-demos/sliplane-deploy/sliplane-deploy.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SliplaneDeploy", "SliplaneDeploy.csproj", "{243D802A-DC67-4E24-9FFA-0CF49FF9018D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|x64.Build.0 = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Debug|x86.Build.0 = Debug|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|x64.ActiveCfg = Release|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|x64.Build.0 = Release|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|x86.ActiveCfg = Release|Any CPU
+		{243D802A-DC67-4E24-9FFA-0CF49FF9018D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/sliplane-manage/GlobalUsings.cs
+++ b/project-demos/sliplane-manage/GlobalUsings.cs
@@ -1,15 +1,8 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Http;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.Text.Json;
-global using System.ComponentModel.DataAnnotations;
 global using System.Globalization;
 global using System.Reactive.Linq;
 

--- a/project-demos/sliplane-manage/sliplane-manage.sln
+++ b/project-demos/sliplane-manage/sliplane-manage.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SliplaneManage", "SliplaneManage.csproj", "{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|x64.Build.0 = Release|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F1C2BA2-8319-4654-8BB0-3A701F4D613E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/snowflake-dashboard/Apps/DashboardApp.cs
+++ b/project-demos/snowflake-dashboard/Apps/DashboardApp.cs
@@ -5,7 +5,7 @@ public class DashboardApp : ViewBase
 {
     private const int LIMIT = 25;
     private const float CONTENT_WIDTH = 0.7f;
-    
+
     public override object? Build()
     {
         var refreshToken = this.UseRefreshToken();
@@ -220,7 +220,7 @@ public class DashboardApp : ViewBase
                 .Title($"Top {LIMIT} Brands")
                 .Width(Size.Fraction(CONTENT_WIDTH));
     }
-    
+
     private class BrandStats
     {
         public string Brand { get; set; } = "";
@@ -229,19 +229,19 @@ public class DashboardApp : ViewBase
         public double MinPrice { get; set; }
         public double MaxPrice { get; set; }
     }
-    
+
     private class SizeStats
     {
         public long Size { get; set; }
         public long Count { get; set; }
     }
-    
+
     private class ContainerStats
     {
         public string Container { get; set; } = "";
         public long Count { get; set; }
     }
-    
+
     // Helper methods
     private async Task<List<BrandStats>> LoadBrandsAsync(SnowflakeService service, int limit)
     {
@@ -257,7 +257,7 @@ public class DashboardApp : ViewBase
             GROUP BY P_BRAND
             ORDER BY ItemCount DESC
             LIMIT {limit}";
-        
+
         var result = await service.ExecuteQueryAsync(sql);
         return result.Rows.Cast<System.Data.DataRow>()
             .Select(row => new BrandStats
@@ -270,21 +270,21 @@ public class DashboardApp : ViewBase
             })
             .ToList();
     }
-    
+
     private void CalculateBrandStatistics(List<BrandStats> brands, IState<long> totalItems, IState<double> avgPrice, IState<double> minPrice, IState<double> maxPrice)
     {
         if (brands.Count == 0) return;
-        
+
         totalItems.Value = brands.Sum(b => b.ItemCount);
         avgPrice.Value = brands.Average(b => b.AvgPrice);
         minPrice.Value = brands.Min(b => b.MinPrice);
         maxPrice.Value = brands.Max(b => b.MaxPrice);
     }
-    
+
     private async Task LoadPopularBrandDataAsync(SnowflakeService service, string brand, IState<List<SizeStats>> popularBrandSizes, IState<List<ContainerStats>> popularBrandContainers)
     {
         var escapedBrand = brand.Replace("'", "''");
-        
+
         // Load sizes
         var sizesSql = $@"
             SELECT P_SIZE as Size, COUNT(*) as Count
@@ -292,7 +292,7 @@ public class DashboardApp : ViewBase
             WHERE P_BRAND = '{escapedBrand}' AND P_SIZE IS NOT NULL
             GROUP BY P_SIZE
             ORDER BY Count DESC";
-        
+
         var sizesResult = await service.ExecuteQueryAsync(sizesSql);
         popularBrandSizes.Value = sizesResult.Rows.Cast<System.Data.DataRow>()
             .Select(row => new SizeStats
@@ -301,7 +301,7 @@ public class DashboardApp : ViewBase
                 Count = Convert.ToInt64(row["Count"] ?? 0)
             })
             .ToList();
-        
+
         // Load containers
         var containersSql = $@"
             SELECT P_CONTAINER as Container, COUNT(*) as Count
@@ -309,7 +309,7 @@ public class DashboardApp : ViewBase
             WHERE P_BRAND = '{escapedBrand}' AND P_CONTAINER IS NOT NULL
             GROUP BY P_CONTAINER
             ORDER BY Count DESC";
-        
+
         var containersResult = await service.ExecuteQueryAsync(containersSql);
         popularBrandContainers.Value = containersResult.Rows.Cast<System.Data.DataRow>()
             .Select(row => new ContainerStats
@@ -319,7 +319,7 @@ public class DashboardApp : ViewBase
             })
             .ToList();
     }
-    
+
     private async Task<List<ContainerStats>> LoadContainersAsync(SnowflakeService service, int limit)
     {
         var sql = $@"
@@ -329,7 +329,7 @@ public class DashboardApp : ViewBase
             GROUP BY P_CONTAINER
             ORDER BY Count DESC
             LIMIT {limit}";
-        
+
         var result = await service.ExecuteQueryAsync(sql);
         return result.Rows.Cast<System.Data.DataRow>()
             .Select(row => new ContainerStats

--- a/project-demos/snowflake-dashboard/Connections/SnowflakeConnection.cs
+++ b/project-demos/snowflake-dashboard/Connections/SnowflakeConnection.cs
@@ -3,7 +3,7 @@ namespace SnowflakeDashboard.Connections;
 public class SnowflakeConnection : IConnection
 {
     public SnowflakeConnection() { }
-    
+
     public string GetConnectionType() => typeof(SnowflakeConnection).ToString();
     public string GetContext(string connectionPath) => throw new NotImplementedException();
     public ConnectionEntity[] GetEntities() => throw new NotImplementedException();
@@ -40,16 +40,16 @@ public class SnowflakeConnection : IConnection
             var account = configuration["Snowflake:Account"];
             var user = configuration["Snowflake:User"];
             var password = configuration["Snowflake:Password"];
-            
+
             if (string.IsNullOrWhiteSpace(account) || string.IsNullOrWhiteSpace(user) || string.IsNullOrWhiteSpace(password))
             {
                 return new SnowflakeService("");
             }
-            
+
             var connString = $"account={account};user={user};password={password};";
             return new SnowflakeService(connString);
         });
     }
-    
+
     public string GetConnectionString(IConfiguration configuration) => "";
 }

--- a/project-demos/snowflake-dashboard/GlobalUsings.cs
+++ b/project-demos/snowflake-dashboard/GlobalUsings.cs
@@ -1,18 +1,10 @@
 global using Ivy;
-global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
-global using System.ComponentModel.DataAnnotations;
 global using System.Data;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using SnowflakeDashboard.Services;
-global using SnowflakeDashboard.Connections;
 global using SnowflakeDashboard.Helpers;
 global using Snowflake.Data.Client;
 

--- a/project-demos/snowflake-dashboard/Helpers/CodeView.cs
+++ b/project-demos/snowflake-dashboard/Helpers/CodeView.cs
@@ -6,16 +6,16 @@ public class CodeView : ViewBase
     {
         var assembly = typeof(CodeView).Assembly;
         var resourceName = "SnowflakeDashboard.Apps.DashboardApp.cs";
-        
+
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
         {
             return new Exception("Resource not found.");
         }
-        
+
         using var reader = new StreamReader(stream);
         var code = reader.ReadToEnd();
-        
+
         return new CodeBlock(code, Languages.Csharp).Width(Size.Fit()).Height(Size.Fit());
     }
 }

--- a/project-demos/snowflake-dashboard/Program.cs
+++ b/project-demos/snowflake-dashboard/Program.cs
@@ -1,5 +1,3 @@
-using SnowflakeDashboard;
-
 CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 var server = new Server();
 #if DEBUG

--- a/project-demos/snowflake-dashboard/Services/SnowflakeService.cs
+++ b/project-demos/snowflake-dashboard/Services/SnowflakeService.cs
@@ -3,56 +3,56 @@ namespace SnowflakeDashboard.Services;
 public class SnowflakeService
 {
     private readonly string? _connectionString;
-    
+
     public SnowflakeService(string? connectionString) => _connectionString = connectionString;
-    
+
     public async Task<System.Data.DataTable> ExecuteQueryAsync(string sql)
     {
         if (string.IsNullOrWhiteSpace(_connectionString))
             throw new InvalidOperationException("Snowflake connection is not configured.");
-        
+
         using var connection = new SnowflakeDbConnection(_connectionString);
         await connection.OpenAsync();
-        
+
         using var command = connection.CreateCommand();
         command.CommandText = sql;
-        
+
         using var reader = await command.ExecuteReaderAsync();
         var dataTable = new System.Data.DataTable();
         dataTable.Load(reader);
         return dataTable;
     }
-    
+
     public async Task<object?> ExecuteScalarAsync(string sql)
     {
         if (string.IsNullOrWhiteSpace(_connectionString))
             throw new InvalidOperationException("Snowflake connection is not configured.");
-        
+
         using var connection = new SnowflakeDbConnection(_connectionString);
         await connection.OpenAsync();
-        
+
         using var command = connection.CreateCommand();
         command.CommandText = sql;
         return await command.ExecuteScalarAsync();
     }
-    
+
     public async Task<bool> TestConnectionAsync()
     {
         if (string.IsNullOrWhiteSpace(_connectionString)) return false;
-        
+
         SnowflakeDbConnection? connection = null;
         try
         {
             var testConnectionString = _connectionString.TrimEnd(';') + ";poolingEnabled=false;";
             connection = new SnowflakeDbConnection(testConnectionString);
-            
+
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
             await connection.OpenAsync(cts.Token);
-            
+
             using var command = connection.CreateCommand();
             command.CommandText = "SELECT 1";
             command.CommandTimeout = 5;
-            
+
             return await command.ExecuteScalarAsync(cts.Token) != null;
         }
         catch

--- a/project-demos/snowflake-dashboard/snowflake-dashboard.sln
+++ b/project-demos/snowflake-dashboard/snowflake-dashboard.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnowflakeDashboard", "SnowflakeDashboard.csproj", "{CCCF049B-89ED-414C-AF2B-50A0FB416E96}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|x64.Build.0 = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Debug|x86.Build.0 = Debug|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|x64.ActiveCfg = Release|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|x64.Build.0 = Release|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|x86.ActiveCfg = Release|Any CPU
+		{CCCF049B-89ED-414C-AF2B-50A0FB416E96}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/project-demos/snowflake/GlobalUsings.cs
+++ b/project-demos/snowflake/GlobalUsings.cs
@@ -1,18 +1,12 @@
 global using Ivy;
 global using Ivy.Core;
-global using Ivy.Core.Hooks;
-global using Ivy.Views;
-global using Ivy.Views.Builders;
 global using Microsoft.Extensions.Configuration;
 global using Microsoft.Extensions.DependencyInjection;
-global using Microsoft.Extensions.Logging;
-global using System.Collections.Immutable;
 global using System.ComponentModel.DataAnnotations;
 global using System.Data;
 global using System.Globalization;
 global using System.Reactive.Linq;
 global using SnowflakeExample.Services;
-global using SnowflakeExample.Connections;
 global using Snowflake.Data.Client;
 global using System.Linq.Expressions;
 

--- a/project-demos/snowflake/snowflake.sln
+++ b/project-demos/snowflake/snowflake.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SnowflakeExample", "SnowflakeExample.csproj", "{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|x64.Build.0 = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Debug|x86.Build.0 = Debug|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|x64.ActiveCfg = Release|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|x64.Build.0 = Release|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|x86.ActiveCfg = Release|Any CPU
+		{C3CF44AC-73DA-435B-BB59-DB5392ACDB48}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
# Summary

## Changes

Generated `.sln` files for 18 `packages-demos/` and 17 `project-demos/` directories that were missing them. Ran `dotnet format` on all new (and existing) `.sln` files in both directories, formatting 154 source files.

## API Changes

None.

## Files Modified

- **packages-demos/** — 18 new `.sln` files (aspose-barcode, cronos, csvhelper, diffplex, epplus, fastmember, fluentdatetime, github, ibannet, puppeteersharp, questpdf, scriban, sharpyaml, shopifysharp, smartformat-net, stripe-net, timezonenames, unitsnet)
- **project-demos/** — 17 new `.sln` files (QueryParamIdApp, auth-github-test, autodealer-crm, book-library, course-template, crm-vc, github-wrapped, ivy-ask-statistics, llm-tornado-ollama, llm-tornado-openai, microsoft-agent-framework, pr-staging-deploy, showcase-crm, sliplane-deploy, sliplane-manage, snowflake-dashboard, snowflake)
- **Formatting** — 154 `.cs` files auto-formatted across both directories

## Commits

- `dd073a7` [00103] Add .sln files for 18 packages-demos
- `d6ebffa` [00103] Add .sln files for 17 project-demos
- `b3e7383` [00103] Format packages-demos and project-demos code