### PR TITLE
[pr-staging-deploy]: multi-repo config, service naming, and webhook routing

### DIFF
--- a/project-demos/pr-staging-deploy/Apps/PrStagingDeployApp.cs
+++ b/project-demos/pr-staging-deploy/Apps/PrStagingDeployApp.cs
@@ -1,16 +1,21 @@
 namespace PrStagingDeploy.Apps;
 
+using System.Linq.Expressions;
 using System.Text;
 using PrStagingDeploy.Models;
 using PrStagingDeploy.Services;
 
 /// <summary>
-/// PR Staging Deploy — one table: PRs with Sliplane deploy status. Data from GitHub + Sliplane API.
+/// PR Staging Deploy — one table: PRs across all configured repos with Sliplane deploy status.
+/// Data from GitHub + Sliplane API.
 /// </summary>
 [App(id: "pr-staging-deploy-app", icon: Icons.GitBranch, title: "PR Staging Deploy", searchHints: ["pr", "staging", "deploy", "samples", "docs"])]
 public class PrStagingDeployApp : ViewBase
 {
     private record PrRow(
+        string Id,
+        string RepoKey,
+        string RepoLabel,
         string HeadRef,
         int Number,
         string Title,
@@ -21,7 +26,9 @@ public class PrStagingDeployApp : ViewBase
         string SamplesDisplay,
         string? HtmlUrl,
         string? DocsUrl,
-        string? SamplesUrl);
+        string? SamplesUrl,
+        bool HasDocs,
+        bool HasSamples);
 
     public override object? Build()
     {
@@ -31,15 +38,16 @@ public class PrStagingDeployApp : ViewBase
         var prComments = this.UseService<PrStagingDeployCommentService>();
         var errorWatcher = this.UseService<StagingErrorWatcherQueue>();
         var sliplane = this.UseService<SliplaneStagingClient>();
+        var reposProvider = this.UseService<StagingReposProvider>();
         var client = this.UseService<IClientProvider>();
         var refreshToken = this.UseRefreshToken();
         var (alertView, showAlert) = this.UseAlert();
         var message = this.UseState<(string Text, bool IsError)?>(() => null);
         var pinnedTableRows = this.UseState<List<PrRow>?>(() => null);
         var deleteAllWaitingForFreshNoStaging = this.UseState(false);
-        // Tracks branches for which a deploy was triggered but Sliplane hasn't created the service yet.
+        // Tracks (repoKey/branch) keys for which a deploy was triggered but Sliplane hasn't created the service yet.
         // Prevents the row from flickering back to "not deployed" during the query refresh window.
-        var deployingBranches = this.UseState(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        var deployingItems = this.UseState(() => new HashSet<string>(StringComparer.OrdinalIgnoreCase));
 
         var overviewQuery = this.UseQuery<List<PrRow>, string>(
             key: $"pr-overview:{config["Sliplane:ApiToken"] ?? ""}",
@@ -48,70 +56,96 @@ public class PrStagingDeployApp : ViewBase
                 var token = config["Sliplane:ApiToken"] ?? "";
                 var projId = config["Sliplane:ProjectId"] ?? "";
                 refreshToken.Refresh();
-                var prs = await github.GetPullRequestsAsync(
-                    config["GitHub:Owner"] ?? "Ivy-Interactive",
-                    config["GitHub:Repo"] ?? "Ivy-Examples",
-                    config["GitHub:Token"] ?? "", "open");
+
+                var ghToken = config["GitHub:Token"] ?? "";
+                var allRepos = reposProvider.All;
+
                 var deployments = string.IsNullOrEmpty(token)
                     ? new List<StagingDeployment>()
                     : await deploySvc.ListDeploymentsAsync(token);
 
                 var rows = new List<PrRow>();
-                foreach (var pr in prs)
+
+                foreach (var rc in allRepos)
                 {
-                    var dep = deployments.FirstOrDefault(d => d.BranchSafe == pr.Number.ToString());
-
-                    string status;
-                    Icons statusIcon;
-                    string docsDisplay = "";
-                    string samplesDisplay = "";
-                    string expiresAt = "—";
-
-                    if (dep != null)
+                    var prs = await github.GetPullRequestsAsync(rc.Owner, rc.Repo, ghToken, "open");
+                    foreach (var pr in prs)
                     {
-                        expiresAt = dep.ExpiresAt.ToString("yyyy-MM-dd");
-                        var docsEvents = !string.IsNullOrEmpty(projId) && !string.IsNullOrEmpty(dep.DocsServiceId)
-                            ? await sliplane.GetServiceEventsAsync(token, projId, dep.DocsServiceId)
-                            : new List<SliplaneServiceEvent>();
-                        var samplesEvents = !string.IsNullOrEmpty(projId) && !string.IsNullOrEmpty(dep.SamplesServiceId)
-                            ? await sliplane.GetServiceEventsAsync(token, projId, dep.SamplesServiceId)
-                            : new List<SliplaneServiceEvent>();
+                        var rowId = $"{rc.Key}/{pr.HeadRef}";
+                        var dep = deployments.FirstOrDefault(d =>
+                            d.RepoKey.Equals(rc.Key, StringComparison.OrdinalIgnoreCase) &&
+                            d.BranchSafe == pr.Number.ToString());
 
-                        var (statusLabel, icon) = GetCombinedRowStatus(
-                            dep.DocsServiceId, docsEvents, dep.SamplesServiceId, samplesEvents);
-                        status = statusLabel;
-                        statusIcon = icon;
+                        string status;
+                        Icons statusIcon;
+                        string docsDisplay = rc.HasDocs ? "" : NotConfiguredHint;
+                        string samplesDisplay = rc.HasSamples ? "" : NotConfiguredHint;
+                        string expiresAt = "—";
 
-                        docsDisplay = GetServiceDisplay(dep.DocsUrl, dep.DocsStatus, docsEvents, statusLabel);
-                        samplesDisplay = GetServiceDisplay(dep.SamplesUrl, dep.SamplesStatus, samplesEvents, statusLabel);
-                    }
-                    else
-                    {
-                        // Sliplane doesn't know about this branch yet.
-                        // If we triggered a deploy and are waiting for the service to appear, keep "Deploying...".
-                        if (deployingBranches.Value.Contains(pr.HeadRef))
+                        if (dep != null)
                         {
-                            status = "pending";
-                            statusIcon = Icons.Clock;
-                            docsDisplay = "Deploying...";
-                            samplesDisplay = "Deploying...";
+                            expiresAt = dep.ExpiresAt.ToString("yyyy-MM-dd");
+                            var docsEvents = !string.IsNullOrEmpty(projId) && !string.IsNullOrEmpty(dep.DocsServiceId)
+                                ? await sliplane.GetServiceEventsAsync(token, projId, dep.DocsServiceId)
+                                : new List<SliplaneServiceEvent>();
+                            var samplesEvents = !string.IsNullOrEmpty(projId) && !string.IsNullOrEmpty(dep.SamplesServiceId)
+                                ? await sliplane.GetServiceEventsAsync(token, projId, dep.SamplesServiceId)
+                                : new List<SliplaneServiceEvent>();
+
+                            var (statusLabel, icon) = GetCombinedRowStatus(
+                                dep.DocsServiceId, docsEvents, dep.SamplesServiceId, samplesEvents);
+                            status = statusLabel;
+                            statusIcon = icon;
+
+                            if (rc.HasDocs)
+                                docsDisplay = GetServiceDisplay(dep.DocsUrl, dep.DocsStatus, docsEvents, statusLabel);
+                            if (rc.HasSamples)
+                                samplesDisplay = GetServiceDisplay(dep.SamplesUrl, dep.SamplesStatus, samplesEvents, statusLabel);
                         }
                         else
                         {
-                            status = "not deployed";
-                            statusIcon = Icons.CircleX;
-                            docsDisplay = NotDeployedDocsSamplesHint;
-                            samplesDisplay = NotDeployedDocsSamplesHint;
+                            // Sliplane doesn't know about this branch yet.
+                            // If we triggered a deploy and are waiting for the service to appear, keep "Deploying...".
+                            if (deployingItems.Value.Contains(rowId))
+                            {
+                                status = "pending";
+                                statusIcon = Icons.Clock;
+                                if (rc.HasDocs) docsDisplay = "Deploying...";
+                                if (rc.HasSamples) samplesDisplay = "Deploying...";
+                            }
+                            else
+                            {
+                                status = "not deployed";
+                                statusIcon = Icons.CircleX;
+                                if (rc.HasDocs) docsDisplay = NotDeployedDocsSamplesHint;
+                                if (rc.HasSamples) samplesDisplay = NotDeployedDocsSamplesHint;
+                            }
                         }
-                    }
 
-                    rows.Add(new PrRow(
-                        pr.HeadRef, pr.Number, pr.Title,
-                        status, statusIcon, expiresAt, docsDisplay, samplesDisplay, pr.HtmlUrl,
-                        dep?.DocsUrl, dep?.SamplesUrl));
+                        rows.Add(new PrRow(
+                            Id: rowId,
+                            RepoKey: rc.Key,
+                            RepoLabel: rc.Repo,
+                            HeadRef: pr.HeadRef,
+                            Number: pr.Number,
+                            Title: pr.Title,
+                            Status: status,
+                            StatusIcon: statusIcon,
+                            ExpiresAt: expiresAt,
+                            DocsDisplay: docsDisplay,
+                            SamplesDisplay: samplesDisplay,
+                            HtmlUrl: pr.HtmlUrl,
+                            DocsUrl: dep?.DocsUrl,
+                            SamplesUrl: dep?.SamplesUrl,
+                            HasDocs: rc.HasDocs,
+                            HasSamples: rc.HasSamples));
+                    }
                 }
 
-                return rows.OrderByDescending(r => r.Number).ToList();
+                return rows
+                    .OrderBy(r => r.RepoLabel, StringComparer.OrdinalIgnoreCase)
+                    .ThenByDescending(r => r.Number)
+                    .ToList();
             },
             options: new QueryOptions
             {
@@ -138,20 +172,18 @@ public class PrStagingDeployApp : ViewBase
                     if (result.IsOk())
                     {
                         var rowList = overviewQuery.Value ?? new List<PrRow>();
-                        var prsToDeploy = rowList.Where(RowLooksLikeNoStagingYet)
-                            .Select(r => (r.HeadRef, r.Number))
-                            .ToList();
+                        var prsToDeploy = rowList.Where(RowLooksLikeNoStagingYet).ToList();
                         if (prsToDeploy.Count > 0)
                         {
-                            var branchSet = prsToDeploy.Select(x => x.HeadRef).ToHashSet();
+                            var idSet = prsToDeploy.Select(r => r.Id).ToHashSet(StringComparer.OrdinalIgnoreCase);
                             var updated = rowList.Select(r =>
-                                branchSet.Contains(r.HeadRef)
+                                idSet.Contains(r.Id)
                                     ? r with
                                     {
                                         Status = "pending",
                                         StatusIcon = Icons.Clock,
-                                        DocsDisplay = "Deploying...",
-                                        SamplesDisplay = "Deploying...",
+                                        DocsDisplay = r.HasDocs ? "Deploying..." : NotConfiguredHint,
+                                        SamplesDisplay = r.HasSamples ? "Deploying..." : NotConfiguredHint,
                                         DocsUrl = null,
                                         SamplesUrl = null
                                     }
@@ -162,7 +194,7 @@ public class PrStagingDeployApp : ViewBase
 
                         ShowMessage($"Triggering deploy for {prsToDeploy.Count} PRs...", false);
                         foreach (var item in prsToDeploy)
-                            _ = DeployBranchAsync(item.HeadRef, item.Number, clearMessageFirst: false);
+                            _ = DeployRowAsync(item, clearMessageFirst: false);
                     }
                     await Task.CompletedTask;
                 }, "Deploy All", AlertButtonSet.OkCancel);
@@ -183,8 +215,8 @@ public class PrStagingDeployApp : ViewBase
                                     {
                                         Status = "pending",
                                         StatusIcon = Icons.Clock,
-                                        DocsDisplay = DeletingStagingCellHint,
-                                        SamplesDisplay = DeletingStagingCellHint,
+                                        DocsDisplay = r.HasDocs ? DeletingStagingCellHint : NotConfiguredHint,
+                                        SamplesDisplay = r.HasSamples ? DeletingStagingCellHint : NotConfiguredHint,
                                         ExpiresAt = "—",
                                         DocsUrl = null,
                                         SamplesUrl = null
@@ -212,14 +244,14 @@ public class PrStagingDeployApp : ViewBase
                             var res = await sliplane.DeleteAllServicesInProjectAsync(token, projectId);
                             ShowMessage($"Deleted {res.Deleted} services. Failed: {res.Failed}.", res.Failed > 0);
 
-                            // Now update PR comments to "Deleted" for any PRs that had staging services
-                            var owner = config["GitHub:Owner"] ?? "";
-                            var repo = config["GitHub:Repo"] ?? "";
-                            if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
+                            // Update PR comments to "Deleted" for any PRs that had staging services.
+                            var prsThatHadServices = rowList.Where(r => !RowLooksLikeNoStagingYet(r)).ToList();
+                            foreach (var pr in prsThatHadServices)
                             {
-                                var prsThatHadServices = rowList.Where(r => !RowLooksLikeNoStagingYet(r)).ToList();
-                                foreach (var pr in prsThatHadServices)
-                                    _ = prComments.TryPostStagingRemovedAsync(owner, repo, pr.Number);
+                                var rc = reposProvider.FindByKey(pr.RepoKey);
+                                if (rc != null)
+                                    _ = prComments.TryPostStagingRemovedAsync(rc.Owner, rc.Repo, pr.Number,
+                                        docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
                             }
 
                             overviewQuery.Mutator.Revalidate();
@@ -271,31 +303,35 @@ public class PrStagingDeployApp : ViewBase
             return line.Length <= maxLen ? line : line[..maxLen] + "...";
         }
 
-        async Task DeployBranchAsync(string branchName, int prNumber, bool clearMessageFirst = true)
+        async Task DeployRowAsync(PrRow row, bool clearMessageFirst = true)
         {
             var t = config["Sliplane:ApiToken"] ?? "";
             if (string.IsNullOrEmpty(t)) { ShowMessage("Sliplane API token required.", true); return; }
             if (clearMessageFirst) ClearMessage();
 
+            var rc = reposProvider.FindByKey(row.RepoKey);
+            if (rc == null)
+            {
+                ShowMessage($"Repo {row.RepoKey} not configured.", true);
+                return;
+            }
+
             // Mark this branch as "deploying" so the query fetcher keeps the row in Deploying... state
             // even before Sliplane registers the new service.
-            deployingBranches.Set(prev =>
+            deployingItems.Set(prev =>
             {
-                var next = new HashSet<string>(prev, StringComparer.OrdinalIgnoreCase) { branchName };
+                var next = new HashSet<string>(prev, StringComparer.OrdinalIgnoreCase) { row.Id };
                 return next;
             });
 
             try
             {
-                var owner = config["GitHub:Owner"] ?? "";
-                var repo = config["GitHub:Repo"] ?? "";
+                var result = await deploySvc.DeployBranchAsync(t, rc, row.HeadRef, row.Number);
 
-                var result = await deploySvc.DeployBranchAsync(t, branchName, prNumber, null, owner, repo);
-
-                deployingBranches.Set(prev =>
+                deployingItems.Set(prev =>
                 {
                     var next = new HashSet<string>(prev, StringComparer.OrdinalIgnoreCase);
-                    next.Remove(branchName);
+                    next.Remove(row.Id);
                     return next;
                 });
 
@@ -311,64 +347,68 @@ public class PrStagingDeployApp : ViewBase
                 {
                     overviewQuery.Mutator.Revalidate();
 
-                    if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
+                    if (!string.IsNullOrEmpty(result.DocsServiceId) || !string.IsNullOrEmpty(result.SamplesServiceId))
                     {
-                        if (result.Success && (!string.IsNullOrEmpty(result.DocsServiceId) || !string.IsNullOrEmpty(result.SamplesServiceId)))
-                        {
-                            await prComments.TryPostStagingAsync(
-                                owner, repo, prNumber, result.DocsUrl, result.SamplesUrl, error: null);
-                            if (!string.IsNullOrEmpty(result.DocsServiceId) || !string.IsNullOrEmpty(result.SamplesServiceId))
-                                await errorWatcher.EnqueueAsync(new StagingErrorWatchRequest(
-                                    owner, repo, prNumber, result.DocsServiceId, result.SamplesServiceId));
-                        }
-                        else
-                        {
-                            await prComments.TryPostStagingAsync(
-                                owner, repo, prNumber, null, null, TruncLine(result.Message, 500));
-                        }
+                        await prComments.TryPostStagingAsync(
+                            rc.Owner, rc.Repo, row.Number, result.DocsUrl, result.SamplesUrl, error: null,
+                            docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
+                        await errorWatcher.EnqueueAsync(new StagingErrorWatchRequest(
+                            rc.Key, rc.Owner, rc.Repo, row.Number, result.DocsServiceId, result.SamplesServiceId));
+                    }
+                    else
+                    {
+                        await prComments.TryPostStagingAsync(
+                            rc.Owner, rc.Repo, row.Number, null, null, TruncLine(result.Message, 500),
+                            docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
                     }
                 }
-                else if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
+                else
                 {
                     await prComments.TryPostStagingAsync(
-                        owner, repo, prNumber, null, null, TruncLine(result.Message, 500));
+                        rc.Owner, rc.Repo, row.Number, null, null, TruncLine(result.Message, 500),
+                        docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
                 }
             }
             catch (Exception ex)
             {
-                // On unexpected error, also remove from deployingBranches.
-                deployingBranches.Set(prev =>
+                deployingItems.Set(prev =>
                 {
                     var next = new HashSet<string>(prev, StringComparer.OrdinalIgnoreCase);
-                    next.Remove(branchName);
+                    next.Remove(row.Id);
                     return next;
                 });
                 ShowMessage(ex.Message, true);
             }
         }
 
-        async Task DeleteBranchAsync(string branchName, int prNumber)
+        async Task DeleteRowAsync(PrRow row)
         {
             var t = config["Sliplane:ApiToken"] ?? "";
             if (string.IsNullOrEmpty(t)) { ShowMessage("Sliplane API token required.", true); return; }
             ClearMessage();
+
+            var rc = reposProvider.FindByKey(row.RepoKey);
+            if (rc == null)
+            {
+                ShowMessage($"Repo {row.RepoKey} not configured.", true);
+                return;
+            }
+
             try
             {
-                var owner = config["GitHub:Owner"] ?? "";
-                var repo = config["GitHub:Repo"] ?? "";
-
-                var result = await deploySvc.DeleteBranchAsync(t, prNumber);
+                var result = await deploySvc.DeleteBranchAsync(t, rc, row.Number);
                 ShowMessage(result.Message, !result.Success);
                 if (result.Success)
                 {
                     overviewQuery.Mutator.Revalidate();
-                    if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
-                        await prComments.TryPostStagingRemovedAsync(owner, repo, prNumber);
+                    await prComments.TryPostStagingRemovedAsync(rc.Owner, rc.Repo, row.Number,
+                        docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
                 }
-                else if (!string.IsNullOrEmpty(owner) && !string.IsNullOrEmpty(repo))
+                else
                 {
                     await prComments.TryPostStagingAsync(
-                        owner, repo, prNumber, null, null, TruncLine(result.Message, 500));
+                        rc.Owner, rc.Repo, row.Number, null, null, TruncLine(result.Message, 500),
+                        docsEnabled: rc.HasDocs, samplesEnabled: rc.HasSamples);
                 }
             }
             catch (Exception ex) { ShowMessage(ex.Message, true); }
@@ -378,6 +418,11 @@ public class PrStagingDeployApp : ViewBase
             return Layout.Center()
                 | Text.H2("PR Staging Deploy")
                 | Text.Muted("Configure Sliplane:ApiToken in appsettings or environment variables.");
+
+        if (reposProvider.All.Count == 0)
+            return Layout.Center()
+                | Text.H2("PR Staging Deploy")
+                | Text.Muted("No repos configured. Set GitHub:Owner/Repo (legacy) or Repos[] (multi-repo).");
 
         var rows = pinnedTableRows.Value ?? overviewQuery.Value ?? new List<PrRow>();
 
@@ -390,11 +435,36 @@ public class PrStagingDeployApp : ViewBase
         var header = Layout.Horizontal().Height(Size.Fit())
             | Text.H2("PR Staging Deploy");
 
+        var showSamplesColumn = reposProvider.All.Any(r => r.HasSamples);
+
+        var hiddenColumns = new List<Expression<Func<PrRow, object>>>
+        {
+            r => r.Id,
+            r => r.RepoKey,
+            r => r.HeadRef,
+            r => r.HtmlUrl!,
+            r => r.DocsUrl!,
+            r => r.SamplesUrl!,
+            r => r.HasDocs,
+            r => r.HasSamples,
+        };
+        if (!showSamplesColumn)
+            hiddenColumns.Add(r => r.SamplesDisplay);
+
+        var openSubmenu = new List<MenuItem>
+        {
+            MenuItem.Default(Icons.GitBranch, "pr").Label("Open PR").Tag("pr"),
+            MenuItem.Default(Icons.FileText, "docs").Label("Open Docs").Tag("docs"),
+        };
+        if (showSamplesColumn)
+            openSubmenu.Add(MenuItem.Default(Icons.Box, "samples").Label("Open Samples").Tag("samples"));
+
         var table = rows
             .AsQueryable()
-            .ToDataTable(r => r.HeadRef)
+            .ToDataTable(r => r.Id)
             .RefreshToken(refreshToken)
             .Height(Size.Full())
+            .Header(r => r.RepoLabel, "Repo")
             .Header(r => r.Number, "# PR")
             .Header(r => r.Title, "Name PR")
             .Header(r => r.StatusIcon, "Icon")
@@ -402,6 +472,7 @@ public class PrStagingDeployApp : ViewBase
             .Header(r => r.ExpiresAt, "Expires")
             .Header(r => r.DocsDisplay, "Docs")
             .Header(r => r.SamplesDisplay, "Samples")
+            .Width(r => r.RepoLabel, Size.Px(160))
             .Width(r => r.Number, Size.Px(50))
             .Width(r => r.Title, Size.Px(300))
             .Width(r => r.StatusIcon, Size.Px(50))
@@ -409,95 +480,97 @@ public class PrStagingDeployApp : ViewBase
             .Width(r => r.ExpiresAt, Size.Px(100))
             .Width(r => r.DocsDisplay, Size.Px(450))
             .Width(r => r.SamplesDisplay, Size.Px(450))
-            .Hidden(r => r.HeadRef)
-            .Hidden(r => r.HtmlUrl)
-            .Hidden(r => r.DocsUrl)
-            .Hidden(r => r.SamplesUrl)
+            .Hidden(hiddenColumns)
             .Config(c =>
             {
                 c.AllowSorting = true;
                 c.AllowFiltering = true;
                 c.ShowSearch = true;
-
             })
             .RowActions(
                 MenuItem.Default(Icons.Rocket, "Deploy").Tag("deploy"),
                 MenuItem.Default(Icons.Trash2, "Delete").Tag("delete"),
                 MenuItem.Default(Icons.ExternalLink, "open").Label("Open").Tag("open-dd")
-                    .Children([
-                        MenuItem.Default(Icons.GitBranch, "pr").Label("Open PR").Tag("pr"),
-                        MenuItem.Default(Icons.FileText, "docs").Label("Open Docs").Tag("docs"),
-                        MenuItem.Default(Icons.Box, "samples").Label("Open Samples").Tag("samples"),
-                    ]))
+                    .Children(openSubmenu.ToArray()))
             .OnRowAction(e =>
             {
                 var args = e.Value;
                 if (args is null) return ValueTask.CompletedTask;
-                var headRef = args.Id?.ToString();
+                var rowId = args.Id?.ToString();
                 var tag = args.Tag?.ToString();
-                if (string.IsNullOrEmpty(headRef)) return ValueTask.CompletedTask;
+                if (string.IsNullOrEmpty(rowId)) return ValueTask.CompletedTask;
+                var row = rows.FirstOrDefault(r => r.Id == rowId);
+                if (row == null) return ValueTask.CompletedTask;
 
                 if (tag == "deploy")
                 {
-                    var branch = headRef;
-                    var prRow = rows.FirstOrDefault(r => r.HeadRef == branch);
-                    if (prRow != null && !RowLooksLikeNoStagingYet(prRow))
+                    if (!RowLooksLikeNoStagingYet(row))
                     {
-                        // Services already exist — just inform the user, no action taken.
                         showAlert(
-                            $"Staging services for branch \"{branch}\" already exist.",
+                            $"Staging services for {row.RepoLabel}/{row.HeadRef} already exist.",
                             _ => { }, "Services already deployed", AlertButtonSet.Ok);
                     }
                     else
                     {
-                        showAlert($"Deploy docs and samples for branch \"{branch}\"?", result =>
+                        showAlert($"Deploy staging for {row.RepoLabel}/{row.HeadRef}?", result =>
                         {
                             if (result.IsOk())
                             {
-                                var updated = rows.Select(r => r.HeadRef == branch
-                                    ? r with { Status = "pending", StatusIcon = Icons.Clock, DocsDisplay = "Deploying...", SamplesDisplay = "Deploying...", DocsUrl = null, SamplesUrl = null }
+                                var capturedRow = row;
+                                var updated = rows.Select(r => r.Id == capturedRow.Id
+                                    ? r with
+                                    {
+                                        Status = "pending",
+                                        StatusIcon = Icons.Clock,
+                                        DocsDisplay = r.HasDocs ? "Deploying..." : NotConfiguredHint,
+                                        SamplesDisplay = r.HasSamples ? "Deploying..." : NotConfiguredHint,
+                                        DocsUrl = null,
+                                        SamplesUrl = null
+                                    }
                                     : r).ToList();
                                 overviewQuery.Mutator.Mutate(updated, revalidate: false);
                                 refreshToken.Refresh();
-                                var newPrRow = rows.FirstOrDefault(r => r.HeadRef == branch);
-                                if (newPrRow != null)
-                                    _ = DeployBranchAsync(branch, newPrRow.Number);
+                                _ = DeployRowAsync(capturedRow);
                             }
                         }, "Deploy", AlertButtonSet.OkCancel);
                     }
                 }
                 else if (tag == "delete")
                 {
-                    var branch = headRef;
-                    showAlert($"Are you sure you want to delete deployment for branch \"{branch}\"?", result =>
+                    showAlert($"Are you sure you want to delete deployment for {row.RepoLabel}/{row.HeadRef}?", result =>
                     {
                         if (result.IsOk())
                         {
-                            var updated = rows.Select(r => r.HeadRef == branch
-                                ? r with { Status = "not deployed", StatusIcon = Icons.CircleX, DocsDisplay = NotDeployedDocsSamplesHint, SamplesDisplay = NotDeployedDocsSamplesHint, ExpiresAt = "—", DocsUrl = null, SamplesUrl = null }
+                            var capturedRow = row;
+                            var updated = rows.Select(r => r.Id == capturedRow.Id
+                                ? r with
+                                {
+                                    Status = "not deployed",
+                                    StatusIcon = Icons.CircleX,
+                                    DocsDisplay = r.HasDocs ? NotDeployedDocsSamplesHint : NotConfiguredHint,
+                                    SamplesDisplay = r.HasSamples ? NotDeployedDocsSamplesHint : NotConfiguredHint,
+                                    ExpiresAt = "—",
+                                    DocsUrl = null,
+                                    SamplesUrl = null
+                                }
                                 : r).ToList();
                             overviewQuery.Mutator.Mutate(updated, revalidate: false);
                             refreshToken.Refresh();
-                            var prRow = rows.FirstOrDefault(r => r.HeadRef == branch);
-                            if (prRow != null)
-                                _ = DeleteBranchAsync(branch, prRow.Number);
+                            _ = DeleteRowAsync(capturedRow);
                         }
                     }, "Delete", AlertButtonSet.OkCancel);
                 }
                 else if (tag == "pr")
                 {
-                    var pr = rows.FirstOrDefault(r => r.HeadRef == headRef);
-                    if (pr?.HtmlUrl != null) client.OpenUrl(pr.HtmlUrl);
+                    if (row.HtmlUrl != null) client.OpenUrl(row.HtmlUrl);
                 }
                 else if (tag == "docs")
                 {
-                    var pr = rows.FirstOrDefault(r => r.HeadRef == headRef);
-                    if (!string.IsNullOrEmpty(pr?.DocsUrl)) client.OpenUrl(pr.DocsUrl!);
+                    if (!string.IsNullOrEmpty(row.DocsUrl)) client.OpenUrl(row.DocsUrl!);
                 }
                 else if (tag == "samples")
                 {
-                    var pr = rows.FirstOrDefault(r => r.HeadRef == headRef);
-                    if (!string.IsNullOrEmpty(pr?.SamplesUrl)) client.OpenUrl(pr.SamplesUrl!);
+                    if (!string.IsNullOrEmpty(row.SamplesUrl)) client.OpenUrl(row.SamplesUrl!);
                 }
                 return ValueTask.CompletedTask;
             });
@@ -512,13 +585,18 @@ public class PrStagingDeployApp : ViewBase
         "No staging service yet.\n\n"
         + "Use Deploy (rocket) in the row menu — after Sliplane creates the service, deploy/build events appear here.";
 
+    private const string NotConfiguredHint = "—";
+
     private const string DeletingStagingCellHint = "Deleting staging…";
 
     /// <summary>Matches rows built in the query fetcher when there is no Sliplane deployment for the branch.</summary>
-    private static bool RowLooksLikeNoStagingYet(PrRow r) =>
-        r.Status == "not deployed"
-        && string.Equals(r.DocsDisplay, NotDeployedDocsSamplesHint, StringComparison.Ordinal)
-        && string.Equals(r.SamplesDisplay, NotDeployedDocsSamplesHint, StringComparison.Ordinal);
+    private static bool RowLooksLikeNoStagingYet(PrRow r)
+    {
+        if (r.Status != "not deployed") return false;
+        var docsOk = !r.HasDocs || string.Equals(r.DocsDisplay, NotDeployedDocsSamplesHint, StringComparison.Ordinal);
+        var samplesOk = !r.HasSamples || string.Equals(r.SamplesDisplay, NotDeployedDocsSamplesHint, StringComparison.Ordinal);
+        return docsOk && samplesOk;
+    }
 
     private const string PreparingStagingLogMessage =
         "Preparing…\nBuild and deploy events will appear here shortly.";
@@ -654,5 +732,4 @@ public class PrStagingDeployApp : ViewBase
 
         return PreparingStagingLogMessage;
     }
-
 }

--- a/project-demos/pr-staging-deploy/Models/StagingModels.cs
+++ b/project-demos/pr-staging-deploy/Models/StagingModels.cs
@@ -20,6 +20,7 @@ public record GitHubPullRequest(
 
 /// <summary>Staging deployment for a branch (docs + samples services).</summary>
 public record StagingDeployment(
+    string RepoKey,
     string BranchName,
     string BranchSafe,
     string? DocsServiceId,

--- a/project-demos/pr-staging-deploy/Models/StagingRepoConfig.cs
+++ b/project-demos/pr-staging-deploy/Models/StagingRepoConfig.cs
@@ -1,0 +1,42 @@
+namespace PrStagingDeploy.Models;
+
+/// <summary>
+/// Single repository configured for PR staging deploys.
+/// A repo may have <see cref="Docs"/>, <see cref="Samples"/>, or both. Whichever section is present
+/// is the one this repo deploys for each PR.
+/// </summary>
+public sealed class StagingRepoConfig
+{
+    /// <summary>Stable slug used in Sliplane service names. Lowercase, hyphenated.</summary>
+    public string Key { get; set; } = "";
+
+    /// <summary>GitHub owner (org/user) where PRs live.</summary>
+    public string Owner { get; set; } = "";
+
+    /// <summary>GitHub repo name where PRs live.</summary>
+    public string Repo { get; set; } = "";
+
+    /// <summary>Docs component (omit to skip docs deploys for this repo).</summary>
+    public StagingComponentConfig? Docs { get; set; }
+
+    /// <summary>Samples component (omit to skip samples deploys for this repo).</summary>
+    public StagingComponentConfig? Samples { get; set; }
+
+    public bool HasDocs => Docs != null && !string.IsNullOrWhiteSpace(Docs.Repo);
+    public bool HasSamples => Samples != null && !string.IsNullOrWhiteSpace(Samples.Repo);
+}
+
+/// <summary>
+/// One deployable component (docs OR samples) of a <see cref="StagingRepoConfig"/>.
+/// </summary>
+public sealed class StagingComponentConfig
+{
+    /// <summary>Git URL Sliplane will clone (typically the same as the PR repo, but can differ for monorepos).</summary>
+    public string Repo { get; set; } = "";
+
+    /// <summary>Path to the Dockerfile within the cloned repo.</summary>
+    public string Dockerfile { get; set; } = "Dockerfile";
+
+    /// <summary>Docker build context within the cloned repo.</summary>
+    public string Context { get; set; } = ".";
+}

--- a/project-demos/pr-staging-deploy/Program.cs
+++ b/project-demos/pr-staging-deploy/Program.cs
@@ -19,6 +19,7 @@ server.Services.AddHttpClient("Sliplane", client =>
 });
 
 server.Services.AddSingleton(server.Configuration);
+server.Services.AddSingleton<StagingReposProvider>();
 server.Services.AddScoped<GitHubApiClient>();
 server.Services.AddScoped<SliplaneStagingClient>();
 server.Services.AddScoped<StagingDeployService>();

--- a/project-demos/pr-staging-deploy/README.md
+++ b/project-demos/pr-staging-deploy/README.md
@@ -20,20 +20,20 @@ This application is powered by [Ivy Framework](https://github.com/Ivy-Interactiv
 - **GitHub Webhook** — `POST /webhook`:
   - `pull_request` opened/reopened → auto-deploy
   - `pull_request` synchronize → redeploy
-  - `pull_request` closed → deployment kept (no immediate delete)
+  - `pull_request` closed → delete staging services for that PR
   - `issue_comment` with `/deploy` → deploy on command
 - **Auto-cleanup** — background job runs hourly; removes deployments only when **both** ExpiryDays passed (since deploy start) **and** PR is closed
-- **PR comments (optional)** — after a successful deploy (webhook auto-deploy, `/deploy`, or Deploy in the UI), posts or updates **one** comment on the PR with Docs and Samples links. Uses a dedicated PAT; the comment appears as that GitHub user (bot or service account).
-- **PR comment reactions (optional)** — when someone posts `/deploy` and is allowed, the bot reacts to that comment with the GitHub `rocket` reaction (so people see it was read).
+- **PR comments (optional)** — after deploy, posts or updates **one** comment with Docs/Samples links (uses `GitHub:PrCommentToken`, or `GitHub:Token` if unset)
+- **PR comment reactions (optional)** — bot can react with `rocket` to `/deploy` comments when configured
 
 ## Configuration
 
-### Option 1: User Secrets (Recommended for Local Development)
+### Option 1: User Secrets (recommended for local development)
 
 ```bash
 cd project-demos/pr-staging-deploy
 
-# GitHub (required for /deploy comments and expiry cleanup)
+# GitHub — legacy single-repo (simplest): PRs live in this repo
 dotnet user-secrets set "GitHub:Owner" "your-org"
 dotnet user-secrets set "GitHub:Repo" "your-repo"
 dotnet user-secrets set "GitHub:Token" "ghp_your_token"
@@ -43,7 +43,7 @@ dotnet user-secrets set "Sliplane:ApiToken" "api_rw_org_xxx"
 dotnet user-secrets set "Sliplane:ProjectId" "project_xxx"
 dotnet user-secrets set "Sliplane:ServerId" "server_xxx"
 
-# Staging (optional – defaults shown)
+# Staging — optional (defaults shown). Omit Docs/Samples URLs to skip that target.
 dotnet user-secrets set "Staging:SamplesRepo" "https://github.com/your-org/your-repo"
 dotnet user-secrets set "Staging:DocsRepo" "https://github.com/your-org/your-repo"
 dotnet user-secrets set "Staging:SamplesDockerContext" "."
@@ -52,31 +52,27 @@ dotnet user-secrets set "Staging:SamplesDockerfile" ".github/docker/Dockerfile.s
 dotnet user-secrets set "Staging:DocsDockerfile" ".github/docker/Dockerfile.docs"
 dotnet user-secrets set "Staging:ExpiryDays" "7"
 
-# Webhook (optional – for auto-deploy on PR open/update/close)
+# Optional: first segment of Sliplane service names — default "ivy" → names start with "ivy-staging-…".
+# Set your own prefix per deployment (e.g. "tendril" → "tendril-staging-…-docs-…").
+# dotnet user-secrets set "Staging:DeploymentKey" "tendril"
+
+# Webhook (optional — auto-deploy on PR open/update/close)
 dotnet user-secrets set "GitHub:WebhookSecret" "your_webhook_secret"
 
-# Optional: comma-separated GitHub logins (case-insensitive). If empty, no user-based restriction.
-# Auto-deploy (PR open / push): only if the PR author is in this list.
-# /deploy comment: only if the comment author is in this list (PR author may be anyone).
+# Optional: comma-separated GitHub logins. PR auto-deploy and `/deploy` can be restricted.
 dotnet user-secrets set "GitHub:DeployAllowedUsers" "alice,bob"
 
-# Optional: PAT used for PR comment and comment reactions (Issues API). Reaction/comment appear as the PAT owner.
-# Fine-grained: Issues read/write on the repo. Classic: repo scope.
+# Optional: PAT for PR comments (Issues API). If omitted, GitHub:Token is used.
 dotnet user-secrets set "GitHub:PrCommentToken" "ghp_xxx"
 ```
 
-### Who can trigger deploy (webhooks)
+If **`Repos`** is empty, the app builds one staging entry from **`GitHub:Owner`**, **`GitHub:Repo`**, and **`Staging:*`** as above.
 
-| Event | Who must be on the list (when `DeployAllowedUsers` is set) |
-|--------|-----------------------------------------------------------|
-| PR opened / reopened / synchronize | **PR author** (whose PR gets auto-deploy) |
-| Comment `/deploy` | **Comment author** (so a maintainer on the list can deploy someone else’s PR) |
+### Multi-repo (`Repos[]`)
 
-If `DeployAllowedUsers` is **empty**, GitHub user checks are skipped (same as before). Closing a PR is **not** gated by this list. The in-app **Deploy** buttons are not tied to GitHub identity — restrict the app URL separately if needed.
+For several GitHub repos in one app, use a **`Repos`** array (JSON in `appsettings` or flat keys like `Repos:0:Owner`, `Repos:0:Repo`, `Repos:0:Docs:Repo`, …). Each row can enable Docs only, Samples only, or both. See comments in code and `StagingRepoConfig` for the full shape.
 
-### Option 2: Environment Variables (for Sliplane Deployment)
-
-When deploying to Sliplane, set these environment variables:
+### Option 2: Environment variables (Sliplane)
 
 ```
 GitHub__Owner=your-org
@@ -92,76 +88,72 @@ Staging__DocsDockerContext=.
 Staging__SamplesDockerfile=.github/docker/Dockerfile.samples
 Staging__DocsDockerfile=.github/docker/Dockerfile.docs
 Staging__ExpiryDays=7
+# Optional — prefix before "-staging-" in service names (default ivy). Example: tendril → tendril-staging-…
+# Staging__DeploymentKey=tendril
+GitHub__WebhookSecret=your_webhook_secret
 GitHub__DeployAllowedUsers=alice,bob
 GitHub__PrCommentToken=ghp_xxx
 ```
 
-### GitHub Webhook (Optional)
+Legacy keys above apply when **`Repos__0__*`** is not set; otherwise prefer **`Repos__0__Owner`**, **`Repos__0__Repo`**, **`Repos__0__Docs__*`** / **`Repos__0__Samples__*`**, etc.
 
-Webhook notifies the server; deploy is triggered only by `/deploy` comment or UI (no auto-deploy on PR open):
+### Service names (full pattern)
 
-1. GitHub → Settings → Webhooks → Add webhook
-2. **Payload URL**: `https://your-domain.com/webhook`
-3. **Content type**: `application/json`
-4. **Secret**: `openssl rand -hex 32`
-5. **Events**: Pull requests, Issue comments
-6. Add to config: `GitHub:WebhookSecret`
+One slug at the start only:
 
-- **`/deploy`** in PR comment → deploy (requires `GitHub:Token`)
-- **PR closed** → deployment stays until ExpiryDays + closed PR (cleanup job removes it)
+`{slug}-staging-docs-{prNumber}` and `{slug}-staging-samples-{prNumber}`.
 
-**Auto-deploy not working?** Check:
-1. **GitHub** → Webhooks → Recent Deliveries: did `pull_request` get **200**? (401 = secret mismatch)
-2. **Sliplane logs**: look for `"PR #X opened"` and `"Deploy result"` — if missing, webhook may not reach the app
-3. **Env vars** on Sliplane: `Sliplane__ApiToken`, `Sliplane__ProjectId`, `Sliplane__ServerId` must be set
-4. **Staging repos**: `Staging__SamplesRepo` and `Staging__DocsRepo` must point to the repo where the PR branch exists (e.g. same repo as the webhook)
+- **`slug`** = **`Staging:DeploymentKey`** (sanitized) when that value is set — shared by every repo in this app.
+- If **`Staging:DeploymentKey`** is **not** set, **`slug`** = each entry’s **`Repos[].Key`** (or legacy sanitized **`GitHub:Repo`**).
 
-**Troubleshooting 401:** If GitHub shows "Invalid HTTP Response: 401", the webhook secret doesn't match. Either:
-- Remove `GitHub__WebhookSecret` from Sliplane (temporarily disables verification), or
-- Regenerate the secret and set the same value in both GitHub and Sliplane.
+Examples:
+
+- `Staging:DeploymentKey` = `ivy-tendril` → **`ivy-tendril-staging-docs-1`** (not `ivy-tendril-staging-ivy-tendril-docs-1`).
+- No deployment key, repo key `my-app` → **`my-app-staging-samples-42`**.
+
+Older deployments may still use the previous `{deploymentKey}-staging-{repoKey}-docs-{pr}` shape; the app still recognizes those until you recreate services.
+
+### Who can trigger deploy (webhooks)
+
+| Event | Who must be on the list (when `DeployAllowedUsers` is set) |
+|--------|-----------------------------------------------------------|
+| PR opened / reopened / synchronize | **PR author** |
+| Comment `/deploy` | **Comment author** |
+
+If `DeployAllowedUsers` is **empty**, user checks are skipped.
+
+### GitHub Webhook
+
+1. GitHub → Settings → Webhooks → Add webhook  
+2. **Payload URL**: `https://your-domain.com/webhook`  
+3. **Content type**: `application/json`  
+4. **Secret**: match `GitHub:WebhookSecret`  
+5. **Events**: Pull requests, Issue comments  
+
+**Troubleshooting:** 401 on delivery usually means the webhook secret does not match the app config.
 
 ## How to Run Locally
 
-1. **Prerequisites:** .NET 10.0 SDK, GitHub token, Sliplane API token
-2. **Navigate to the project:**
-   ```bash
-   cd project-demos/pr-staging-deploy
-   ```
-3. **Restore dependencies:**
-   ```bash
-   dotnet restore
-   ```
-4. **Configure credentials** (see Option 1 above):
-   ```bash
-   dotnet user-secrets set "GitHub:Owner" "your-org"
-   dotnet user-secrets set "GitHub:Repo" "your-repo"
-   dotnet user-secrets set "GitHub:Token" "ghp_xxx"
-   dotnet user-secrets set "Sliplane:ApiToken" "api_xxx"
-   dotnet user-secrets set "Sliplane:ProjectId" "project_xxx"
-   dotnet user-secrets set "Sliplane:ServerId" "server_xxx"
-   ```
-5. **Start the app:**
-   ```bash
-   dotnet watch
-   ```
-6. **Open your browser** to the URL shown in the terminal (typically `http://localhost:5010`)
+1. **Prerequisites:** .NET 10.0 SDK, GitHub token, Sliplane API token  
+2. **Navigate:** `cd project-demos/pr-staging-deploy`  
+3. **Restore:** `dotnet restore`  
+4. **Configure** — Option 1 above (`dotnet user-secrets set …`)  
+5. **Run:** `dotnet watch`  
+6. Open the URL from the terminal (often `http://localhost:5010`)
 
 ## Deploy to Ivy Hosting
 
-1. **Navigate to the project:**
-   ```bash
-   cd project-demos/pr-staging-deploy
-   ```
-2. **Deploy:**
-   ```bash
-   ivy deploy
-   ```
-3. **Configure environment variables** in your Sliplane deployment (see Option 2 above).
+```bash
+cd project-demos/pr-staging-deploy
+ivy deploy
+```
+
+Set environment variables on Sliplane (Option 2).
 
 ## Learn More
 
-- [Sliplane](https://sliplane.io) — Deploy and manage containers
-- [GitHub API](https://docs.github.com/en/rest) — Pull requests, webhooks
+- [Sliplane](https://sliplane.io)
+- [GitHub API](https://docs.github.com/en/rest)
 - [Ivy documentation](https://docs.ivy.app)
 
 ## Tags

--- a/project-demos/pr-staging-deploy/Services/GitHubWebhookHandler.cs
+++ b/project-demos/pr-staging-deploy/Services/GitHubWebhookHandler.cs
@@ -2,14 +2,17 @@ namespace PrStagingDeploy.Services;
 
 using System.Security.Cryptography;
 using System.Text;
+using PrStagingDeploy.Models;
 
 /// <summary>
 /// Handles GitHub webhooks: pull_request (opened/reopened/synchronize → deploy; closed → delete staging), issue_comment (/deploy).
+/// Routes each event to the matching <see cref="StagingRepoConfig"/> by owner+repo.
 /// </summary>
 public class GitHubWebhookHandler
 {
     private readonly StagingDeployService _deployService;
     private readonly GitHubApiClient _github;
+    private readonly StagingReposProvider _reposProvider;
     private readonly PrStagingDeployCommentService _prComments;
     private readonly StagingErrorWatcherQueue _errorWatcher;
     private readonly IConfiguration _config;
@@ -18,6 +21,7 @@ public class GitHubWebhookHandler
     public GitHubWebhookHandler(
         StagingDeployService deployService,
         GitHubApiClient github,
+        StagingReposProvider reposProvider,
         PrStagingDeployCommentService prComments,
         StagingErrorWatcherQueue errorWatcher,
         IConfiguration config,
@@ -25,6 +29,7 @@ public class GitHubWebhookHandler
     {
         _deployService = deployService;
         _github = github;
+        _reposProvider = reposProvider;
         _prComments = prComments;
         _errorWatcher = errorWatcher;
         _config = config;
@@ -87,6 +92,15 @@ public class GitHubWebhookHandler
         var owner = repoEl.GetProperty("owner").GetProperty("login").GetString() ?? "";
         var repoName = repoEl.GetProperty("name").GetString() ?? "";
 
+        var repoConfig = _reposProvider.FindByOwnerRepo(owner, repoName);
+        if (repoConfig == null)
+        {
+            _logger.LogInformation(
+                "PR webhook for {Owner}/{Repo} ignored — no matching entry in Repos config.",
+                owner, repoName);
+            return;
+        }
+
         var headRepoEl = pr.GetProperty("head").GetProperty("repo");
         var headRepoCloneUrl = headRepoEl.TryGetProperty("clone_url", out var cu)
             ? cu.GetString()
@@ -99,7 +113,9 @@ public class GitHubWebhookHandler
             return;
         }
 
-        _logger.LogInformation("Processing PR webhook: action={Action} PR#{Pr} branch={Branch}", action, prNumber, branch);
+        _logger.LogInformation(
+            "Processing PR webhook: action={Action} repo={RepoKey} PR#{Pr} branch={Branch}",
+            action, repoConfig.Key, prNumber, branch);
 
         switch (action)
         {
@@ -113,7 +129,7 @@ public class GitHubWebhookHandler
                     break;
                 }
 
-                var existingDepOnOpen = await _deployService.GetDeploymentByPrNumberAsync(apiToken, prNumber);
+                var existingDepOnOpen = await _deployService.GetDeploymentByPrNumberAsync(apiToken, repoConfig, prNumber);
                 if (existingDepOnOpen != null)
                 {
                     _logger.LogInformation(
@@ -123,7 +139,8 @@ public class GitHubWebhookHandler
                     {
                         await _prComments.TryPostStagingAsync(
                             owner, repoName, prNumber,
-                            existingDepOnOpen.DocsUrl, existingDepOnOpen.SamplesUrl, error: null);
+                            existingDepOnOpen.DocsUrl, existingDepOnOpen.SamplesUrl, error: null,
+                            docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
                     }
 
                     break;
@@ -131,7 +148,7 @@ public class GitHubWebhookHandler
 
                 _logger.LogInformation("PR #{Pr} opened: {Title} branch={Branch}", prNumber, title, branch);
                 var deployResult = await _deployService.DeployBranchAsync(
-                    apiToken, branch, prNumber, headRepoCloneUrl, owner, repoName);
+                    apiToken, repoConfig, branch, prNumber, headRepoCloneUrl);
                 _logger.LogInformation("Deploy result: {Success} - {Message}", deployResult.Success, deployResult.Message);
                 if (deployResult.SkippedBecausePrNotOpen)
                 {
@@ -142,13 +159,15 @@ public class GitHubWebhookHandler
                 if (deployResult.Success && (!string.IsNullOrEmpty(deployResult.DocsServiceId) || !string.IsNullOrEmpty(deployResult.SamplesServiceId)))
                 {
                     await _prComments.TryPostStagingAsync(
-                        owner, repoName, prNumber, deployResult.DocsUrl, deployResult.SamplesUrl, error: null);
-                    await EnqueueErrorWatchAsync(owner, repoName, prNumber, deployResult.DocsServiceId, deployResult.SamplesServiceId);
+                        owner, repoName, prNumber, deployResult.DocsUrl, deployResult.SamplesUrl, error: null,
+                        docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
+                    await EnqueueErrorWatchAsync(repoConfig.Key, owner, repoName, prNumber, deployResult.DocsServiceId, deployResult.SamplesServiceId);
                 }
                 else
                 {
                     await _prComments.TryPostStagingAsync(
-                        owner, repoName, prNumber, null, null, TruncLine(deployResult.Message, 500));
+                        owner, repoName, prNumber, null, null, TruncLine(deployResult.Message, 500),
+                        docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
                 }
 
                 break;
@@ -163,14 +182,14 @@ public class GitHubWebhookHandler
                 }
 
                 _logger.LogInformation("PR #{Pr} updated: {Branch}", prNumber, branch);
-                var redeployResult = await _deployService.RedeployBranchAsync(apiToken, branch, prNumber);
+                var redeployResult = await _deployService.RedeployBranchAsync(apiToken, repoConfig, branch, prNumber);
                 _logger.LogInformation("Redeploy result: {Success} - {Message}", redeployResult.Success, redeployResult.Message);
 
                 if (!redeployResult.Success)
                 {
                     _logger.LogInformation("PR #{Pr} redeploy found 0 services, falling back to fresh deploy", prNumber);
                     var fallbackResult = await _deployService.DeployBranchAsync(
-                        apiToken, branch, prNumber, headRepoCloneUrl, owner, repoName);
+                        apiToken, repoConfig, branch, prNumber, headRepoCloneUrl);
                     _logger.LogInformation("Fallback deploy result: {Success} - {Message}", fallbackResult.Success, fallbackResult.Message);
 
                     if (fallbackResult.SkippedBecausePrNotOpen)
@@ -182,32 +201,36 @@ public class GitHubWebhookHandler
                     if (fallbackResult.Success && (!string.IsNullOrEmpty(fallbackResult.DocsServiceId) || !string.IsNullOrEmpty(fallbackResult.SamplesServiceId)))
                     {
                         await _prComments.TryPostStagingAsync(
-                            owner, repoName, prNumber, fallbackResult.DocsUrl, fallbackResult.SamplesUrl, error: null);
-                        await EnqueueErrorWatchAsync(owner, repoName, prNumber, fallbackResult.DocsServiceId, fallbackResult.SamplesServiceId);
+                            owner, repoName, prNumber, fallbackResult.DocsUrl, fallbackResult.SamplesUrl, error: null,
+                            docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
+                        await EnqueueErrorWatchAsync(repoConfig.Key, owner, repoName, prNumber, fallbackResult.DocsServiceId, fallbackResult.SamplesServiceId);
                     }
                     else
                     {
                         await _prComments.TryPostStagingAsync(
-                            owner, repoName, prNumber, null, null, TruncLine(fallbackResult.Message, 500));
+                            owner, repoName, prNumber, null, null, TruncLine(fallbackResult.Message, 500),
+                            docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
                     }
 
                     break;
                 }
 
                 // Redeploy triggered OK — post current known links, service will rebuild in background.
-                var syncDep = await _deployService.GetDeploymentByPrNumberAsync(apiToken, prNumber);
+                var syncDep = await _deployService.GetDeploymentByPrNumberAsync(apiToken, repoConfig, prNumber);
                 await _prComments.TryPostStagingAsync(
-                    owner, repoName, prNumber, syncDep?.DocsUrl, syncDep?.SamplesUrl, error: null);
-                await EnqueueErrorWatchAsync(owner, repoName, prNumber, syncDep?.DocsServiceId, syncDep?.SamplesServiceId);
+                    owner, repoName, prNumber, syncDep?.DocsUrl, syncDep?.SamplesUrl, error: null,
+                    docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
+                await EnqueueErrorWatchAsync(repoConfig.Key, owner, repoName, prNumber, syncDep?.DocsServiceId, syncDep?.SamplesServiceId);
 
                 break;
 
             case "closed":
                 _logger.LogInformation("PR #{Pr} closed: {Branch} — removing Sliplane staging services", prNumber, branch);
-                var deleteResult = await _deployService.DeleteBranchAsync(apiToken, prNumber);
+                var deleteResult = await _deployService.DeleteBranchAsync(apiToken, repoConfig, prNumber);
                 _logger.LogInformation("Delete result: {Success} - {Message}", deleteResult.Success, deleteResult.Message);
                 if (deleteResult.Success)
-                    await _prComments.TryPostStagingRemovedAsync(owner, repoName, prNumber);
+                    await _prComments.TryPostStagingRemovedAsync(owner, repoName, prNumber,
+                        docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
                 break;
 
             default:
@@ -236,6 +259,16 @@ public class GitHubWebhookHandler
         var prNumber = issue.GetProperty("number").GetInt32();
         var owner = root.GetProperty("repository").GetProperty("owner").GetProperty("login").GetString() ?? "";
         var repo = root.GetProperty("repository").GetProperty("name").GetString() ?? "";
+
+        var repoConfig = _reposProvider.FindByOwnerRepo(owner, repo);
+        if (repoConfig == null)
+        {
+            _logger.LogInformation(
+                "issue_comment /deploy for {Owner}/{Repo} ignored — no matching entry in Repos config.",
+                owner, repo);
+            return;
+        }
+
         var ghToken = _config["GitHub:Token"] ?? "";
 
         var branch = await _github.GetPullRequestBranchAsync(owner, repo, prNumber, ghToken);
@@ -263,21 +296,22 @@ public class GitHubWebhookHandler
 
         await _prComments.TryAddRocketReactionAsync(owner, repo, commentId);
 
-        var existingDep = await _deployService.GetDeploymentByPrNumberAsync(apiToken, prNumber);
+        var existingDep = await _deployService.GetDeploymentByPrNumberAsync(apiToken, repoConfig, prNumber);
         if (existingDep != null)
         {
             _logger.LogInformation("Staging services already exist for PR #{Pr}, posting current links", prNumber);
             if (!string.IsNullOrEmpty(existingDep.DocsServiceId) || !string.IsNullOrEmpty(existingDep.SamplesServiceId))
             {
                 await _prComments.TryPostStagingAsync(
-                    owner, repo, prNumber, existingDep.DocsUrl, existingDep.SamplesUrl, error: null);
+                    owner, repo, prNumber, existingDep.DocsUrl, existingDep.SamplesUrl, error: null,
+                    docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
             }
 
             return;
         }
 
         _logger.LogInformation("PR #{Pr} /deploy comment: {Branch}", prNumber, branch);
-        var result = await _deployService.DeployBranchAsync(apiToken, branch, prNumber, null, owner, repo);
+        var result = await _deployService.DeployBranchAsync(apiToken, repoConfig, branch, prNumber);
         _logger.LogInformation("Deploy result: {Success} - {Message}", result.Success, result.Message);
         if (result.SkippedBecausePrNotOpen)
         {
@@ -287,23 +321,25 @@ public class GitHubWebhookHandler
 
         if (result.Success && (!string.IsNullOrEmpty(result.DocsServiceId) || !string.IsNullOrEmpty(result.SamplesServiceId)))
         {
-            await _prComments.TryPostStagingAsync(owner, repo, prNumber, result.DocsUrl, result.SamplesUrl, error: null);
-            await EnqueueErrorWatchAsync(owner, repo, prNumber, result.DocsServiceId, result.SamplesServiceId);
+            await _prComments.TryPostStagingAsync(owner, repo, prNumber, result.DocsUrl, result.SamplesUrl, error: null,
+                docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
+            await EnqueueErrorWatchAsync(repoConfig.Key, owner, repo, prNumber, result.DocsServiceId, result.SamplesServiceId);
         }
         else
         {
-            await _prComments.TryPostStagingAsync(owner, repo, prNumber, null, null, TruncLine(result.Message, 500));
+            await _prComments.TryPostStagingAsync(owner, repo, prNumber, null, null, TruncLine(result.Message, 500),
+                docsEnabled: repoConfig.HasDocs, samplesEnabled: repoConfig.HasSamples);
         }
     }
 
     private ValueTask EnqueueErrorWatchAsync(
-        string owner, string repo, int prNumber,
+        string repoKey, string owner, string repo, int prNumber,
         string? docsServiceId, string? samplesServiceId)
     {
         if (string.IsNullOrEmpty(docsServiceId) && string.IsNullOrEmpty(samplesServiceId))
             return ValueTask.CompletedTask;
         return _errorWatcher.EnqueueAsync(
-            new StagingErrorWatchRequest(owner, repo, prNumber, docsServiceId, samplesServiceId));
+            new StagingErrorWatchRequest(repoKey, owner, repo, prNumber, docsServiceId, samplesServiceId));
     }
 
     private string GetApiToken()

--- a/project-demos/pr-staging-deploy/Services/PrStagingDeployCommentService.cs
+++ b/project-demos/pr-staging-deploy/Services/PrStagingDeployCommentService.cs
@@ -39,9 +39,11 @@ public class PrStagingDeployCommentService
         string? docsUrl,
         string? samplesUrl,
         string? error,
+        bool docsEnabled = true,
+        bool samplesEnabled = true,
         CancellationToken cancellationToken = default)
     {
-        var body = BuildBody(docsUrl, samplesUrl, error, removed: false);
+        var body = BuildBody(docsUrl, samplesUrl, error, removed: false, docsEnabled, samplesEnabled);
         return PostMarkerCommentAsync(owner, repo, prNumber, body, cancellationToken);
     }
 
@@ -50,9 +52,11 @@ public class PrStagingDeployCommentService
         string owner,
         string repo,
         int prNumber,
+        bool docsEnabled = true,
+        bool samplesEnabled = true,
         CancellationToken cancellationToken = default)
     {
-        var body = BuildBody(docsUrl: null, samplesUrl: null, error: null, removed: true);
+        var body = BuildBody(docsUrl: null, samplesUrl: null, error: null, removed: true, docsEnabled, samplesEnabled);
         return PostMarkerCommentAsync(owner, repo, prNumber, body, cancellationToken);
     }
 
@@ -62,11 +66,24 @@ public class PrStagingDeployCommentService
         long issueCommentId,
         CancellationToken cancellationToken = default)
     {
-        var pat = _config["GitHub:PrCommentToken"] ?? "";
+        var pat = ResolveCommentPat();
         if (string.IsNullOrWhiteSpace(pat))
             return;
 
         await _github.AddReactionToIssueCommentAsync(owner, repo, issueCommentId, RocketReaction, pat, cancellationToken);
+    }
+
+    /// <summary>
+    /// PAT for Issues API (comments + reactions). Prefer <c>GitHub:PrCommentToken</c> so the bot identity can differ from <c>GitHub:Token</c>.
+    /// If unset, falls back to <c>GitHub:Token</c> — otherwise PR comments are skipped entirely (easy to miss when only one repo is in <c>Repos[]</c>).
+    /// </summary>
+    private string? ResolveCommentPat()
+    {
+        var pr = _config["GitHub:PrCommentToken"];
+        if (!string.IsNullOrWhiteSpace(pr))
+            return pr;
+        var gh = _config["GitHub:Token"];
+        return string.IsNullOrWhiteSpace(gh) ? null : gh;
     }
 
     private async Task PostMarkerCommentAsync(
@@ -76,9 +93,14 @@ public class PrStagingDeployCommentService
         string body,
         CancellationToken cancellationToken)
     {
-        var pat = _config["GitHub:PrCommentToken"] ?? "";
+        var pat = ResolveCommentPat();
         if (string.IsNullOrWhiteSpace(pat))
+        {
+            _logger.LogWarning(
+                "Skipping PR #{Pr} staging comment: neither GitHub:PrCommentToken nor GitHub:Token is set.",
+                prNumber);
             return;
+        }
 
         await DeleteAllMarkerCommentsAsync(owner, repo, prNumber, pat, cancellationToken);
         var id = await _github.CreateIssueCommentAsync(owner, repo, prNumber, pat, body, cancellationToken);
@@ -88,7 +110,13 @@ public class PrStagingDeployCommentService
             _logger.LogInformation("Replaced staging comment on PR #{Pr} (deleted prior marker comments)", prNumber);
     }
 
-    private static string BuildBody(string? docsUrl, string? samplesUrl, string? error, bool removed)
+    private static string BuildBody(
+        string? docsUrl,
+        string? samplesUrl,
+        string? error,
+        bool removed,
+        bool docsEnabled,
+        bool samplesEnabled)
     {
         var sb = new StringBuilder();
         sb.AppendLine(Marker);
@@ -113,8 +141,10 @@ public class PrStagingDeployCommentService
 
         sb.AppendLine("### Staging preview");
         sb.AppendLine();
-        sb.AppendLine(FormatLinkLine("📄 Docs", docsUrl));
-        sb.AppendLine(FormatLinkLine("🧪 Samples", samplesUrl));
+        if (docsEnabled)
+            sb.AppendLine(FormatLinkLine("📄 Docs", docsUrl));
+        if (samplesEnabled)
+            sb.AppendLine(FormatLinkLine("🧪 Samples", samplesUrl));
         return sb.ToString();
     }
 

--- a/project-demos/pr-staging-deploy/Services/StagingDeployService.cs
+++ b/project-demos/pr-staging-deploy/Services/StagingDeployService.cs
@@ -2,45 +2,83 @@ namespace PrStagingDeploy.Services;
 
 using PrStagingDeploy.Models;
 
-/// <summary>Orchestrates deploy/delete of docs + samples for a branch.</summary>
+/// <summary>Orchestrates deploy/delete of docs + samples for a branch across one or more repos.</summary>
 public class StagingDeployService
 {
     private readonly SliplaneStagingClient _sliplane;
     private readonly GitHubApiClient _github;
+    private readonly StagingReposProvider _reposProvider;
     private readonly IConfiguration _config;
     private readonly ILogger<StagingDeployService> _logger;
 
     public StagingDeployService(
         SliplaneStagingClient sliplane,
         GitHubApiClient github,
+        StagingReposProvider reposProvider,
         IConfiguration config,
         ILogger<StagingDeployService> logger)
     {
         _sliplane = sliplane;
         _github = github;
+        _reposProvider = reposProvider;
         _config = config;
         _logger = logger;
     }
 
-    public string SamplesRepo => _config["Staging:SamplesRepo"] ?? "https://github.com/Ivy-Interactive/Ivy-Examples";
-    public string DocsRepo => _config["Staging:DocsRepo"] ?? "https://github.com/Ivy-Interactive/Ivy-Framework";
-    public string SamplesContext => _config["Staging:SamplesDockerContext"] ?? "project-demos/sliplane-manage";
-    public string DocsContext => _config["Staging:DocsDockerContext"] ?? "docs";
-    public string SamplesDockerfile => _config["Staging:SamplesDockerfile"] ?? "Dockerfile";
-    public string DocsDockerfile => _config["Staging:DocsDockerfile"] ?? "Dockerfile";
+    /// <summary>
+    /// Configured deployment slug when <c>Staging:DeploymentKey</c> is set; otherwise default <c>ivy</c> for legacy name parsing only.
+    /// Actual service names use <see cref="ResolveServiceSlug"/> (DeploymentKey if set, else each repo’s <c>Key</c>).
+    /// </summary>
+    public string DeploymentKey
+    {
+        get
+        {
+            var raw = _config["Staging:DeploymentKey"];
+            if (string.IsNullOrWhiteSpace(raw))
+                return "ivy";
+            return StagingReposProvider.SanitizeKey(raw);
+        }
+    }
+
+    /// <summary>
+    /// Single slug at the start of service names: <c>{slug}-staging-docs-{PR}</c>.
+    /// If <c>Staging:DeploymentKey</c> is set, all repos share that slug; otherwise each repo uses its own <paramref name="repo"/>.Key.
+    /// </summary>
+    public string ResolveServiceSlug(StagingRepoConfig repo)
+    {
+        var raw = _config["Staging:DeploymentKey"];
+        if (!string.IsNullOrWhiteSpace(raw))
+            return StagingReposProvider.SanitizeKey(raw);
+        return repo.Key;
+    }
+
     public int ExpiryDays => int.TryParse(_config["Staging:ExpiryDays"], out var d) ? d : 7;
 
-    /// <summary>Pause (ms) after tearing down old services and before calling Sliplane create, only when GitHub owner/repo are provided. Lets merge/close webhooks win the race. Default 1200; set 0 to disable.</summary>
+    /// <summary>Pause (ms) after tearing down old services and before calling Sliplane create. Lets merge/close webhooks win the race. Default 1200; set 0 to disable.</summary>
     public int PreDeployDelayMs =>
         int.TryParse(_config["Staging:PreDeployDelayMs"], out var ms) ? Math.Max(0, ms) : 1200;
 
+    public IReadOnlyList<StagingRepoConfig> AllRepos => _reposProvider.All;
+
+    public StagingRepoConfig? FindRepoByKey(string? key) => _reposProvider.FindByKey(key);
+
+    public StagingRepoConfig? FindRepoByOwner(string? owner, string? repo) =>
+        _reposProvider.FindByOwnerRepo(owner, repo);
+
+    /// <summary>Sliplane service name: <c>{slug}-staging-docs-{PR}</c>.</summary>
+    public string DocsServiceName(StagingRepoConfig repo, int prNumber)
+        => $"{ResolveServiceSlug(repo)}-staging-docs-{prNumber}";
+
+    /// <summary>Sliplane service name: <c>{slug}-staging-samples-{PR}</c>.</summary>
+    public string SamplesServiceName(StagingRepoConfig repo, int prNumber)
+        => $"{ResolveServiceSlug(repo)}-staging-samples-{prNumber}";
+
     public async Task<StagingDeployResult> DeployBranchAsync(
         string apiToken,
+        StagingRepoConfig repoConfig,
         string branchName,
         int prNumber,
-        string? samplesRepoOverride = null,
-        string? gitHubOwner = null,
-        string? gitHubRepo = null,
+        string? cloneUrlOverride = null,
         CancellationToken cancellationToken = default)
     {
         var projectId = _config["Sliplane:ProjectId"] ?? "";
@@ -48,66 +86,85 @@ public class StagingDeployService
         if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(serverId))
             return new StagingDeployResult(false, "Sliplane:ProjectId and ServerId required.");
 
-        var skip = await TryGetClosedOrMergedSkipAsync(prNumber, gitHubOwner, gitHubRepo, cancellationToken);
+        var skip = await TryGetClosedOrMergedSkipAsync(prNumber, repoConfig.Owner, repoConfig.Repo, cancellationToken);
         if (skip is not null)
             return skip;
 
-        // Tear down any existing services for this PR before creating new ones. Otherwise a
-        // fallback deploy (e.g. synchronize when redeploy finds 0 services) can leave orphan
-        // Sliplane services alongside the new pair.
-        await DeleteBranchAsync(apiToken, prNumber);
+        // Tear down any existing services for this PR (within this repo) before creating new ones.
+        await DeleteBranchAsync(apiToken, repoConfig, prNumber);
 
         var ghToken = _config["GitHub:Token"] ?? "";
         if (PreDeployDelayMs > 0
-            && !string.IsNullOrEmpty(gitHubOwner)
-            && !string.IsNullOrEmpty(gitHubRepo)
+            && !string.IsNullOrEmpty(repoConfig.Owner)
+            && !string.IsNullOrEmpty(repoConfig.Repo)
             && !string.IsNullOrEmpty(ghToken))
         {
             await Task.Delay(PreDeployDelayMs, cancellationToken);
-            skip = await TryGetClosedOrMergedSkipAsync(prNumber, gitHubOwner, gitHubRepo, cancellationToken);
+            skip = await TryGetClosedOrMergedSkipAsync(prNumber, repoConfig.Owner, repoConfig.Repo, cancellationToken);
             if (skip is not null)
                 return skip;
         }
-
-        var docsName = $"ivy-staging-docs-{prNumber}";
-        var samplesName = $"ivy-staging-samples-{prNumber}";
-
-        // For fork PRs use the fork's clone URL so Sliplane can find the branch.
-        var samplesRepo = !string.IsNullOrEmpty(samplesRepoOverride) ? samplesRepoOverride : SamplesRepo;
 
         string? docsUrl = null;
         string? samplesUrl = null;
         string? docsId = null;
         string? samplesId = null;
+        string? lastError = null;
+        var anyAttempted = false;
 
         try
         {
-            var docsResult = await _sliplane.CreateServiceAsync(
-                apiToken, projectId, serverId,
-                docsName, DocsRepo, branchName, DocsDockerfile, DocsContext);
-            if (docsResult.Service != null)
+            if (repoConfig.HasDocs)
             {
-                docsId = docsResult.Service.Id;
-                docsUrl = string.IsNullOrEmpty(docsResult.Service.ManagedDomain)
-                    ? null
-                    : "https://" + docsResult.Service.ManagedDomain;
+                anyAttempted = true;
+                var docsResult = await _sliplane.CreateServiceAsync(
+                    apiToken, projectId, serverId,
+                    DocsServiceName(repoConfig, prNumber),
+                    repoConfig.Docs!.Repo, branchName,
+                    repoConfig.Docs.Dockerfile, repoConfig.Docs.Context);
+                if (docsResult.Service != null)
+                {
+                    docsId = docsResult.Service.Id;
+                    docsUrl = string.IsNullOrEmpty(docsResult.Service.ManagedDomain)
+                        ? null
+                        : "https://" + docsResult.Service.ManagedDomain;
+                }
+                else if (!string.IsNullOrEmpty(docsResult.Error))
+                {
+                    lastError = docsResult.Error;
+                }
             }
 
-            var samplesResult = await _sliplane.CreateServiceAsync(
-                apiToken, projectId, serverId,
-                samplesName, samplesRepo, branchName, SamplesDockerfile, SamplesContext);
-            if (samplesResult.Service != null)
+            if (repoConfig.HasSamples)
             {
-                samplesId = samplesResult.Service.Id;
-                samplesUrl = string.IsNullOrEmpty(samplesResult.Service.ManagedDomain)
-                    ? null
-                    : "https://" + samplesResult.Service.ManagedDomain;
+                anyAttempted = true;
+                // For fork PRs use the fork's clone URL so Sliplane can find the branch.
+                var samplesRepo = !string.IsNullOrEmpty(cloneUrlOverride) ? cloneUrlOverride : repoConfig.Samples!.Repo;
+                var samplesResult = await _sliplane.CreateServiceAsync(
+                    apiToken, projectId, serverId,
+                    SamplesServiceName(repoConfig, prNumber),
+                    samplesRepo, branchName,
+                    repoConfig.Samples!.Dockerfile, repoConfig.Samples.Context);
+                if (samplesResult.Service != null)
+                {
+                    samplesId = samplesResult.Service.Id;
+                    samplesUrl = string.IsNullOrEmpty(samplesResult.Service.ManagedDomain)
+                        ? null
+                        : "https://" + samplesResult.Service.ManagedDomain;
+                }
+                else if (!string.IsNullOrEmpty(samplesResult.Error))
+                {
+                    lastError = samplesResult.Error;
+                }
             }
 
-            var ok = docsResult.Service != null || samplesResult.Service != null;
+            if (!anyAttempted)
+                return new StagingDeployResult(false, $"Repo {repoConfig.Key} has neither Docs nor Samples configured.");
+
+            var ok = docsId != null || samplesId != null;
             var msg = ok
-                ? $"Deployed: docs={docsUrl ?? "pending"}, samples={samplesUrl ?? "pending"}"
-                : (docsResult.Error ?? samplesResult.Error ?? "Failed to create services.");
+                ? FormatDeployMessage(repoConfig, docsUrl, samplesUrl)
+                : (lastError ?? "Failed to create services.");
             return new StagingDeployResult(ok, msg, docsUrl, samplesUrl, docsId, samplesId);
         }
         catch (Exception ex)
@@ -116,12 +173,22 @@ public class StagingDeployService
         }
     }
 
-    public async Task<StagingDeployResult> RedeployBranchAsync(string apiToken, string branchName, int prNumber)
+    private static string FormatDeployMessage(StagingRepoConfig repo, string? docsUrl, string? samplesUrl)
+    {
+        var parts = new List<string>();
+        if (repo.HasDocs) parts.Add($"docs={docsUrl ?? "pending"}");
+        if (repo.HasSamples) parts.Add($"samples={samplesUrl ?? "pending"}");
+        return $"Deployed: {string.Join(", ", parts)}";
+    }
+
+    public async Task<StagingDeployResult> RedeployBranchAsync(string apiToken, StagingRepoConfig repoConfig, string branchName, int prNumber)
     {
         var projectId = _config["Sliplane:ProjectId"] ?? "";
-        var services = await _sliplane.ListStagingServicesAsync(apiToken, projectId, "ivy-staging-");
-        var docsSvc = services.FirstOrDefault(s => s.Name == $"ivy-staging-docs-{prNumber}");
-        var samplesSvc = services.FirstOrDefault(s => s.Name == $"ivy-staging-samples-{prNumber}");
+        var services = await _sliplane.ListAllServicesAsync(apiToken, projectId);
+        var docsName = DocsServiceName(repoConfig, prNumber);
+        var samplesName = SamplesServiceName(repoConfig, prNumber);
+        var docsSvc = services.FirstOrDefault(s => string.Equals(s.Name, docsName, StringComparison.OrdinalIgnoreCase));
+        var samplesSvc = services.FirstOrDefault(s => string.Equals(s.Name, samplesName, StringComparison.OrdinalIgnoreCase));
 
         var triggered = 0;
         if (docsSvc != null && await _sliplane.RedeployServiceAsync(apiToken, projectId, docsSvc.Id))
@@ -129,16 +196,16 @@ public class StagingDeployService
         if (samplesSvc != null && await _sliplane.RedeployServiceAsync(apiToken, projectId, samplesSvc.Id))
             triggered++;
 
+        // Suppress unused parameter warning while keeping signature stable.
+        _ = branchName;
         return new StagingDeployResult(triggered > 0, $"Redeploy triggered for {triggered} service(s).");
     }
 
     /// <summary>Resolves docs/samples URLs from existing Sliplane services for a PR (e.g. after redeploy).</summary>
-    public async Task<(string? DocsUrl, string? SamplesUrl)> GetDeploymentUrlsForPrAsync(string apiToken, int prNumber)
+    public async Task<(string? DocsUrl, string? SamplesUrl)> GetDeploymentUrlsForPrAsync(string apiToken, StagingRepoConfig repoConfig, int prNumber)
     {
-        var list = await ListDeploymentsAsync(apiToken);
-        var dep = list.FirstOrDefault(d => string.Equals(d.BranchSafe, prNumber.ToString(), StringComparison.OrdinalIgnoreCase));
-        if (dep == null)
-            return (null, null);
+        var dep = await GetDeploymentByPrNumberAsync(apiToken, repoConfig, prNumber);
+        if (dep == null) return (null, null);
         return (dep.DocsUrl, dep.SamplesUrl);
     }
 
@@ -162,19 +229,29 @@ public class StagingDeployService
         return (docsEvents, samplesEvents);
     }
 
-    public async Task<StagingDeployment?> GetDeploymentByPrNumberAsync(string apiToken, int prNumber)
+    public async Task<StagingDeployment?> GetDeploymentByPrNumberAsync(string apiToken, StagingRepoConfig repoConfig, int prNumber)
     {
         var list = await ListDeploymentsAsync(apiToken);
-        return list.FirstOrDefault(d => string.Equals(d.BranchSafe, prNumber.ToString(), StringComparison.OrdinalIgnoreCase));
+        return list.FirstOrDefault(d =>
+            d.RepoKey.Equals(repoConfig.Key, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(d.BranchSafe, prNumber.ToString(), StringComparison.OrdinalIgnoreCase));
     }
 
-    public async Task<StagingDeleteResult> DeleteBranchAsync(string apiToken, int prNumber)
+    public async Task<StagingDeleteResult> DeleteBranchAsync(string apiToken, StagingRepoConfig repoConfig, int prNumber)
     {
         var projectId = _config["Sliplane:ProjectId"] ?? "";
 
-        var services = await _sliplane.ListStagingServicesAsync(apiToken, projectId, "ivy-staging-");
+        var services = await _sliplane.ListAllServicesAsync(apiToken, projectId);
+        // Match by parsed name so legacy formats (e.g. ivy-tendril-staging-ivy-tendril-docs-1) are deleted,
+        // not only the current canonical DocsServiceName/SamplesServiceName strings.
         var toDelete = services
-            .Where(s => s.Name == $"ivy-staging-docs-{prNumber}" || s.Name == $"ivy-staging-samples-{prNumber}")
+            .Where(s =>
+            {
+                var parsed = ParseServiceName(s.Name ?? "");
+                return parsed != null
+                       && parsed.Value.RepoKey.Equals(repoConfig.Key, StringComparison.OrdinalIgnoreCase)
+                       && parsed.Value.PrNumber == prNumber;
+            })
             .ToList();
 
         var deleteTasks = toDelete.Select(svc => DeleteWithRetryAsync(apiToken, projectId, svc.Id));
@@ -196,38 +273,42 @@ public class StagingDeployService
         return false;
     }
 
+    /// <summary>Lists deployments across all configured repos (parses repoKey out of the service name).</summary>
     public async Task<List<StagingDeployment>> ListDeploymentsAsync(string apiToken)
     {
         var projectId = _config["Sliplane:ProjectId"] ?? "";
-        var services = await _sliplane.ListStagingServicesAsync(apiToken, projectId, "ivy-staging-");
-        var byBranch = new Dictionary<string, (string? DocsId, string? DocsUrl, string? DocsStatus, string? SamplesId, string? SamplesUrl, string? SamplesStatus, DateTime Oldest)>();
+        var services = await _sliplane.ListAllServicesAsync(apiToken, projectId);
+
+        // Composite key: "{repoKey}|{prNumber}"
+        var byBranch = new Dictionary<string, (string RepoKey, string PrNumber, string? DocsId, string? DocsUrl, string? DocsStatus, string? SamplesId, string? SamplesUrl, string? SamplesStatus, DateTime Oldest)>();
 
         foreach (var svc in services)
         {
             var name = svc.Name ?? "";
-            if (!name.StartsWith("ivy-staging-docs-") && !name.StartsWith("ivy-staging-samples-"))
-                continue;
-            var branchSafe = name.StartsWith("ivy-staging-docs-")
-                ? name["ivy-staging-docs-".Length..]
-                : name["ivy-staging-samples-".Length..];
+            var parsed = ParseServiceName(name);
+            if (parsed == null) continue;
+
+            var (repoKey, type, prNumber) = parsed.Value;
             var url = string.IsNullOrEmpty(svc.ManagedDomain) ? null : "https://" + svc.ManagedDomain;
             var status = svc.Status ?? "live";
+            var compositeKey = $"{repoKey}|{prNumber}";
 
-            if (!byBranch.TryGetValue(branchSafe, out var cur))
-                cur = (null, null, null, null, null, null, svc.CreatedAt);
+            if (!byBranch.TryGetValue(compositeKey, out var cur))
+                cur = (repoKey, prNumber.ToString(), null, null, null, null, null, null, svc.CreatedAt);
 
             var oldest = cur.Oldest < svc.CreatedAt ? cur.Oldest : svc.CreatedAt;
-            if (name.StartsWith("ivy-staging-docs-"))
-                cur = (svc.Id, url, status, cur.SamplesId, cur.SamplesUrl, cur.SamplesStatus, oldest);
+            if (type == "docs")
+                cur = (cur.RepoKey, cur.PrNumber, svc.Id, url, status, cur.SamplesId, cur.SamplesUrl, cur.SamplesStatus, oldest);
             else
-                cur = (cur.DocsId, cur.DocsUrl, cur.DocsStatus, svc.Id, url, status, oldest);
+                cur = (cur.RepoKey, cur.PrNumber, cur.DocsId, cur.DocsUrl, cur.DocsStatus, svc.Id, url, status, oldest);
 
-            byBranch[branchSafe] = cur;
+            byBranch[compositeKey] = cur;
         }
 
         return byBranch.Select(kv => new StagingDeployment(
-            BranchName: kv.Key,
-            BranchSafe: kv.Key,
+            RepoKey: kv.Value.RepoKey,
+            BranchName: kv.Value.PrNumber,
+            BranchSafe: kv.Value.PrNumber,
             DocsServiceId: kv.Value.DocsId,
             DocsUrl: kv.Value.DocsUrl,
             DocsStatus: kv.Value.DocsStatus,
@@ -240,7 +321,83 @@ public class StagingDeployService
         )).OrderByDescending(d => d.DeployedAt).ToList();
     }
 
-    /// <summary>Deletes deployments that are past ExpiryDays AND whose PR is closed.</summary>
+    /// <summary>
+    /// Current format: <c>{slug}-staging-docs-{pr}</c> / <c>{slug}-staging-samples-{pr}</c> where <c>slug</c> is <see cref="ResolveServiceSlug"/>.
+    /// Legacy format (still recognized): <c>{deploymentKey}-staging-{repoKey}-docs-{pr}</c> from older builds.
+    /// </summary>
+    private (string RepoKey, string Type, int PrNumber)? ParseServiceName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return null;
+
+        // New format: single slug, then -staging-docs- or -staging-samples-
+        foreach (var rc in _reposProvider.All.OrderByDescending(r => ResolveServiceSlug(r).Length))
+        {
+            var slug = ResolveServiceSlug(rc);
+            foreach (var (type, marker) in new[] { ("docs", "-staging-docs-"), ("samples", "-staging-samples-") })
+            {
+                var prefix = slug + marker;
+                if (!name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+                var tail = name[prefix.Length..];
+                if (int.TryParse(tail, out var pr))
+                    return (rc.Key, type, pr);
+            }
+        }
+
+        // Legacy: {DeploymentKey}-staging-{repoKey}-docs-{pr}
+        var dkStaging = $"{DeploymentKey}-staging-";
+        if (name.StartsWith(dkStaging, StringComparison.OrdinalIgnoreCase))
+        {
+            var rest = name[dkStaging.Length..];
+            var byLength = _reposProvider.All.OrderByDescending(r => r.Key.Length).ToList();
+            foreach (var rc in byLength)
+            {
+                var keyDash = rc.Key + "-";
+                if (!rest.StartsWith(keyDash, StringComparison.OrdinalIgnoreCase)) continue;
+                var inner = rest[keyDash.Length..];
+                var parsed = ParseTypeAndPr(inner);
+                if (parsed != null)
+                    return (rc.Key, parsed.Value.Type, parsed.Value.PrNumber);
+            }
+
+            if (_reposProvider.All.Count == 1)
+            {
+                var legacy = ParseTypeAndPr(rest);
+                if (legacy != null)
+                    return (_reposProvider.All[0].Key, legacy.Value.Type, legacy.Value.PrNumber);
+            }
+        }
+
+        // Legacy B: any leading slug — <anything>-staging-{repoKey}-docs-{pr} (deployment prefix drift vs config)
+        foreach (var rc in _reposProvider.All.OrderByDescending(r => r.Key.Length))
+        {
+            foreach (var (type, middle) in new[] { ("docs", $"-staging-{rc.Key}-docs-"), ("samples", $"-staging-{rc.Key}-samples-") })
+            {
+                var idx = name.IndexOf(middle, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0) continue;
+                var tail = name[(idx + middle.Length)..];
+                if (int.TryParse(tail, out var pr))
+                    return (rc.Key, type, pr);
+            }
+        }
+
+        return null;
+    }
+
+    private static (string Type, int PrNumber)? ParseTypeAndPr(string remainder)
+    {
+        const string docs = "docs-";
+        const string samples = "samples-";
+        if (remainder.StartsWith(docs, StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(remainder[docs.Length..], out var d))
+            return ("docs", d);
+        if (remainder.StartsWith(samples, StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(remainder[samples.Length..], out var s))
+            return ("samples", s);
+        return null;
+    }
+
+    /// <summary>Deletes deployments that are past ExpiryDays AND whose PR is closed (per-repo PR lookup).</summary>
     public async Task<StagingDeleteResult> DeleteExpiredAsync(string apiToken)
     {
         var deployments = await ListDeploymentsAsync(apiToken);
@@ -248,25 +405,36 @@ public class StagingDeployService
         if (expired.Count == 0)
             return new StagingDeleteResult(false, "No expired deployments.");
 
-        var owner = _config["GitHub:Owner"] ?? "";
-        var repo = _config["GitHub:Repo"] ?? "";
         var ghToken = _config["GitHub:Token"] ?? "";
-        if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(repo))
-            return new StagingDeleteResult(false, "GitHub:Owner/Repo not configured, skipping expiry cleanup.");
 
-        var openPrs = await _github.GetPullRequestsAsync(owner, repo, ghToken, "open");
-        var openPrNumbers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var pr in openPrs)
-            openPrNumbers.Add(pr.Number.ToString());
+        // Cache open PR lists per (owner, repo) so we don't refetch.
+        var openPrCache = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
-        var toDelete = expired.Where(d => !openPrNumbers.Contains(d.BranchSafe)).ToList();
-        var deleted = 0;
-        foreach (var d in toDelete)
+        async Task<HashSet<string>> GetOpenPrsAsync(StagingRepoConfig rc)
         {
+            var key = $"{rc.Owner}/{rc.Repo}";
+            if (openPrCache.TryGetValue(key, out var cached)) return cached;
+            var prs = await _github.GetPullRequestsAsync(rc.Owner, rc.Repo, ghToken, "open");
+            var set = new HashSet<string>(prs.Select(p => p.Number.ToString()), StringComparer.OrdinalIgnoreCase);
+            openPrCache[key] = set;
+            return set;
+        }
+
+        var deleted = 0;
+        foreach (var d in expired)
+        {
+            var rc = _reposProvider.FindByKey(d.RepoKey);
+            if (rc == null) continue;
+
             if (!int.TryParse(d.BranchSafe, out var prNum)) continue;
-            var r = await DeleteBranchAsync(apiToken, prNum);
+
+            var openPrs = await GetOpenPrsAsync(rc);
+            if (openPrs.Contains(d.BranchSafe)) continue;
+
+            var r = await DeleteBranchAsync(apiToken, rc, prNum);
             if (r.Success) deleted++;
         }
+
         return new StagingDeleteResult(deleted > 0, $"Deleted {deleted} expired deployment(s) (closed PRs only).");
     }
 

--- a/project-demos/pr-staging-deploy/Services/StagingErrorWatcherBackgroundService.cs
+++ b/project-demos/pr-staging-deploy/Services/StagingErrorWatcherBackgroundService.cs
@@ -68,8 +68,8 @@ public class StagingErrorWatcherBackgroundService : BackgroundService
                 continue;
 
             _logger.LogInformation(
-                "PR #{Pr} build terminal: docs={Docs} samples={Samples}",
-                req.PrNumber, docsState, samplesState);
+                "PR #{Pr} ({RepoKey}) build terminal: docs={Docs} samples={Samples}",
+                req.PrNumber, req.RepoKey, docsState, samplesState);
 
             if (docsState == "failed" || samplesState == "failed")
             {
@@ -86,7 +86,8 @@ public class StagingErrorWatcherBackgroundService : BackgroundService
 
         if (DateTime.UtcNow >= deadline)
             _logger.LogWarning(
-                "PR #{Pr} build watcher timed out after {Min} min", req.PrNumber, MaxWatchMinutes);
+                "PR #{Pr} ({RepoKey}) build watcher timed out after {Min} min",
+                req.PrNumber, req.RepoKey, MaxWatchMinutes);
     }
 
     private static string ResolveState(string? serviceId, List<SliplaneServiceEvent> events)

--- a/project-demos/pr-staging-deploy/Services/StagingErrorWatcherQueue.cs
+++ b/project-demos/pr-staging-deploy/Services/StagingErrorWatcherQueue.cs
@@ -22,6 +22,7 @@ public class StagingErrorWatcherQueue
 }
 
 public record StagingErrorWatchRequest(
+    string RepoKey,
     string Owner,
     string Repo,
     int PrNumber,

--- a/project-demos/pr-staging-deploy/Services/StagingReposProvider.cs
+++ b/project-demos/pr-staging-deploy/Services/StagingReposProvider.cs
@@ -1,0 +1,148 @@
+namespace PrStagingDeploy.Services;
+
+using PrStagingDeploy.Models;
+
+/// <summary>
+/// Reads the <c>Repos</c> array from configuration (multi-repo PR staging).
+/// If <c>Repos</c> is not configured, falls back to the legacy single-repo keys
+/// (<c>GitHub:Owner</c>, <c>GitHub:Repo</c>, <c>Staging:DocsRepo</c>, <c>Staging:SamplesRepo</c>, …)
+/// so existing single-repo deployments keep working without any config changes.
+/// </summary>
+public sealed class StagingReposProvider
+{
+    private readonly IReadOnlyList<StagingRepoConfig> _repos;
+
+    public StagingReposProvider(IConfiguration config, ILogger<StagingReposProvider> logger)
+    {
+        var configured = config.GetSection("Repos").Get<List<StagingRepoConfig>>() ?? new();
+        configured = configured
+            .Where(r => !string.IsNullOrWhiteSpace(r.Owner) && !string.IsNullOrWhiteSpace(r.Repo))
+            .ToList();
+
+        foreach (var r in configured)
+        {
+            if (string.IsNullOrWhiteSpace(r.Key))
+                r.Key = SanitizeKey(r.Repo);
+            else
+                r.Key = SanitizeKey(r.Key);
+        }
+
+        if (configured.Count == 0)
+        {
+            var legacy = BuildLegacyEntry(config);
+            if (legacy != null)
+            {
+                logger.LogInformation(
+                    "Repos[] not configured; using legacy single-repo entry for {Owner}/{Repo}",
+                    legacy.Owner, legacy.Repo);
+                configured.Add(legacy);
+            }
+            else
+            {
+                logger.LogWarning("No staging repos configured (neither Repos[] nor legacy GitHub:Owner/Repo).");
+            }
+        }
+
+        // Detect duplicate keys; rename collisions deterministically.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in configured)
+        {
+            var baseKey = string.IsNullOrEmpty(r.Key) ? "repo" : r.Key;
+            var key = baseKey;
+            var n = 2;
+            while (!seen.Add(key))
+                key = $"{baseKey}-{n++}";
+            r.Key = key;
+        }
+
+        _repos = configured;
+    }
+
+    public IReadOnlyList<StagingRepoConfig> All => _repos;
+
+    public StagingRepoConfig? FindByOwnerRepo(string? owner, string? repo)
+    {
+        if (string.IsNullOrEmpty(owner) || string.IsNullOrEmpty(repo)) return null;
+        return _repos.FirstOrDefault(r =>
+            r.Owner.Equals(owner, StringComparison.OrdinalIgnoreCase) &&
+            r.Repo.Equals(repo, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public StagingRepoConfig? FindByKey(string? key)
+    {
+        if (string.IsNullOrEmpty(key)) return null;
+        return _repos.FirstOrDefault(r => r.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Sluggify into Sliplane-safe alphanumeric+hyphen lowercase token.</summary>
+    public static string SanitizeKey(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return "repo";
+        var sb = new System.Text.StringBuilder(raw.Length);
+        foreach (var ch in raw.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(ch)) sb.Append(ch);
+            else if (sb.Length > 0 && sb[^1] != '-') sb.Append('-');
+        }
+        var slug = sb.ToString().Trim('-');
+        return string.IsNullOrEmpty(slug) ? "repo" : slug;
+    }
+
+    /// <summary>Build a single repo entry from the legacy keys, when Repos[] is empty.</summary>
+    private static StagingRepoConfig? BuildLegacyEntry(IConfiguration config)
+    {
+        var owner = config["GitHub:Owner"];
+        var repo = config["GitHub:Repo"];
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
+            return null;
+
+        var docsRepo = config["Staging:DocsRepo"];
+        var samplesRepo = config["Staging:SamplesRepo"];
+
+        var entry = new StagingRepoConfig
+        {
+            Key = SanitizeKey(repo),
+            Owner = owner!,
+            Repo = repo!,
+        };
+
+        if (!string.IsNullOrWhiteSpace(docsRepo))
+        {
+            entry.Docs = new StagingComponentConfig
+            {
+                Repo = docsRepo!,
+                Dockerfile = config["Staging:DocsDockerfile"] ?? "Dockerfile",
+                Context = config["Staging:DocsDockerContext"] ?? ".",
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(samplesRepo))
+        {
+            entry.Samples = new StagingComponentConfig
+            {
+                Repo = samplesRepo!,
+                Dockerfile = config["Staging:SamplesDockerfile"] ?? "Dockerfile",
+                Context = config["Staging:SamplesDockerContext"] ?? ".",
+            };
+        }
+
+        // If neither Docs nor Samples specified, use repo as both for backward compat.
+        if (entry.Docs == null && entry.Samples == null)
+        {
+            entry.Docs = new StagingComponentConfig
+            {
+                Repo = $"https://github.com/{owner}/{repo}",
+                Dockerfile = config["Staging:DocsDockerfile"] ?? "Dockerfile",
+                Context = config["Staging:DocsDockerContext"] ?? ".",
+            };
+            entry.Samples = new StagingComponentConfig
+            {
+                Repo = $"https://github.com/{owner}/{repo}",
+                Dockerfile = config["Staging:SamplesDockerfile"] ?? "Dockerfile",
+                Context = config["Staging:SamplesDockerContext"] ?? ".",
+            };
+        }
+
+        return entry;
+    }
+}


### PR DESCRIPTION
## Summary

Extend **PR Staging Deploy** so one instance can manage staging for **multiple GitHub repos**, with clear **Sliplane service names**, reliable **webhook routing**, and **docs-only / samples-only** setups.

## What changed

- **`StagingReposProvider`** — loads `Repos[]` from config; falls back to legacy `GitHub:Owner` / `GitHub:Repo` + `Staging:*` when `Repos` is empty.
- **`StagingRepoConfig` / `StagingComponentConfig`** — per-repo Docs and/or Samples (Dockerfile, context, clone URL).
- **`GitHubWebhookHandler`** — resolves the target repo from the webhook payload and **ignores** events for repos not listed in config.
- **`StagingDeployService`** — deploy/delete/redeploy keyed by `StagingRepoConfig`; **single slug** service names (`{slug}-staging-docs-{PR}`, `{slug}-staging-samples-{PR}`) with configurable `Staging:DeploymentKey` and legacy name parsing for existing services.
- **`PrStagingDeployCommentService`** — optional Docs/Samples lines in PR comments; **`GitHub:Token`** fallback if `GitHub:PrCommentToken` is unset.
- **`PrStagingDeployApp`** — table shows **Repo**, rows per repo × PR; **Samples** column hidden when no repo has Samples configured.
- **`README`** — secrets-first setup, multi-repo mention, service naming, webhook troubleshooting trimmed.

## Migration / ops

- Existing single-repo env vars **keep working** until you introduce `Repos[]`.
- Redeploy this app so new **service names** and **delete-on-close** behavior apply; old Sliplane services may keep previous names until recreated.

https://github.com/user-attachments/assets/b323d4c6-e81f-4771-8135-2c15323691cf

