### PR TITLE
[ci/cd]: align workflow triggers with development branch

### DIFF
--- a/.github/workflows/build-all-projects.yml
+++ b/.github/workflows/build-all-projects.yml
@@ -2,9 +2,9 @@ name: Build All Projects
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *" # daily at 6 AM UTC


### PR DESCRIPTION
## Summary

Updates GitHub Actions branch filters so they match the repository’s integration branch name (`development` instead of `develop`).

## Changes

- **`build-all-projects.yml`**: `push` and `pull_request` triggers now use `[main, development]` instead of `[main, develop]`.

## Why

The repo uses `development`; triggers that only listed `develop` would not run for the real branch, so CI would not run when expected.

## How to verify

- After merge, a push or a PR targeting `main` or `development` should start the **Build All Projects** workflow with the updated config.
