### PR TITLE
[sliplaane-deploy]: Auto-resolve shared Dockerfile for monorepo deploys without per-app Dockerfiles

### DIFF
--- a/.github/docker/Dockerfile.ivy-default
+++ b/.github/docker/Dockerfile.ivy-default
@@ -1,0 +1,34 @@
+# Default Ivy/.NET image: one *.csproj; context = app dir, or repo root + build-arg IVY_APP_DIR=subfolder.
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG BUILD_CONFIGURATION=Release
+ARG IVY_APP_DIR=.
+WORKDIR /src
+COPY . .
+RUN set -eux; \
+    appdir="${IVY_APP_DIR}"; \
+    if [ -z "$appdir" ] || [ "$appdir" = "." ]; then appdir=.; fi; \
+    case "$appdir" in *..*) echo "ERROR: IVY_APP_DIR contains '..' — aborting"; exit 1 ;; esac; \
+    if [ "$appdir" != "." ]; then \
+      test -d "$appdir" || { echo "ERROR: IVY_APP_DIR=$appdir not found in build context"; ls -la; exit 1; }; \
+      cd "$appdir"; \
+    fi; \
+    proj="$(ls -1 *.csproj 2>/dev/null | head -n1)"; \
+    if [ -z "$proj" ]; then echo "ERROR: no *.csproj found in $(pwd)"; ls -la; exit 1; fi; \
+    dotnet restore "$proj"; \
+    dotnet build "$proj" -c "$BUILD_CONFIGURATION" -o /app/build; \
+    dotnet publish "$proj" -c "$BUILD_CONFIGURATION" -o /app/publish /p:UseAppHost=true; \
+    stem="$(basename "$proj" .csproj)"; \
+    printf '%s\n' '#!/bin/sh' "exec dotnet /app/${stem}.dll" > /app/publish/entrypoint.sh; \
+    chmod +x /app/publish/entrypoint.sh
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV PORT=80
+ENV ASPNETCORE_URLS=http://+:80
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
@@ -46,6 +46,7 @@ public class DeployView : ViewBase
     {
         var client = this.UseService<SliplaneApiClient>();
         var config = this.UseService<IConfiguration>();
+        var dockerfileResolver = this.UseService<GitHubDockerfilePathResolver>();
         var model = this.UseState(() => new DeployFormModel
         {
             ServerId = _defaultServerId,
@@ -113,14 +114,17 @@ public class DeployView : ViewBase
             isDeploying.Set(true);
             try
             {
+                var resolution = await dockerfileResolver.ResolveAsync(
+                    m.GitRepo, m.Branch, m.DockerfilePath, m.DockerContext);
+                var envVars = resolution.AdditionalEnv?.ToList() ?? [];
                 var service = await client.CreateServiceAsync(_apiToken, m.ProjectId,
                     ServiceRequestFactory.BuildCreateRequest(
                         name: m.Name, serverId: m.ServerId, gitRepo: m.GitRepo,
-                        branch: m.Branch, dockerfilePath: m.DockerfilePath,
-                        dockerContext: m.DockerContext, autoDeploy: m.AutoDeploy,
+                        branch: m.Branch, dockerfilePath: resolution.DockerfilePath,
+                        dockerContext: resolution.DockerContext, autoDeploy: m.AutoDeploy,
                         networkPublic: m.NetworkPublic, networkProtocol: m.NetworkProtocol,
                         cmd: m.Cmd ?? string.Empty, healthcheck: m.Healthcheck,
-                        env: [], volumeMounts: []));
+                        env: envVars, volumeMounts: []));
 
                 if (service != null)
                     deployedService.Set((m.ProjectId, service));

--- a/project-demos/sliplane-deploy/Program.cs
+++ b/project-demos/sliplane-deploy/Program.cs
@@ -12,6 +12,13 @@ server.Services.AddHttpClient("Ivy", client =>
     client.DefaultRequestHeaders.Add("User-Agent", "Ivy-SliplaneDeploy/1.0");
 });
 
+server.Services.AddHttpClient("GitHubRaw", client =>
+{
+    client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Ivy-SliplaneDeploy/1.0");
+});
+
+server.Services.AddSingleton<GitHubDockerfilePathResolver>();
+
 server.Services.AddSingleton(server.Configuration);
 server.Services.AddHttpContextAccessor();
 server.Services.AddScoped<DeploymentDraftStore>();

--- a/project-demos/sliplane-deploy/Services/GitHubDockerfilePathResolver.cs
+++ b/project-demos/sliplane-deploy/Services/GitHubDockerfilePathResolver.cs
@@ -1,0 +1,135 @@
+namespace SliplaneDeploy.Services;
+
+using System.Net;
+using System.Text.RegularExpressions;
+using SliplaneDeploy.Models;
+
+/// <summary>
+/// Result of resolving which Dockerfile path, Docker context, and extra env vars to send to Sliplane.
+/// </summary>
+public record DockerfileResolution(
+    string DockerfilePath,
+    string DockerContext,
+    IReadOnlyList<EnvironmentVariable>? AdditionalEnv = null);
+
+/// <summary>
+/// When the app folder has no Dockerfile, falls back to <c>.github/docker/Dockerfile.ivy-default</c>.
+/// For monorepo subfolders the context is switched to repo root (<c>"."</c>) so the shared Dockerfile
+/// is inside the build context, and <c>IVY_APP_DIR</c> is passed as an env/build-arg so the Dockerfile
+/// knows which subfolder to build.
+/// </summary>
+public class GitHubDockerfilePathResolver
+{
+    private static readonly Regex GitHubRepoRegex = new(
+        @"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public GitHubDockerfilePathResolver(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    public static bool TryParseGitHubRepo(string? gitRepoUrl, out string owner, out string repo)
+    {
+        owner = repo = "";
+        if (string.IsNullOrWhiteSpace(gitRepoUrl)) return false;
+        var trimmed = gitRepoUrl.Trim().TrimEnd('/');
+        var m = GitHubRepoRegex.Match(trimmed);
+        if (!m.Success) return false;
+        owner = m.Groups["owner"].Value;
+        repo = m.Groups["repo"].Value;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves Dockerfile path, Docker context and optional extra env vars for creating a Sliplane service.
+    /// </summary>
+    public async Task<DockerfileResolution> ResolveAsync(
+        string? gitRepoUrl,
+        string branch,
+        string dockerfilePath,
+        string dockerContext,
+        CancellationToken cancellationToken = default)
+    {
+        var contextTrim = string.IsNullOrWhiteSpace(dockerContext) ? "." : dockerContext.Trim();
+        var path = string.IsNullOrWhiteSpace(dockerfilePath) ? "Dockerfile" : dockerfilePath.Trim();
+        if (!TryParseGitHubRepo(gitRepoUrl, out var owner, out var repo))
+            return new DockerfileResolution(path, contextTrim);
+
+        var branchTrim = string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim();
+
+        // 1. If the requested Dockerfile exists on GitHub, use it as-is.
+        if (await ExistsOnGitHubRawAsync(owner, repo, branchTrim, path, cancellationToken).ConfigureAwait(false))
+            return new DockerfileResolution(path, contextTrim);
+
+        // 2. Try the shared default Dockerfile.
+        var fallback = (_configuration["Sliplane:DefaultDockerfilePath"] ?? ".github/docker/Dockerfile.ivy-default").Trim();
+        if (string.IsNullOrEmpty(fallback) || string.Equals(fallback, path, StringComparison.Ordinal))
+            return new DockerfileResolution(path, contextTrim);
+
+        if (!await ExistsOnGitHubRawAsync(owner, repo, branchTrim, fallback, cancellationToken).ConfigureAwait(false))
+            return new DockerfileResolution(path, contextTrim);
+
+        // 3. Shared Dockerfile exists. Switch context to repo root so the Dockerfile is inside the
+        //    build context (avoids Sliplane rewriting to ../../… which uploads as 2B).
+        //    Pass IVY_APP_DIR so the Dockerfile knows which subfolder contains the *.csproj.
+        var appDir = NormalizeRepoRelativePath(contextTrim);
+        List<EnvironmentVariable>? extraEnv = null;
+        if (appDir.Length > 0 && appDir != ".")
+            extraEnv = [new EnvironmentVariable("IVY_APP_DIR", appDir, Secret: false)];
+
+        return new DockerfileResolution(
+            DockerfilePath: fallback,
+            DockerContext: ".",
+            AdditionalEnv: extraEnv);
+    }
+
+    /// <summary>Normalize to forward-slash path without leading ./ or trailing /.</summary>
+    private static string NormalizeRepoRelativePath(string dockerContext)
+    {
+        var t = dockerContext.Replace('\\', '/').Trim().Trim('/');
+        while (t.StartsWith("./", StringComparison.Ordinal))
+            t = t[2..];
+        return string.IsNullOrEmpty(t) ? "." : t;
+    }
+
+    private async Task<bool> ExistsOnGitHubRawAsync(string owner, string repo, string branch, string repoRelativePath, CancellationToken cancellationToken)
+    {
+        var url = BuildRawUrl(owner, repo, branch, repoRelativePath);
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("GitHubRaw");
+            using (var head = new HttpRequestMessage(HttpMethod.Head, url))
+            {
+                using var headResponse = await client.SendAsync(head, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (headResponse.StatusCode == HttpStatusCode.OK) return true;
+                if (headResponse.StatusCode == HttpStatusCode.NotFound) return false;
+            }
+
+            using (var get = new HttpRequestMessage(HttpMethod.Get, url))
+            {
+                using var getResponse = await client.SendAsync(get, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (getResponse.StatusCode == HttpStatusCode.OK) return true;
+                if (getResponse.StatusCode == HttpStatusCode.NotFound) return false;
+            }
+
+            // Rate limits, private repo without token, etc. — do not treat as "missing".
+            return true;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private static string BuildRawUrl(string owner, string repo, string branch, string repoRelativePath)
+    {
+        var normalized = repoRelativePath.Replace('\\', '/').TrimStart('/');
+        var encodedPath = string.Join("/", normalized.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
+        return $"https://raw.githubusercontent.com/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/{Uri.EscapeDataString(branch)}/{encodedPath}";
+    }
+}


### PR DESCRIPTION
## Summary
- When an app folder has no Dockerfile, the deploy flow now automatically falls back to a shared
  `.github/docker/Dockerfile.ivy-default` and passes `IVY_APP_DIR` as a build-arg so the
  Dockerfile knows which subfolder to build.
- Docker context is switched to the repo root to keep the shared Dockerfile inside the build
  context (avoids the Sliplane `../../` path rewrite that produced empty 2B uploads).
- If an app folder already has its own Dockerfile, it takes priority — no behaviour change.

## Test plan
- [x] Deploy a project **with** its own Dockerfile (e.g. `snowflake`) — uses local Dockerfile as before.
- [x] Deploy a project **without** a Dockerfile (e.g. `book-library`) — auto-resolves to shared Dockerfile, `IVY_APP_DIR` is set, build succeeds.
- [x] Verified Dockerfile transfers as ~1.9kB (not 2B) and `cd $IVY_APP_DIR` finds the correct `.csproj`.

https://github.com/user-attachments/assets/2155709c-eabd-4d2a-94f8-4065afd84cdf
