### PR TITLE
feat(sliplane-deploy): ivy-deploy manifest, multi-service orchestration, and env templates

### DIFF
--- a/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
+++ b/project-demos/sliplane-deploy/Apps/Views/DeployView.cs
@@ -47,6 +47,8 @@ public class DeployView : ViewBase
         var client = this.UseService<SliplaneApiClient>();
         var config = this.UseService<IConfiguration>();
         var dockerfileResolver = this.UseService<GitHubDockerfilePathResolver>();
+        var manifestService = this.UseService<IvyDeployManifestService>();
+        var orchestrator = this.UseService<IvyDeployOrchestrator>();
         var model = this.UseState(() => new DeployFormModel
         {
             ServerId = _defaultServerId,
@@ -67,6 +69,7 @@ public class DeployView : ViewBase
         var deployError = this.UseState<string?>(() => null);
         var validationFailed = this.UseState(false);
         var isDeploying = this.UseState(false);
+        var stackProgress = this.UseState<IReadOnlyList<StackStepRow>>(() => Array.Empty<StackStepRow>());
 
         var (onSubmit, formView, validationView, loading) = this.UseForm(() => model.ToForm("Deploy")
             .Place(m => m.ServerId, m => m.Name)
@@ -103,6 +106,7 @@ public class DeployView : ViewBase
             (string ProjectId, SliplaneService Service)? noSvc = null;
             deployError.Set(noErr);
             deployedService.Set(noSvc);
+            stackProgress.Set(Array.Empty<StackStepRow>());
             validationFailed.Set(false);
             if (!await onSubmit())
             {
@@ -114,29 +118,80 @@ public class DeployView : ViewBase
             isDeploying.Set(true);
             try
             {
-                var resolution = await dockerfileResolver.ResolveAsync(
-                    m.GitRepo, m.Branch, m.DockerfilePath, m.DockerContext);
-                var envVars = resolution.AdditionalEnv?.ToList() ?? [];
-                var service = await client.CreateServiceAsync(_apiToken, m.ProjectId,
-                    ServiceRequestFactory.BuildCreateRequest(
-                        name: m.Name, serverId: m.ServerId, gitRepo: m.GitRepo,
-                        branch: m.Branch, dockerfilePath: resolution.DockerfilePath,
-                        dockerContext: resolution.DockerContext, autoDeploy: m.AutoDeploy,
-                        networkPublic: m.NetworkPublic, networkProtocol: m.NetworkProtocol,
-                        cmd: m.Cmd ?? string.Empty, healthcheck: m.Healthcheck,
-                        env: envVars, volumeMounts: []));
-
-                if (service != null)
-                    deployedService.Set((m.ProjectId, service));
+                var manifest = await manifestService.TryFetchAsync(m.GitRepo, m.Branch);
+                if (manifest is not null)
+                {
+                    await DeployStackAsync(m, manifest);
+                }
+                else
+                {
+                    await DeploySingleServiceAsync(m);
+                }
             }
             catch (Exception ex)
             {
                 deployError.Set(ex.Message);
+                if (stackProgress.Value is { Count: > 0 })
+                {
+                    stackProgress.Set(stackProgress.Value.Select(s =>
+                        s.State == StackStepState.Starting
+                            ? s with { State = StackStepState.Failed, Detail = ex.Message }
+                            : s).ToList());
+                }
             }
             finally
             {
                 isDeploying.Set(false);
             }
+        }
+
+        async Task DeploySingleServiceAsync(DeployFormModel m)
+        {
+            var resolution = await dockerfileResolver.ResolveAsync(
+                m.GitRepo, m.Branch, m.DockerfilePath, m.DockerContext);
+            var envVars = resolution.AdditionalEnv?.ToList() ?? [];
+            var service = await client.CreateServiceAsync(_apiToken, m.ProjectId,
+                ServiceRequestFactory.BuildCreateRequest(
+                    name: m.Name, serverId: m.ServerId, gitRepo: m.GitRepo,
+                    branch: m.Branch, dockerfilePath: resolution.DockerfilePath,
+                    dockerContext: resolution.DockerContext, autoDeploy: m.AutoDeploy,
+                    networkPublic: m.NetworkPublic, networkProtocol: m.NetworkProtocol,
+                    cmd: m.Cmd ?? string.Empty, healthcheck: m.Healthcheck,
+                    env: envVars, volumeMounts: []));
+
+            if (service != null)
+                deployedService.Set((m.ProjectId, service));
+        }
+
+        async Task DeployStackAsync(DeployFormModel m, IvyDeployManifest manifest)
+        {
+            var parentName = string.IsNullOrWhiteSpace(m.Name) ? manifest.ServiceName : m.Name;
+            var normalized = manifest with
+            {
+                GithubRepo = string.IsNullOrWhiteSpace(manifest.GithubRepo) ? m.GitRepo : manifest.GithubRepo,
+                Branch = string.IsNullOrWhiteSpace(manifest.Branch) ? m.Branch : manifest.Branch,
+                DockerfilePath = string.IsNullOrWhiteSpace(manifest.DockerfilePath) ? m.DockerfilePath : manifest.DockerfilePath,
+            };
+
+            var steps = new List<StackStepRow>();
+            foreach (var c in manifest.ChildServices)
+                steps.Add(new StackStepRow(
+                    IvyDeployTemplateEngine.SubstituteEarly(c.ServiceName, parentName),
+                    StackStepState.Starting, c.Description));
+            steps.Add(new StackStepRow(parentName, StackStepState.Starting, "Application service"));
+            stackProgress.Set(steps);
+
+            void OnProgress(string name, StackStepState state, string? detail)
+            {
+                var next = stackProgress.Value.Select(s =>
+                    s.Name == name ? s with { State = state, Detail = detail ?? s.Detail } : s).ToList();
+                stackProgress.Set(next);
+            }
+
+            var result = await orchestrator.DeployAsync(
+                _apiToken, m.ProjectId, m.ServerId, parentName, normalized, OnProgress);
+
+            deployedService.Set((m.ProjectId, result.Parent));
         }
 
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
@@ -162,14 +217,15 @@ public class DeployView : ViewBase
 
         if (isDeploying.Value && deployedService.Value == null)
         {
+            var progressBody = stackProgress.Value is { Count: > 0 }
+                ? BuildStackProgress(stackProgress.Value)
+                : Layout.Vertical()
+                    | Text.Block("Creating service on Sliplane…").Bold()
+                    | new Progress().Indeterminate().Goal("Please wait…");
+
             cardContent = cardContent
                 | new Separator()
-                | new Callout(
-                    Layout.Vertical()
-                        | Text.Block("Creating service on Sliplane…").Bold()
-                        | new Progress().Indeterminate().Goal("Please wait…"),
-                    "Deploying",
-                    CalloutVariant.Info);
+                | new Callout(progressBody, "Deploying", CalloutVariant.Info);
         }
         else if (deployedService.Value is { } deployed)
         {
@@ -207,4 +263,30 @@ public class DeployView : ViewBase
         if (seg.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) seg = seg[..^4];
         return string.IsNullOrWhiteSpace(seg) ? string.Empty : seg.ToLowerInvariant();
     }
+
+    private static object BuildStackProgress(IReadOnlyList<StackStepRow> steps)
+    {
+        var list = Layout.Vertical().Gap(1)
+            | Text.Block("Deploying stack").Bold();
+
+        foreach (var s in steps)
+        {
+            var icon = s.State switch
+            {
+                StackStepState.Succeeded => "✓ ",
+                StackStepState.Failed => "✗ ",
+                _ => "• ",
+            };
+            var detail = string.IsNullOrWhiteSpace(s.Detail) ? string.Empty : $" — {s.Detail}";
+            var line = Text.Block($"{icon}{s.Name}{detail}");
+            list = list | (s.State == StackStepState.Failed ? line.Color(Colors.Red) : line);
+        }
+
+        if (steps.Any(s => s.State == StackStepState.Starting))
+            list = list | new Progress().Indeterminate().Goal("Please wait…");
+
+        return list;
+    }
 }
+
+public record StackStepRow(string Name, StackStepState State, string? Detail);

--- a/project-demos/sliplane-deploy/Models/IvyDeployManifest.cs
+++ b/project-demos/sliplane-deploy/Models/IvyDeployManifest.cs
@@ -1,0 +1,77 @@
+namespace SliplaneDeploy.Models;
+
+/// <summary>
+/// Parsed <c>ivy-deploy.yaml</c> (apiVersion: <c>ivy-deploy/v1</c>).
+///
+/// Template grammar:
+///   <list type="bullet">
+///     <item><c>{parentServiceName}</c> — early-bound literal substitution applied to
+///       <see cref="ServiceName"/>, <see cref="IvyDeployChildService.ServiceName"/>,
+///       <see cref="IvyDeployVolumeSpec.VolumeName"/>, and env default/value strings.</item>
+///     <item><c>{{childName:host}}</c> — late-bound reference to the child service's
+///       <c>network.internalDomain</c>, resolved after the child is created.</item>
+///     <item><c>{{childName:env:KEY}}</c> — late-bound reference to the value passed as
+///       environment variable <c>KEY</c> when creating <c>childName</c>.</item>
+///   </list>
+/// Early-bound substitution runs first, so <c>{{{parentServiceName}-db:host}}</c> resolves
+/// <c>{parentServiceName}</c> inside the reference before child lookup.
+/// </summary>
+public record IvyDeployManifest(
+    string ApiVersion,
+    string ServiceName,
+    string? Title,
+    string? GithubRepo,
+    string? Branch,
+    string? DockerfilePath,
+    int? Port,
+    IvyDeployHealthCheck? HealthCheck,
+    List<IvyDeployEnvVar> Env,
+    List<IvyDeployVolumeSpec> Volumes,
+    List<IvyDeployChildService> ChildServices,
+    IvyDeployRules? DeployRules
+);
+
+public record IvyDeployHealthCheck(
+    string? Path,
+    int? IntervalSeconds,
+    int? TimeoutSeconds,
+    int? StartPeriodSeconds
+);
+
+/// <summary>
+/// Environment variable declaration. Exactly one of <see cref="Value"/>, <see cref="Default"/>,
+/// or <see cref="Generate"/> should be supplied.
+/// <see cref="Generate"/> currently supports <c>random:N</c> (N characters, URL-safe).
+/// </summary>
+public record IvyDeployEnvVar(
+    string Name,
+    string? Value = null,
+    string? Default = null,
+    string? Generate = null,
+    bool Secret = false
+);
+
+public record IvyDeployVolumeSpec(
+    string VolumeName,
+    string MountPath,
+    string? Size
+);
+
+/// <summary>
+/// Child service. Either <see cref="ImageUrl"/> (container image) or <see cref="GithubRepo"/> must be set.
+/// </summary>
+public record IvyDeployChildService(
+    string ServiceName,
+    string? ImageUrl,
+    string? GithubRepo,
+    string? Branch,
+    string? DockerfilePath,
+    string? Description,
+    List<IvyDeployEnvVar> Env,
+    List<IvyDeployVolumeSpec> Volumes
+);
+
+public record IvyDeployRules(
+    bool AutoDeploy,
+    List<string>? IgnorePaths
+);

--- a/project-demos/sliplane-deploy/Models/SliplaneModels.cs
+++ b/project-demos/sliplane-deploy/Models/SliplaneModels.cs
@@ -69,21 +69,30 @@ public record SliplaneServiceDeployment(
 
 public record SliplaneServiceEvent(string Type, string Message, DateTime CreatedAt);
 
-/// <summary>POST /projects/{projectId}/services — matches the Sliplane API spec.</summary>
+/// <summary>
+/// POST /projects/{projectId}/services — matches the Sliplane API spec.
+/// <see cref="Deployment"/> is a <see cref="RepositoryDeployment"/> or <see cref="ImageDeployment"/>
+/// (API oneOf). System.Text.Json emits the runtime type when declared as <c>object</c>.
+/// </summary>
 public record CreateServiceRequest(
     string Name,
     string ServerId,
     ServiceNetworkRequest Network,
-    RepositoryDeployment Deployment,
+    object Deployment,
     string? Cmd = null,
     string? Healthcheck = null,
     List<EnvironmentVariable>? Env = null,
     List<ServiceVolumeMount>? Volumes = null
 );
 
+/// <summary>
+/// A volume mount. Either <see cref="VolumeId"/> (attach existing) or <see cref="VolumeName"/>
+/// (create a new volume with this name on the server) — oneOf per API spec.
+/// </summary>
 public record ServiceVolumeMount(
-    [property: JsonPropertyName("id")] string VolumeId,
-    [property: JsonPropertyName("mountPath")] string MountPath
+    [property: JsonPropertyName("mountPath")] string MountPath,
+    [property: JsonPropertyName("id")] string? VolumeId = null,
+    [property: JsonPropertyName("name")] string? VolumeName = null
 );
 
 public record ServiceNetworkRequest(bool Public = true, string Protocol = "http");
@@ -93,7 +102,14 @@ public record RepositoryDeployment(
     string Branch = "main",
     bool AutoDeploy = true,
     string DockerfilePath = "Dockerfile",
-    string DockerContext = "."
+    string DockerContext = ".",
+    [property: JsonPropertyName("ignorePaths")] List<string>? IgnorePaths = null
+);
+
+/// <summary>Container image deployment (e.g., <c>docker.io/library/postgres:16</c>).</summary>
+public record ImageDeployment(
+    string Url,
+    [property: JsonPropertyName("registryAuthenticationId")] string? RegistryAuthenticationId = null
 );
 
 public record EnvironmentVariable(string Key, string Value, bool Secret = false);

--- a/project-demos/sliplane-deploy/Program.cs
+++ b/project-demos/sliplane-deploy/Program.cs
@@ -18,11 +18,13 @@ server.Services.AddHttpClient("GitHubRaw", client =>
 });
 
 server.Services.AddSingleton<GitHubDockerfilePathResolver>();
+server.Services.AddSingleton<IvyDeployManifestService>();
 
 server.Services.AddSingleton(server.Configuration);
 server.Services.AddHttpContextAccessor();
 server.Services.AddScoped<DeploymentDraftStore>();
 server.Services.AddScoped<SliplaneApiClient>();
+server.Services.AddScoped<IvyDeployOrchestrator>();
 
 Server.ConfigureAuthCookieOptions = options =>
 {

--- a/project-demos/sliplane-deploy/Services/IvyDeployManifestService.cs
+++ b/project-demos/sliplane-deploy/Services/IvyDeployManifestService.cs
@@ -1,0 +1,210 @@
+namespace SliplaneDeploy.Services;
+
+using System.Net;
+using SliplaneDeploy.Models;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+/// <summary>
+/// Downloads and parses <c>ivy-deploy.yaml</c> from the root of a GitHub branch. Uses the same
+/// <c>raw.githubusercontent.com</c> access pattern as <see cref="GitHubDockerfilePathResolver"/>.
+/// </summary>
+public class IvyDeployManifestService
+{
+    private const string ManifestFileName = "ivy-deploy.yaml";
+    private const string ExpectedApiVersion = "ivy-deploy/v1";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public IvyDeployManifestService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    /// <summary>
+    /// Attempts to fetch <c>ivy-deploy.yaml</c> for the given GitHub repo/branch. Returns
+    /// <c>null</c> when the file is absent (HTTP 404). Throws on malformed YAML or unexpected
+    /// API versions so the UI surfaces a clear error instead of silently falling back.
+    /// </summary>
+    public async Task<IvyDeployManifest?> TryFetchAsync(
+        string gitRepoUrl,
+        string branch,
+        CancellationToken cancellationToken = default)
+    {
+        if (!GitHubDockerfilePathResolver.TryParseGitHubRepo(gitRepoUrl, out var owner, out var repo))
+            return null;
+
+        var branchTrim = string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim();
+        var url = BuildRawUrl(owner, repo, branchTrim, ManifestFileName);
+
+        using var client = _httpClientFactory.CreateClient("GitHubRaw");
+        using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Failed to fetch {ManifestFileName} from {url}: {(int)response.StatusCode} {response.StatusCode}.");
+
+        var yaml = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        return Parse(yaml);
+    }
+
+    /// <summary>Parses a YAML manifest string. Exposed for tests and error-reporting.</summary>
+    public static IvyDeployManifest Parse(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+            throw new InvalidOperationException("ivy-deploy.yaml is empty.");
+
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .Build();
+
+        RawManifest raw;
+        try
+        {
+            raw = deserializer.Deserialize<RawManifest>(yaml)
+                  ?? throw new InvalidOperationException("ivy-deploy.yaml deserialized to null.");
+        }
+        catch (YamlException ex)
+        {
+            throw new InvalidOperationException($"ivy-deploy.yaml is not valid YAML: {ex.Message}", ex);
+        }
+
+        if (!string.Equals(raw.ApiVersion?.Trim(), ExpectedApiVersion, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Unsupported apiVersion '{raw.ApiVersion}'. Expected '{ExpectedApiVersion}'.");
+
+        if (string.IsNullOrWhiteSpace(raw.ServiceName))
+            throw new InvalidOperationException("serviceName is required in ivy-deploy.yaml.");
+
+        return new IvyDeployManifest(
+            ApiVersion: raw.ApiVersion!,
+            ServiceName: raw.ServiceName!.Trim(),
+            Title: raw.Title,
+            GithubRepo: raw.GithubRepo,
+            Branch: raw.Branch,
+            DockerfilePath: raw.DockerfilePath,
+            Port: raw.Port,
+            HealthCheck: raw.HealthCheck is null ? null : new IvyDeployHealthCheck(
+                Path: raw.HealthCheck.Path,
+                IntervalSeconds: raw.HealthCheck.IntervalSeconds,
+                TimeoutSeconds: raw.HealthCheck.TimeoutSeconds,
+                StartPeriodSeconds: raw.HealthCheck.StartPeriodSeconds),
+            Env: (raw.Env ?? []).Select(ToEnvVar).ToList(),
+            Volumes: (raw.Volumes ?? []).Select(ToVolume).ToList(),
+            ChildServices: (raw.ChildServices ?? []).Select(ToChild).ToList(),
+            DeployRules: raw.DeployRules is null ? null : new IvyDeployRules(
+                AutoDeploy: raw.DeployRules.AutoDeploy ?? true,
+                IgnorePaths: raw.DeployRules.IgnorePaths));
+    }
+
+    private static IvyDeployEnvVar ToEnvVar(RawEnv e)
+    {
+        if (string.IsNullOrWhiteSpace(e.Name))
+            throw new InvalidOperationException("env entry is missing 'name'.");
+        return new IvyDeployEnvVar(
+            Name: e.Name!.Trim(),
+            Value: e.Value,
+            Default: e.Default,
+            Generate: e.Generate,
+            Secret: e.Secret ?? false);
+    }
+
+    private static IvyDeployVolumeSpec ToVolume(RawVolume v)
+    {
+        if (string.IsNullOrWhiteSpace(v.VolumeName))
+            throw new InvalidOperationException("volume entry is missing 'volumeName'.");
+        if (string.IsNullOrWhiteSpace(v.MountPath))
+            throw new InvalidOperationException($"volume '{v.VolumeName}' is missing 'mountPath'.");
+        return new IvyDeployVolumeSpec(
+            VolumeName: v.VolumeName!.Trim(),
+            MountPath: v.MountPath!.Trim(),
+            Size: v.Size);
+    }
+
+    private static IvyDeployChildService ToChild(RawChild c)
+    {
+        if (string.IsNullOrWhiteSpace(c.ServiceName))
+            throw new InvalidOperationException("childServices entry is missing 'serviceName'.");
+        if (string.IsNullOrWhiteSpace(c.ImageUrl) && string.IsNullOrWhiteSpace(c.GithubRepo))
+            throw new InvalidOperationException(
+                $"child '{c.ServiceName}' must set either 'imageUrl' or 'githubRepo'.");
+        return new IvyDeployChildService(
+            ServiceName: c.ServiceName!.Trim(),
+            ImageUrl: c.ImageUrl,
+            GithubRepo: c.GithubRepo,
+            Branch: c.Branch,
+            DockerfilePath: c.DockerfilePath,
+            Description: c.Description,
+            Env: (c.Env ?? []).Select(ToEnvVar).ToList(),
+            Volumes: (c.Volumes ?? []).Select(ToVolume).ToList());
+    }
+
+    private static string BuildRawUrl(string owner, string repo, string branch, string path)
+    {
+        var encoded = string.Join("/", path.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
+        return $"https://raw.githubusercontent.com/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/{Uri.EscapeDataString(branch)}/{encoded}";
+    }
+
+    // ── Raw YAML shapes (YamlDotNet fills via reflection). Kept private + mutable. ──────────
+
+    private class RawManifest
+    {
+        public string? ApiVersion { get; set; }
+        public string? ServiceName { get; set; }
+        public string? Title { get; set; }
+        public string? GithubRepo { get; set; }
+        public string? Branch { get; set; }
+        public string? DockerfilePath { get; set; }
+        public int? Port { get; set; }
+        public RawHealthCheck? HealthCheck { get; set; }
+        public List<RawEnv>? Env { get; set; }
+        public List<RawVolume>? Volumes { get; set; }
+        public List<RawChild>? ChildServices { get; set; }
+        public RawDeployRules? DeployRules { get; set; }
+    }
+
+    private class RawHealthCheck
+    {
+        public string? Path { get; set; }
+        public int? IntervalSeconds { get; set; }
+        public int? TimeoutSeconds { get; set; }
+        public int? StartPeriodSeconds { get; set; }
+    }
+
+    private class RawEnv
+    {
+        public string? Name { get; set; }
+        public string? Value { get; set; }
+        public string? Default { get; set; }
+        public string? Generate { get; set; }
+        public bool? Secret { get; set; }
+    }
+
+    private class RawVolume
+    {
+        public string? VolumeName { get; set; }
+        public string? MountPath { get; set; }
+        public string? Size { get; set; }
+    }
+
+    private class RawChild
+    {
+        public string? ServiceName { get; set; }
+        public string? ImageUrl { get; set; }
+        public string? GithubRepo { get; set; }
+        public string? Branch { get; set; }
+        public string? DockerfilePath { get; set; }
+        public string? Description { get; set; }
+        public List<RawEnv>? Env { get; set; }
+        public List<RawVolume>? Volumes { get; set; }
+    }
+
+    private class RawDeployRules
+    {
+        public bool? AutoDeploy { get; set; }
+        public List<string>? IgnorePaths { get; set; }
+    }
+}

--- a/project-demos/sliplane-deploy/Services/IvyDeployOrchestrator.cs
+++ b/project-demos/sliplane-deploy/Services/IvyDeployOrchestrator.cs
@@ -1,0 +1,226 @@
+namespace SliplaneDeploy.Services;
+
+using SliplaneDeploy.Models;
+
+/// <summary>
+/// Creates a multi-service stack described by an <see cref="IvyDeployManifest"/>.
+///
+/// Order of operations:
+/// <list type="number">
+///   <item>Resolve early-bound <c>{parentServiceName}</c> substitutions and compute generated
+///     env values for every child.</item>
+///   <item>Create each child via <see cref="SliplaneApiClient.CreateServiceAsync"/>, polling
+///     until <c>network.internalDomain</c> is known so late-bound <c>{{child:host}}</c> refs
+///     can be resolved.</item>
+///   <item>Resolve late-bound refs in the parent env and create the parent service.</item>
+/// </list>
+/// The orchestrator is stateless — every call is self-contained and reports progress via the
+/// <see cref="StackDeploymentProgress"/> callback so the UI can surface per-service status.
+/// </summary>
+public class IvyDeployOrchestrator
+{
+    private const int HostPollMaxAttempts = 20;
+    private static readonly TimeSpan HostPollDelay = TimeSpan.FromSeconds(1);
+
+    private readonly SliplaneApiClient _client;
+    private readonly GitHubDockerfilePathResolver _dockerfileResolver;
+
+    public IvyDeployOrchestrator(SliplaneApiClient client, GitHubDockerfilePathResolver dockerfileResolver)
+    {
+        _client = client;
+        _dockerfileResolver = dockerfileResolver;
+    }
+
+    public async Task<StackDeploymentResult> DeployAsync(
+        string apiToken,
+        string projectId,
+        string serverId,
+        string parentServiceName,
+        IvyDeployManifest manifest,
+        StackDeploymentProgress? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var childResolutions = new Dictionary<string, IvyDeployTemplateEngine.ChildResolution>(StringComparer.Ordinal);
+        var createdChildren = new List<SliplaneService>();
+
+        foreach (var child in manifest.ChildServices)
+        {
+            var (created, resolution) = await CreateChildAsync(
+                apiToken, projectId, serverId, parentServiceName, child, cancellationToken, progress);
+            createdChildren.Add(created);
+            childResolutions[created.Name] = resolution;
+        }
+
+        progress?.Invoke(parentServiceName, StackStepState.Starting, "Creating parent service");
+        var parent = await CreateParentAsync(
+            apiToken, projectId, serverId, parentServiceName, manifest, childResolutions, cancellationToken);
+        progress?.Invoke(parentServiceName, StackStepState.Succeeded, null);
+
+        return new StackDeploymentResult(parent, createdChildren);
+    }
+
+    private async Task<(SliplaneService Service, IvyDeployTemplateEngine.ChildResolution Resolution)> CreateChildAsync(
+        string apiToken,
+        string projectId,
+        string serverId,
+        string parentServiceName,
+        IvyDeployChildService child,
+        CancellationToken cancellationToken,
+        StackDeploymentProgress? progress)
+    {
+        var childName = IvyDeployTemplateEngine.SubstituteEarly(child.ServiceName, parentServiceName);
+        progress?.Invoke(childName, StackStepState.Starting, child.Description);
+
+        var env = BuildChildEnv(child, parentServiceName);
+
+        var volumeMounts = child.Volumes
+            .Select(v => new ServiceVolumeMount(
+                MountPath: v.MountPath,
+                VolumeName: IvyDeployTemplateEngine.SubstituteEarly(v.VolumeName, parentServiceName)))
+            .ToList();
+
+        object deployment = !string.IsNullOrWhiteSpace(child.ImageUrl)
+            ? new ImageDeployment(Url: child.ImageUrl!.Trim())
+            : new RepositoryDeployment(
+                Url: child.GithubRepo!.Trim(),
+                Branch: string.IsNullOrWhiteSpace(child.Branch) ? "main" : child.Branch!.Trim(),
+                AutoDeploy: true,
+                DockerfilePath: string.IsNullOrWhiteSpace(child.DockerfilePath) ? "Dockerfile" : child.DockerfilePath!.Trim(),
+                DockerContext: ".");
+
+        var request = new CreateServiceRequest(
+            Name: childName,
+            ServerId: serverId,
+            Network: new ServiceNetworkRequest(Public: false, Protocol: "http"),
+            Deployment: deployment,
+            Env: env.Count > 0 ? env.Select(kv => new EnvironmentVariable(kv.Key, kv.Value, kv.Secret)).ToList() : null,
+            Volumes: volumeMounts.Count > 0 ? volumeMounts : null);
+
+        var created = await _client.CreateServiceAsync(apiToken, projectId, request)
+            ?? throw new InvalidOperationException($"Sliplane returned no body when creating child '{childName}'.");
+
+        var host = await ResolveHostAsync(apiToken, projectId, created, cancellationToken);
+        var resolution = new IvyDeployTemplateEngine.ChildResolution(
+            Host: host,
+            Env: env.ToDictionary(e => e.Key, e => e.Value, StringComparer.Ordinal));
+
+        progress?.Invoke(childName, StackStepState.Succeeded, $"Internal host: {host}");
+        return (created, resolution);
+    }
+
+    private async Task<SliplaneService> CreateParentAsync(
+        string apiToken,
+        string projectId,
+        string serverId,
+        string parentServiceName,
+        IvyDeployManifest manifest,
+        IReadOnlyDictionary<string, IvyDeployTemplateEngine.ChildResolution> children,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(manifest.GithubRepo))
+            throw new InvalidOperationException("ivy-deploy.yaml: parent 'githubRepo' is required.");
+
+        var branch = string.IsNullOrWhiteSpace(manifest.Branch) ? "main" : manifest.Branch!;
+        var dockerfilePath = string.IsNullOrWhiteSpace(manifest.DockerfilePath) ? "Dockerfile" : manifest.DockerfilePath!;
+
+        var resolution = await _dockerfileResolver.ResolveAsync(
+            manifest.GithubRepo, branch, dockerfilePath, ".", cancellationToken);
+        var baseEnv = resolution.AdditionalEnv?.ToList() ?? [];
+
+        var parentEnv = BuildParentEnv(manifest, parentServiceName, children);
+        var env = baseEnv
+            .Concat(parentEnv.Select(e => new EnvironmentVariable(e.Key, e.Value, e.Secret)))
+            .ToList();
+
+        var volumeMounts = manifest.Volumes
+            .Select(v => new ServiceVolumeMount(
+                MountPath: v.MountPath,
+                VolumeName: IvyDeployTemplateEngine.SubstituteEarly(v.VolumeName, parentServiceName)))
+            .ToList();
+
+        var autoDeploy = manifest.DeployRules?.AutoDeploy ?? true;
+        var ignorePaths = manifest.DeployRules?.IgnorePaths;
+
+        var request = new CreateServiceRequest(
+            Name: parentServiceName,
+            ServerId: serverId,
+            Network: new ServiceNetworkRequest(Public: true, Protocol: "http"),
+            Deployment: new RepositoryDeployment(
+                Url: manifest.GithubRepo!.Trim(),
+                Branch: branch,
+                AutoDeploy: autoDeploy,
+                DockerfilePath: resolution.DockerfilePath,
+                DockerContext: resolution.DockerContext,
+                IgnorePaths: ignorePaths is { Count: > 0 } ? ignorePaths.ToList() : null),
+            Healthcheck: string.IsNullOrWhiteSpace(manifest.HealthCheck?.Path) ? null : manifest.HealthCheck!.Path,
+            Env: env.Count > 0 ? env : null,
+            Volumes: volumeMounts.Count > 0 ? volumeMounts : null);
+
+        return await _client.CreateServiceAsync(apiToken, projectId, request)
+            ?? throw new InvalidOperationException($"Sliplane returned no body when creating parent '{parentServiceName}'.");
+    }
+
+    private static List<(string Key, string Value, bool Secret)> BuildChildEnv(
+        IvyDeployChildService child, string parentServiceName)
+    {
+        var result = new List<(string Key, string Value, bool Secret)>(child.Env.Count);
+        foreach (var e in child.Env)
+        {
+            var value = ChooseRawValue(e) ?? throw new InvalidOperationException(
+                $"Env '{e.Name}' on child '{child.ServiceName}' has no value, default, or generate spec.");
+            var resolved = IvyDeployTemplateEngine.SubstituteEarly(value, parentServiceName);
+            result.Add((e.Name, resolved, e.Secret));
+        }
+        return result;
+    }
+
+    private static List<(string Key, string Value, bool Secret)> BuildParentEnv(
+        IvyDeployManifest manifest,
+        string parentServiceName,
+        IReadOnlyDictionary<string, IvyDeployTemplateEngine.ChildResolution> children)
+    {
+        var result = new List<(string Key, string Value, bool Secret)>(manifest.Env.Count);
+        foreach (var e in manifest.Env)
+        {
+            var value = ChooseRawValue(e) ?? throw new InvalidOperationException(
+                $"Env '{e.Name}' on parent service has no value, default, or generate spec.");
+            var resolved = IvyDeployTemplateEngine.Resolve(value, parentServiceName, children);
+            result.Add((e.Name, resolved, e.Secret));
+        }
+        return result;
+    }
+
+    private static string? ChooseRawValue(IvyDeployEnvVar e)
+    {
+        if (!string.IsNullOrEmpty(e.Value)) return e.Value;
+        if (!string.IsNullOrEmpty(e.Default)) return e.Default;
+        if (!string.IsNullOrEmpty(e.Generate)) return IvyDeployTemplateEngine.Generate(e.Generate);
+        return null;
+    }
+
+    private async Task<string> ResolveHostAsync(
+        string apiToken, string projectId, SliplaneService created, CancellationToken cancellationToken)
+    {
+        var immediate = created.Network?.InternalDomain;
+        if (!string.IsNullOrWhiteSpace(immediate)) return immediate!;
+
+        for (var attempt = 0; attempt < HostPollMaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await Task.Delay(HostPollDelay, cancellationToken).ConfigureAwait(false);
+
+            var latest = await _client.GetServiceAsync(apiToken, projectId, created.Id);
+            var host = latest?.Network?.InternalDomain;
+            if (!string.IsNullOrWhiteSpace(host)) return host!;
+        }
+
+        throw new InvalidOperationException(
+            $"Timed out waiting for internalDomain of service '{created.Name}' ({created.Id}).");
+    }
+}
+
+public enum StackStepState { Starting, Succeeded, Failed }
+
+public delegate void StackDeploymentProgress(string serviceName, StackStepState state, string? detail);
+
+public record StackDeploymentResult(SliplaneService Parent, IReadOnlyList<SliplaneService> Children);

--- a/project-demos/sliplane-deploy/Services/IvyDeployOrchestrator.cs
+++ b/project-demos/sliplane-deploy/Services/IvyDeployOrchestrator.cs
@@ -79,19 +79,24 @@ public class IvyDeployOrchestrator
                 VolumeName: IvyDeployTemplateEngine.SubstituteEarly(v.VolumeName, parentServiceName)))
             .ToList();
 
-        object deployment = !string.IsNullOrWhiteSpace(child.ImageUrl)
+        var isImage = !string.IsNullOrWhiteSpace(child.ImageUrl);
+        object deployment = isImage
             ? new ImageDeployment(Url: child.ImageUrl!.Trim())
             : new RepositoryDeployment(
-                Url: child.GithubRepo!.Trim(),
+                Url: NormalizeGitHubRepoUrl(child.GithubRepo!.Trim()),
                 Branch: string.IsNullOrWhiteSpace(child.Branch) ? "main" : child.Branch!.Trim(),
                 AutoDeploy: true,
                 DockerfilePath: string.IsNullOrWhiteSpace(child.DockerfilePath) ? "Dockerfile" : child.DockerfilePath!.Trim(),
                 DockerContext: ".");
 
+        // Sliplane docs: databases and many registry images are not HTTP — use "tcp" (or "udp"). Using "http" here
+        // has been seen to fail create with misleading errors (e.g. "Invalid external docker image") for postgres.
+        var networkProtocol = isImage ? "tcp" : "http";
+
         var request = new CreateServiceRequest(
             Name: childName,
             ServerId: serverId,
-            Network: new ServiceNetworkRequest(Public: false, Protocol: "http"),
+            Network: new ServiceNetworkRequest(Public: false, Protocol: networkProtocol),
             Deployment: deployment,
             Env: env.Count > 0 ? env.Select(kv => new EnvironmentVariable(kv.Key, kv.Value, kv.Secret)).ToList() : null,
             Volumes: volumeMounts.Count > 0 ? volumeMounts : null);
@@ -120,11 +125,12 @@ public class IvyDeployOrchestrator
         if (string.IsNullOrWhiteSpace(manifest.GithubRepo))
             throw new InvalidOperationException("ivy-deploy.yaml: parent 'githubRepo' is required.");
 
+        var repoUrl = NormalizeGitHubRepoUrl(manifest.GithubRepo!);
         var branch = string.IsNullOrWhiteSpace(manifest.Branch) ? "main" : manifest.Branch!;
         var dockerfilePath = string.IsNullOrWhiteSpace(manifest.DockerfilePath) ? "Dockerfile" : manifest.DockerfilePath!;
 
         var resolution = await _dockerfileResolver.ResolveAsync(
-            manifest.GithubRepo, branch, dockerfilePath, ".", cancellationToken);
+            repoUrl, branch, dockerfilePath, ".", cancellationToken);
         var baseEnv = resolution.AdditionalEnv?.ToList() ?? [];
 
         var parentEnv = BuildParentEnv(manifest, parentServiceName, children);
@@ -146,7 +152,7 @@ public class IvyDeployOrchestrator
             ServerId: serverId,
             Network: new ServiceNetworkRequest(Public: true, Protocol: "http"),
             Deployment: new RepositoryDeployment(
-                Url: manifest.GithubRepo!.Trim(),
+                Url: repoUrl,
                 Branch: branch,
                 AutoDeploy: autoDeploy,
                 DockerfilePath: resolution.DockerfilePath,
@@ -216,6 +222,22 @@ public class IvyDeployOrchestrator
 
         throw new InvalidOperationException(
             $"Timed out waiting for internalDomain of service '{created.Name}' ({created.Id}).");
+    }
+
+    /// <summary>
+    /// Sliplane API expects a repository URL with scheme (see <c>format: uri</c> in OpenAPI). UI often accepts
+    /// <c>owner/repo</c>; we normalize to <c>https://github.com/owner/repo</c>.
+    /// </summary>
+    private static string NormalizeGitHubRepoUrl(string raw)
+    {
+        var t = raw.Trim();
+        if (t.Length == 0) return t;
+        if (t.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+            t.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+            return t;
+        if (t.StartsWith("github.com/", StringComparison.OrdinalIgnoreCase))
+            return "https://" + t;
+        return "https://github.com/" + t.TrimStart('/');
     }
 }
 

--- a/project-demos/sliplane-deploy/Services/IvyDeployTemplateEngine.cs
+++ b/project-demos/sliplane-deploy/Services/IvyDeployTemplateEngine.cs
@@ -1,0 +1,118 @@
+namespace SliplaneDeploy.Services;
+
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Template engine for <c>ivy-deploy.yaml</c> strings.
+///
+/// Two kinds of substitution are applied in this order:
+/// <list type="number">
+///   <item><c>{parentServiceName}</c> — early-bound literal replaced with the parent service
+///     name everywhere.</item>
+///   <item>Late-bound references — after early substitution, any <c>{child:host}</c> or
+///     <c>{child:env:KEY}</c> (single or double braces around the expression) resolves to the
+///     corresponding child service's <c>internalDomain</c> or passed env value.</item>
+/// </list>
+/// Running early substitution first means that <c>{{parentServiceName}-db:host}</c> naturally
+/// becomes <c>{myapp-db:host}</c>, which is then a valid late reference.
+/// </summary>
+public static class IvyDeployTemplateEngine
+{
+    public const string ParentServicePlaceholder = "{parentServiceName}";
+
+    // Matches '{child:host}' / '{child:env:KEY}' with optional duplicated braces on each side.
+    // The inner content forbids '{' and '}' (early substitution has already run), so inner-most
+    // refs are found regardless of whether the author used '{...}' or '{{...}}'.
+    private static readonly Regex LateRefPattern = new(
+        @"\{{1,2}(?<expr>[^{}]*:[^{}]+?)\}{1,2}",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static string SubstituteEarly(string input, string parentServiceName) =>
+        string.IsNullOrEmpty(input) ? input
+            : input.Replace(ParentServicePlaceholder, parentServiceName, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Describes a resolved child service: the host (<c>network.internalDomain</c>) plus any
+    /// env values that were passed to it at creation time.
+    /// </summary>
+    public record ChildResolution(string Host, IReadOnlyDictionary<string, string> Env);
+
+    /// <summary>
+    /// Applies early-bound substitution, then resolves every late-bound reference using the
+    /// supplied child resolutions. Unknown references throw
+    /// <see cref="InvalidOperationException"/> so a misconfigured manifest fails loudly rather
+    /// than shipping broken env values.
+    /// </summary>
+    public static string Resolve(
+        string input,
+        string parentServiceName,
+        IReadOnlyDictionary<string, ChildResolution> children)
+    {
+        if (string.IsNullOrEmpty(input)) return input;
+
+        var early = SubstituteEarly(input, parentServiceName);
+        if (!early.Contains(':', StringComparison.Ordinal)) return early;
+
+        return LateRefPattern.Replace(early, match =>
+        {
+            var expr = match.Groups["expr"].Value.Trim();
+            return ResolveRef(expr, children);
+        });
+    }
+
+    private static string ResolveRef(string expr, IReadOnlyDictionary<string, ChildResolution> children)
+    {
+        var parts = expr.Split(':');
+        if (parts.Length < 2)
+            throw new InvalidOperationException(
+                $"Invalid template reference '{{{expr}}}'. Expected '{{child:host}}' or '{{child:env:KEY}}'.");
+
+        var childName = parts[0].Trim();
+        var field = parts[1].Trim();
+
+        if (!children.TryGetValue(childName, out var resolution))
+            throw new InvalidOperationException(
+                $"Template reference '{{{expr}}}' points to unknown child service '{childName}'.");
+
+        return field switch
+        {
+            "host" when parts.Length == 2 => resolution.Host,
+            "env" when parts.Length == 3 => ResolveEnv(childName, resolution, parts[2].Trim()),
+            _ => throw new InvalidOperationException(
+                $"Invalid template field in '{{{expr}}}'. Use 'host' or 'env:KEY'."),
+        };
+    }
+
+    private static string ResolveEnv(string childName, ChildResolution resolution, string key)
+    {
+        if (!resolution.Env.TryGetValue(key, out var value))
+            throw new InvalidOperationException(
+                $"Template reference '{{{childName}:env:{key}}}' targets env '{key}' which was not set on '{childName}'.");
+        return value;
+    }
+
+    /// <summary>
+    /// Resolves <c>generate: random:N</c>. Currently the only supported form. Returns a URL-safe
+    /// Base64 string of length <c>N</c>.
+    /// </summary>
+    public static string Generate(string spec)
+    {
+        const string prefix = "random:";
+        if (!spec.StartsWith(prefix, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Unsupported generate spec '{spec}'. Only '{prefix}N' is supported.");
+
+        if (!int.TryParse(spec[prefix.Length..], out var length) || length <= 0 || length > 256)
+            throw new InvalidOperationException(
+                $"Invalid length in generate spec '{spec}'. Must be an integer in (0, 256].");
+
+        var byteLen = (int)Math.Ceiling(length * 3.0 / 4.0);
+        var bytes = RandomNumberGenerator.GetBytes(byteLen);
+        var base64 = Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+        return base64.Length <= length ? base64 : base64[..length];
+    }
+}

--- a/project-demos/sliplane-deploy/Services/ServiceRequestFactory.cs
+++ b/project-demos/sliplane-deploy/Services/ServiceRequestFactory.cs
@@ -17,11 +17,12 @@ internal static class ServiceRequestFactory
         string? cmd,
         string? healthcheck,
         IReadOnlyCollection<EnvironmentVariable>? env,
-        IReadOnlyCollection<(string VolumeId, string MountPath)>? volumeMounts)
+        IReadOnlyCollection<(string VolumeId, string MountPath)>? volumeMounts,
+        IReadOnlyCollection<string>? ignorePaths = null)
     {
         var envList = env is { Count: > 0 } ? env.ToList() : null;
         var volumes = volumeMounts is { Count: > 0 }
-            ? volumeMounts.Select(v => new ServiceVolumeMount(v.VolumeId, v.MountPath)).ToList()
+            ? volumeMounts.Select(v => new ServiceVolumeMount(v.MountPath, VolumeId: v.VolumeId)).ToList()
             : null;
 
         return new CreateServiceRequest(
@@ -33,7 +34,8 @@ internal static class ServiceRequestFactory
                 Branch: string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim(),
                 AutoDeploy: autoDeploy,
                 DockerfilePath: string.IsNullOrWhiteSpace(dockerfilePath) ? "Dockerfile" : dockerfilePath.Trim(),
-                DockerContext: string.IsNullOrWhiteSpace(dockerContext) ? "." : dockerContext.Trim()
+                DockerContext: string.IsNullOrWhiteSpace(dockerContext) ? "." : dockerContext.Trim(),
+                IgnorePaths: ignorePaths is { Count: > 0 } ? ignorePaths.ToList() : null
             ),
             Cmd: string.IsNullOrWhiteSpace(cmd) ? null : cmd.Trim(),
             Healthcheck: string.IsNullOrWhiteSpace(healthcheck) ? null : healthcheck.Trim(),

--- a/project-demos/sliplane-deploy/SliplaneDeploy.csproj
+++ b/project-demos/sliplane-deploy/SliplaneDeploy.csproj
@@ -15,6 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>
 

--- a/project-demos/sliplane-deploy/SliplaneDeploy.csproj
+++ b/project-demos/sliplane-deploy/SliplaneDeploy.csproj
@@ -9,6 +9,10 @@
     <UserSecretsId>3901cf22-a0ae-47ab-879c-682515e69029</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Do not compile helper tools nested under this folder (they would break the single Exe with top-level statements). -->
+    <Compile Remove="tools/**" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Adds end-to-end support in **sliplane-deploy** for deploying stacks defined in `ivy-deploy.yaml` at the repo root: fetch the manifest from GitHub raw, create child services (image or git), resolve late-bound connection strings, then create the parent app service. Falls back to the existing single-service flow when the file is missing.

## What’s included

- **Manifest:** HTTP fetch + YAML parse (`YamlDotNet`), validation for `apiVersion: ivy-deploy/v1` and required fields.
- **Models:** `IvyDeployManifest` and related records (health check, env with `value` / `default` / `generate: random:N`, volumes, `deployRules`, `childServices`).
- **Template engine:** `{parentServiceName}` early substitution; after children exist, resolve `{child:host}` and `{child:env:KEY}` (including forms with doubled braces as used in real manifests).
- **Orchestrator:** Ordered deploy (children → parent); poll for `network.internalDomain`; image children use `tcp` and `ImageDeployment`; git children and parent use `RepositoryDeployment` with optional `ignorePaths`; normalize short `owner/repo` to `https://github.com/owner/repo`.
- **Sliplane API types:** `CreateServiceRequest.Deployment` as git **or** image; `ServiceVolumeMount` supports existing volume `id` or new volume `name`; `RepositoryDeployment` gains `ignorePaths`.
- **UI:** `DeployView` loads manifest on deploy; stack path shows per-step progress; single-service path unchanged.
- **Project:** `YamlDotNet` package reference; `Compile Remove` for `tools/**` under the demo app project.

## Scope

- Changes are limited to `project-demos/sliplane-deploy` only (no sliplane-manage changes in this PR).

## Notes / limitations

- Sliplane’s public API exposes `healthcheck` as a path string; interval/timeout/start-period from YAML are not sent as separate API fields.
- `deployRules.ignorePaths` is mapped to `RepositoryDeployment.ignorePaths` where applicable.


https://github.com/user-attachments/assets/00d547d8-a643-4632-ae41-2be6e2c9a766

