### PR TITLE
[project-demos]: create TendrilDeploy — Ivy app to deploy Ivy Tendril to Sliplane

### DIFF
--- a/.github/workflows/build-all-projects.yml
+++ b/.github/workflows/build-all-projects.yml
@@ -2,9 +2,9 @@ name: Build All Projects
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, development]
   pull_request:
-    branches: [main, develop]
+    branches: [main, development]
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *" # daily at 6 AM UTC

--- a/.github/workflows/update-project-catalog.yml
+++ b/.github/workflows/update-project-catalog.yml
@@ -1,9 +1,13 @@
 name: Update Project Catalog
 
 on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+  workflow_dispatch:
   schedule:
     - cron: "0 2 * * *" # daily at 2 AM UTC
-  workflow_dispatch:
 
 jobs:
   update-catalog:
@@ -25,6 +29,7 @@ jobs:
           .github/scripts/generate-project-catalog.sh
 
       - name: Commit and push changes
+        if: github.event_name != 'pull_request'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
@@ -84,7 +84,7 @@ public class TendrilDeployApp : ViewBase
                 | (Layout.Vertical().AlignContent(Align.Center).Gap(6)
                     | Text.H2("Deploy Tendril to Sliplane")
                     | Text.Muted($"Default repository: {TendrilDeployDefaults.DefaultRepoUrl}")
-                    | Text.Muted("Sign in with Sliplane to deploy. You can change the Git URL after login; add API keys in Sliplane if needed."));
+                    | Text.Muted("Sign in with Sliplane to deploy. Git URL and API keys can be edited on the next screen."));
         }
 
         var serversReady = !firstServerQuery.Loading || firstServerQuery.Value != null;

--- a/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
@@ -1,0 +1,109 @@
+namespace TendrilDeploy.Apps;
+
+using TendrilDeploy.Apps.Views;
+using TendrilDeploy.Models;
+using TendrilDeploy.Services;
+
+/// <summary>
+/// One-click Tendril deploy to Sliplane from Git (default fork with <c>.github/docker/Dockerfile.tendril</c>).
+/// <c>?repo=</c> is captured by <see cref="RepoCaptureFilter"/> the same way as sliplane-deploy.
+/// </summary>
+[App(
+    id: "tendril-deploy-app",
+    icon: Icons.Container,
+    title: "Tendril on Sliplane",
+    isVisible: true)]
+public class TendrilDeployApp : ViewBase
+{
+    public override object? Build()
+    {
+        var config = UseService<IConfiguration>();
+        var auth = UseService<IAuthService>();
+        var draftStore = UseService<DeploymentDraftStore>();
+        var args = UseArgs<TendrilDeployArgs>();
+        var client = UseService<SliplaneApiClient>();
+
+        var draftState = UseState<DeployDraft?>(() =>
+            args is not null
+                ? DeploymentDraftStore.ParseGitHubUrl(args.Repo)
+                : draftStore.LastDraft ?? TendrilDeployDefaults.InitialDraft);
+
+        var firstServerQuery = UseQuery<SliplaneServer?, (string, string)>(
+            key: ("tendril-default-server", config["Sliplane:ApiToken"] ?? auth.GetAuthSession().AuthToken?.AccessToken ?? string.Empty),
+            fetcher: async (key, ct) => (await client.GetServersAsync(key.Item2)).FirstOrDefault());
+
+        var ivyProjectQuery = UseQuery<SliplaneProject?, (string, bool)>(
+            key: (config["Sliplane:ApiToken"] ?? auth.GetAuthSession().AuthToken?.AccessToken ?? string.Empty, draftState.Value is not null),
+            fetcher: async (key, ct) =>
+            {
+                var (token, needIvy) = key;
+                if (!needIvy) return null;
+                var projects = await client.GetProjectsAsync(token);
+                var ivy = projects.FirstOrDefault(p => p.Name.Equals("Ivy", StringComparison.OrdinalIgnoreCase));
+                return ivy ?? await client.CreateProjectAsync(token, "Ivy");
+            });
+
+        var firstProjectQuery = UseQuery<SliplaneProject?, (string, string)>(
+            key: ("tendril-default-project", config["Sliplane:ApiToken"] ?? auth.GetAuthSession().AuthToken?.AccessToken ?? string.Empty),
+            fetcher: async (key, ct) => (await client.GetProjectsAsync(key.Item2)).FirstOrDefault());
+
+        var serverLookupPreload = UseQuery<Option<string>?, (string, string?, int)>(
+            key: ("tendril-server-lookup", string.IsNullOrEmpty(firstServerQuery.Value?.Id ?? "") ? null : firstServerQuery.Value!.Id, 0),
+            fetcher: async _ =>
+            {
+                var currentServerId = firstServerQuery.Value?.Id ?? "";
+                return string.IsNullOrEmpty(currentServerId)
+                    ? null
+                    : new Option<string>(firstServerQuery.Value!.Name, currentServerId);
+            });
+
+        var projectLookupPreload = UseQuery<Option<string>?, (string, string?, int)>(
+            key: ("tendril-project-lookup", string.IsNullOrEmpty((draftState.Value is not null ? ivyProjectQuery.Value?.Id : firstProjectQuery.Value?.Id) ?? "") ? null : (draftState.Value is not null ? ivyProjectQuery.Value?.Id : firstProjectQuery.Value?.Id), 0),
+            fetcher: async _ =>
+            {
+                var currentNeedIvyProject = draftState.Value is not null;
+                var currentProjectId = (currentNeedIvyProject ? ivyProjectQuery.Value?.Id : firstProjectQuery.Value?.Id) ?? "";
+                return string.IsNullOrEmpty(currentProjectId)
+                    ? null
+                    : new Option<string>((currentNeedIvyProject ? ivyProjectQuery.Value?.Name : firstProjectQuery.Value?.Name) ?? "Ivy", currentProjectId);
+            });
+
+        var session = auth.GetAuthSession();
+        var apiToken = config["Sliplane:ApiToken"]
+                       ?? session.AuthToken?.AccessToken
+                       ?? string.Empty;
+        var draft = draftState.Value ?? TendrilDeployDefaults.InitialDraft;
+        var needIvyProject = draftState.Value is not null;
+        var ivyProject = needIvyProject ? ivyProjectQuery.Value : null;
+        var preServerId = firstServerQuery.Value?.Id ?? "";
+        var preProjectId = (needIvyProject ? ivyProject?.Id : firstProjectQuery.Value?.Id) ?? "";
+
+        if (string.IsNullOrWhiteSpace(apiToken))
+        {
+            return Layout.Center()
+                | (Layout.Vertical().AlignContent(Align.Center).Gap(6)
+                    | Text.H2("Deploy Tendril to Sliplane")
+                    | Text.Muted($"Default repository: {TendrilDeployDefaults.DefaultRepoUrl}")
+                    | Text.Muted("Sign in with Sliplane to deploy. You can change the Git URL after login; add API keys in Sliplane if needed."));
+        }
+
+        var serversReady = !firstServerQuery.Loading || firstServerQuery.Value != null;
+        var projectsReady = needIvyProject
+            ? (!ivyProjectQuery.Loading || ivyProjectQuery.Value != null)
+            : (!firstProjectQuery.Loading || firstProjectQuery.Value != null);
+        var serverLkpReady = string.IsNullOrEmpty(preServerId) || !serverLookupPreload.Loading || serverLookupPreload.Value != null;
+        var projectLkpReady = string.IsNullOrEmpty(preProjectId) || !projectLookupPreload.Loading || projectLookupPreload.Value != null;
+
+        if (!serversReady || !projectsReady || !serverLkpReady || !projectLkpReady)
+            return Layout.Center() | Text.Muted("Loading…");
+
+        var needDefaults = true;
+        var defaultServerId = needDefaults ? preServerId : (firstServerQuery.Value?.Id ?? "");
+        var defaultProjectId = needDefaults ? preProjectId : ((needIvyProject ? ivyProject?.Id : firstProjectQuery.Value?.Id) ?? "");
+
+        return new TendrilDeployView(apiToken, draft, defaultServerId, defaultProjectId);
+    }
+}
+
+/// <summary>Navigation with <c>?repo=</c> to pre-fill Git source.</summary>
+public record TendrilDeployArgs(string Repo);

--- a/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
@@ -84,7 +84,7 @@ public class TendrilDeployApp : ViewBase
                 | (Layout.Vertical().AlignContent(Align.Center).Gap(6)
                     | Text.H2("Deploy Tendril to Sliplane")
                     | Text.Muted($"Default repository: {TendrilDeployDefaults.DefaultRepoUrl}")
-                    | Text.Muted("Sign in with Sliplane to deploy. Git URL and API keys can be edited on the next screen."));
+                    | Text.Muted("Sign in to deploy. Git/Docker settings use user-secrets; the next screen asks for server, name, and API keys."));
         }
 
         var serversReady = !firstServerQuery.Loading || firstServerQuery.Value != null;

--- a/project-demos/tendril-deploy/Apps/TendrilDeployDefaults.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployDefaults.cs
@@ -1,0 +1,18 @@
+namespace TendrilDeploy.Apps;
+
+using TendrilDeploy;
+using TendrilDeploy.Services;
+
+/// <summary>Default Git source for Ivy Tendril (Dockerfile is expected from that repo or your fork).</summary>
+public static class TendrilDeployDefaults
+{
+    public const string DefaultRepoUrl = "https://github.com/ArtemLazarchuk/Ivy-Tendril";
+    public const string DefaultBranch = "development";
+
+    /// <summary>Pre-filled draft when no <c>?repo=</c> and no cookie draft.</summary>
+    public static DeployDraft InitialDraft => new(
+        DefaultRepoUrl,
+        DefaultBranch,
+        DockerContext: ".",
+        DockerfilePath: TendrilDeploymentPaths.DefaultDockerfilePath);
+}

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployStatusView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployStatusView.cs
@@ -1,0 +1,107 @@
+namespace TendrilDeploy.Apps.Views;
+
+using TendrilDeploy.Models;
+using TendrilDeploy.Services;
+
+public class TendrilDeployStatusView : ViewBase
+{
+    private readonly string _apiToken;
+    private readonly string _projectId;
+    private readonly SliplaneService _service;
+
+    public TendrilDeployStatusView(string apiToken, string projectId, SliplaneService service)
+    {
+        _apiToken = apiToken;
+        _projectId = projectId;
+        _service = service;
+    }
+
+    public override object? Build()
+    {
+        var client = this.UseService<SliplaneApiClient>();
+        var eventsQuery = this.UseQuery<List<SliplaneServiceEvent>, (string, string, string)>(
+            key: ("deploy-status-events", _projectId, _service.Id),
+            fetcher: async ct => await client.GetServiceEventsAsync(_apiToken, _projectId, _service.Id),
+            options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(2), KeepPrevious = true });
+        var serviceQuery = this.UseQuery<SliplaneService?, (string, string, string)>(
+            key: ("deploy-service-details", _projectId, _service.Id),
+            fetcher: async ct => await client.GetServiceAsync(_apiToken, _projectId, _service.Id),
+            options: new QueryOptions { RefreshInterval = TimeSpan.FromSeconds(3), KeepPrevious = true });
+
+        var events = eventsQuery.Value ?? [];
+        var status = DeriveStatus(events);
+
+        var latestService = serviceQuery.Value ?? _service;
+        var siteHost = ResolveSiteHost(latestService) ?? ResolveSiteHost(_service) ?? string.Empty;
+        var siteUrlAbsolute = string.IsNullOrWhiteSpace(siteHost) ? string.Empty
+            : siteHost.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? siteHost
+            : "https://" + siteHost;
+
+        var manageUrl = "https://ivy-sliplane-management.sliplane.app/$auth";
+
+        var content = Layout.Vertical().Gap(2).AlignContent(Align.Left).Width(Size.Full());
+
+        if (!string.IsNullOrEmpty(siteUrlAbsolute))
+            content = content | LabelPlusUrlRow("Your app will be available at:", siteUrlAbsolute);
+
+        content = content | LabelPlusUrlRow("You can manage it at:", manageUrl);
+
+        if (status == DeployStatus.Failed)
+        {
+            var failureMessage = GetFailureMessage(events);
+            var errBody = !string.IsNullOrEmpty(failureMessage)
+                ? failureMessage
+                : "Deployment failed. Check the service logs in Sliplane dashboard.";
+            content = content | new Callout(Text.Markdown($"**Deployment failed.**\n\n{MarkdownEscapePlain(errBody)}"),
+                variant: CalloutVariant.Error).Width(Size.Full());
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    /// Single horizontal row: bold label + link button. Avoids <see cref="Text.Markdown"/> here because
+    /// it renders as block content (line breaks, extra icons) and breaks inline layout with the URL.
+    /// </summary>
+    private static object LabelPlusUrlRow(string label, string absoluteUrl) =>
+        Layout.Horizontal().AlignContent(Align.Left).Gap(2)
+            | Text.Block(label).Bold()
+            | new Button(absoluteUrl).Link().Url(absoluteUrl).Width(Size.Fit());
+
+    private static string MarkdownEscapePlain(string s) =>
+        s.Replace("\\", "\\\\", StringComparison.Ordinal)
+         .Replace("*", "\\*", StringComparison.Ordinal)
+         .Replace("_", "\\_", StringComparison.Ordinal)
+         .Replace("#", "\\#", StringComparison.Ordinal)
+         .Replace("`", "\\`", StringComparison.Ordinal);
+
+    private static string? ResolveSiteHost(SliplaneService? s)
+    {
+        if (s == null) return null;
+        var custom = s.Network?.CustomDomains?.FirstOrDefault(d => !string.IsNullOrWhiteSpace(d.Domain))?.Domain;
+        if (!string.IsNullOrWhiteSpace(custom)) return custom.Trim();
+        var managed = s.Network?.ManagedDomain;
+        if (!string.IsNullOrWhiteSpace(managed)) return managed.Trim();
+        return s.Domains?.Select(d => d.Domain).FirstOrDefault(d => !string.IsNullOrWhiteSpace(d))?.Trim();
+    }
+
+    private enum DeployStatus { Unknown, Deploying, Success, Failed }
+
+    private static DeployStatus DeriveStatus(List<SliplaneServiceEvent> events)
+    {
+        if (events.Any(e => e.Type == "service_deploy_success")) return DeployStatus.Success;
+        if (events.Any(e => e.Type == "service_deploy_failed" || e.Type == "service_build_failed")) return DeployStatus.Failed;
+        var last = events.LastOrDefault();
+        if (last == null) return DeployStatus.Unknown;
+        return last.Type switch
+        {
+            "service_deploy_success" => DeployStatus.Success,
+            "service_deploy_failed" or "service_build_failed" => DeployStatus.Failed,
+            _ => DeployStatus.Deploying,
+        };
+    }
+
+    private static string? GetFailureMessage(List<SliplaneServiceEvent> events) =>
+        events.LastOrDefault(e => e.Type is "service_deploy_failed" or "service_build_failed")
+              ?.Message is { Length: > 0 } msg ? msg : null;
+}

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -1,0 +1,275 @@
+namespace TendrilDeploy.Apps.Views;
+
+using TendrilDeploy;
+using TendrilDeploy.Apps;
+using TendrilDeploy.Models;
+using TendrilDeploy.Services;
+
+public class TendrilDeployFormModel
+{
+    [Display(Name = "Server", Order = 1, Prompt = "Select a server")]
+    [Required(ErrorMessage = "Select a server")]
+    public string ServerId { get; set; } = "";
+
+    public string ProjectId { get; set; } = "";
+
+    [Display(Name = "Service name", Order = 3, Prompt = "e.g. ivy-tendril")]
+    [Required(ErrorMessage = "Enter a service name")]
+    [MinLength(2, ErrorMessage = "Service name must be at least 2 characters")]
+    public string Name { get; set; } = "";
+
+    [Display(Name = "Git repository", Order = 4)]
+    [Required(ErrorMessage = "Enter the Git repository URL")]
+    public string GitRepo { get; set; } = "";
+
+    [Display(Name = "Branch", Order = 5)]
+    public string Branch { get; set; } = "development";
+
+    [Display(Name = "Dockerfile path", Order = 6)]
+    public string DockerfilePath { get; set; } = TendrilDeploymentPaths.DefaultDockerfilePath;
+
+    [Display(Name = "Docker context", Order = 7)]
+    public string DockerContext { get; set; } = ".";
+
+    [Display(Name = "PORT", Order = 8)]
+    public string Port { get; set; } = "8000";
+
+    [Display(Name = "TENDRIL_HOME", Order = 9)]
+    public string TendrilHome { get; set; } = "/data/tendril";
+
+    [Display(Name = "Volume ID (optional)", Order = 10,
+        Prompt = "Sliplane persistent volume — mount at TENDRIL_HOME")]
+    public string? VolumeId { get; set; }
+
+    public bool AutoDeploy { get; set; } = true;
+    public bool NetworkPublic { get; set; } = true;
+    public string NetworkProtocol { get; set; } = "http";
+    public string Healthcheck { get; set; } = "/";
+    public string? Cmd { get; set; }
+}
+
+public class TendrilDeployView : ViewBase
+{
+    private readonly string _apiToken;
+    private readonly DeployDraft _draft;
+    private readonly string _defaultServerId;
+    private readonly string _defaultProjectId;
+
+    public TendrilDeployView(string apiToken, DeployDraft draft, string defaultServerId = "", string defaultProjectId = "")
+    {
+        _apiToken = apiToken;
+        _draft = draft;
+        _defaultServerId = defaultServerId;
+        _defaultProjectId = defaultProjectId;
+    }
+
+    public override object? Build()
+    {
+        var client = UseService<SliplaneApiClient>();
+        var config = UseService<IConfiguration>();
+        var dockerfileResolver = UseService<GitHubDockerfilePathResolver>();
+
+        var model = UseState(() => new TendrilDeployFormModel
+        {
+            ServerId = _defaultServerId,
+            ProjectId = _defaultProjectId,
+            GitRepo = _draft.RepoUrl,
+            Branch = string.IsNullOrWhiteSpace(_draft.Branch) ? TendrilDeployDefaults.DefaultBranch : _draft.Branch,
+            DockerContext = string.IsNullOrWhiteSpace(_draft.DockerContext) ? "." : _draft.DockerContext,
+            DockerfilePath = string.IsNullOrWhiteSpace(_draft.DockerfilePath)
+                ? TendrilDeploymentPaths.DefaultDockerfilePath
+                : _draft.DockerfilePath,
+            Name = DeriveServiceName(_draft.RepoUrl, _draft.DockerContext),
+            Port = "8000",
+            TendrilHome = "/data/tendril",
+            AutoDeploy = true,
+            NetworkPublic = true,
+            NetworkProtocol = "http",
+            Healthcheck = "/",
+        });
+
+        var reloadCounter = UseState(0);
+        var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
+        var deployError = UseState<string?>(() => null);
+        var validationFailed = UseState(false);
+        var isDeploying = UseState(false);
+
+        var (onSubmit, formView, validationView, loading) = UseForm(() => model.Value.ToForm("Deploy Tendril")
+            .Place(m => m.ServerId, m => m.Name)
+            .Builder(m => m.ServerId,
+                s => s.ToAsyncSelectInput(QueryServers, LookupServer, placeholder: "Search server…"))
+            .Builder(m => m.Name, s => s.ToTextInput().Placeholder("e.g. ivy-tendril"))
+            .Builder(m => m.GitRepo, s => s.ToTextInput().Placeholder("https://github.com/owner/repo"))
+            .Builder(m => m.Branch, s => s.ToTextInput())
+            .Builder(m => m.DockerfilePath, s => s.ToTextInput().Placeholder(TendrilDeploymentPaths.DefaultDockerfilePath))
+            .Builder(m => m.DockerContext, s => s.ToTextInput().Placeholder("."))
+            .Builder(m => m.Port, b => b.ToTextInput())
+            .Builder(m => m.TendrilHome, b => b.ToTextInput())
+            .Builder(m => m.VolumeId, b => b.ToTextInput().Placeholder("optional"))
+            .Remove(m => m.ProjectId, m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
+                m => m.Healthcheck, m => m.Cmd)
+            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo));
+
+        QueryResult<Option<string>[]> QueryServers(IViewContext ctx, string q) =>
+            ctx.UseQuery<Option<string>[], (string, string, int)>(
+                key: ("tendril-deploy-servers", q, reloadCounter.Value),
+                fetcher: async _ =>
+                    (await client.GetServersAsync(_apiToken))
+                        .Where(s => string.IsNullOrEmpty(q) || s.Name.Contains(q, StringComparison.OrdinalIgnoreCase))
+                        .Take(20)
+                        .Select(s => new Option<string>(s.Name, s.Id))
+                        .ToArray());
+
+        QueryResult<Option<string>?> LookupServer(IViewContext ctx, string? id) =>
+            ctx.UseQuery<Option<string>?, (string, string?, int)>(
+                key: ("tendril-deploy-server-lookup", id, reloadCounter.Value),
+                fetcher: async _ =>
+                {
+                    if (string.IsNullOrEmpty(id)) return null;
+                    var s = (await client.GetServersAsync(_apiToken)).FirstOrDefault(x => x.Id == id);
+                    return s is null ? null : new Option<string>(s.Name, s.Id);
+                });
+
+        _ = QueryServers(Context, "");
+        _ = LookupServer(Context, model.Value.ServerId);
+
+        async ValueTask HandleDeploy()
+        {
+            deployError.Set(null);
+            deployedService.Set(null);
+            validationFailed.Set(false);
+            if (!await onSubmit())
+            {
+                validationFailed.Set(true);
+                return;
+            }
+
+            var m = model.Value;
+
+            isDeploying.Set(true);
+            try
+            {
+                var resolution = await dockerfileResolver.ResolveAsync(
+                    m.GitRepo, m.Branch, m.DockerfilePath, m.DockerContext);
+
+                var envVars = new List<EnvironmentVariable>();
+                foreach (var e in resolution.AdditionalEnv ?? [])
+                {
+                    var k = (e.Key ?? "").Trim();
+                    var v = (e.Value ?? "").Trim();
+                    if (k.Length > 0 && v.Length > 0)
+                        envVars.Add(new EnvironmentVariable(k, v, e.Secret));
+                }
+
+                var port = string.IsNullOrWhiteSpace(m.Port) ? "8000" : m.Port.Trim();
+                var home = string.IsNullOrWhiteSpace(m.TendrilHome) ? "/data/tendril" : m.TendrilHome.Trim();
+
+                envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
+                envVars.Add(new EnvironmentVariable("TENDRIL_HOME", home, Secret: false));
+
+                List<(string VolumeId, string MountPath)>? volumes = null;
+                if (!string.IsNullOrWhiteSpace(m.VolumeId))
+                    volumes = [(m.VolumeId.Trim(), home)];
+
+                var service = await client.CreateServiceAsync(_apiToken, m.ProjectId,
+                    ServiceRequestFactory.BuildCreateRequest(
+                        name: m.Name,
+                        serverId: m.ServerId,
+                        gitRepo: m.GitRepo,
+                        branch: m.Branch,
+                        dockerfilePath: resolution.DockerfilePath,
+                        dockerContext: resolution.DockerContext,
+                        autoDeploy: m.AutoDeploy,
+                        networkPublic: m.NetworkPublic,
+                        networkProtocol: m.NetworkProtocol,
+                        cmd: m.Cmd ?? string.Empty,
+                        healthcheck: m.Healthcheck,
+                        env: envVars,
+                        volumeMounts: volumes));
+
+                if (service != null)
+                    deployedService.Set((m.ProjectId, service));
+            }
+            catch (Exception ex)
+            {
+                deployError.Set(ex.Message);
+            }
+            finally
+            {
+                isDeploying.Set(false);
+            }
+        }
+
+        var calloutNoDockerfile = new Callout(
+            Text.Markdown(
+                "Default image: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** branch `development`, Dockerfile **[`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)**. " +
+                "Add **ANTHROPIC_API_KEY** and **GITHUB_TOKEN** in the Sliplane service environment after deploy if you did not set them there."),
+            variant: CalloutVariant.Warning).Width(Size.Full());
+
+        var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
+            | Text.H1("Deploy Tendril to Sliplane")
+            | Text.Lead("Pick server and Git settings, then deploy. Runtime secrets are configured in Sliplane, not in this form.");
+
+        var actionsRow = Layout.Vertical()
+            | (Layout.Horizontal().AlignContent(Align.Center)
+                | new Button("Deploy").Primary().Large()
+                    .Loading(loading || isDeploying.Value).Disabled(loading || isDeploying.Value)
+                    .Width(Size.Fraction(0.5f))
+                    .OnClick(async _ => await HandleDeploy()))
+            | (validationFailed.Value
+                ? new Callout(validationView, "Please fix the following", CalloutVariant.Error)
+                : validationView);
+
+        var cardContent = Layout.Vertical()
+            | headerSection
+            | calloutNoDockerfile
+            | new Separator()
+            | formView
+            | new Spacer()
+            | actionsRow;
+
+        if (isDeploying.Value && deployedService.Value == null)
+        {
+            cardContent = cardContent
+                | new Separator()
+                | new Callout(
+                    Layout.Vertical()
+                        | Text.Block("Creating Tendril service on Sliplane…").Bold()
+                        | new Progress().Indeterminate().Goal("Please wait…"),
+                    "Deploying",
+                    CalloutVariant.Info);
+        }
+        else if (deployedService.Value is { } deployed)
+        {
+            cardContent = cardContent
+                | new Separator()
+                | new TendrilDeployStatusView(_apiToken, deployed.ProjectId, deployed.Service);
+        }
+
+        if (deployError.Value != null)
+            cardContent = cardContent | new Callout(deployError.Value, variant: CalloutVariant.Error);
+
+        var card = new Card(cardContent).Width(Size.Fraction(0.42f));
+        var manageServicesUrl = config["Sliplane:ManageServicesUrl"]?.Trim();
+        if (string.IsNullOrEmpty(manageServicesUrl))
+            manageServicesUrl = "https://ivy-sliplane-management.sliplane.app/";
+        var manageBtn = new Button("Manage services")
+            .Link().Url(manageServicesUrl)
+            .Outline().Large().BorderRadius(BorderRadius.Full);
+        var manageFloat = new FloatingPanel(manageBtn, Align.BottomRight).Offset(new Thickness(0, 0, 20, 10));
+
+        return new Fragment(Layout.Center() | card, manageFloat);
+    }
+
+    private static string DeriveServiceName(string repoUrl, string dockerContext = ".")
+    {
+        var source = (!string.IsNullOrWhiteSpace(dockerContext) && dockerContext != ".")
+            ? dockerContext
+            : repoUrl;
+
+        if (string.IsNullOrWhiteSpace(source)) return string.Empty;
+        var seg = source.TrimEnd('/').Split('/').LastOrDefault() ?? string.Empty;
+        if (seg.EndsWith(".git", StringComparison.OrdinalIgnoreCase)) seg = seg[..^4];
+        return string.IsNullOrWhiteSpace(seg) ? string.Empty : seg.ToLowerInvariant();
+    }
+}

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -33,24 +33,23 @@ public class TendrilDeployFormModel
 
     [Display(Name = "Anthropic API key (optional)", Order = 8,
         Prompt = "ANTHROPIC_API_KEY from Claude Console — use this **or** “Claude subscription token” below (not both needed). If both are set, the API key takes precedence in Claude Code.")]
-    public string AnthropicApiKey { get; set; } = "";
+    public string? AnthropicApiKey { get; set; }
 
     [Display(Name = "Claude subscription token (optional)", Order = 9,
         Prompt = "Run `claude setup-token` locally (Pro / Max / Team / Enterprise), then paste here — sent as CLAUDE_CODE_OAUTH_TOKEN for headless hosts with no browser login.")]
-    public string ClaudeCodeOAuthToken { get; set; } = "";
+    public string? ClaudeCodeOAuthToken { get; set; }
 
-    [Display(Name = "GitHub token", Order = 10,
-        Prompt = "GITHUB_TOKEN for gh / PRs — sent to Sliplane as a secret env var")]
-    [Required(ErrorMessage = "Enter your GitHub token")]
-    public string GithubToken { get; set; } = "";
+    [Display(Name = "GitHub token (optional)", Order = 10,
+        Prompt = "GITHUB_TOKEN for gh / PRs — add in Sliplane later if you skip it here; empty values are not sent")]
+    public string? GithubToken { get; set; }
 
-    [Display(Name = "OpenAI API key (Codex CLI)", Order = 11,
+    [Display(Name = "OpenAI API key (Codex CLI, optional)", Order = 11,
         Prompt = "OPENAI_API_KEY — optional; enables OpenAI Codex without `codex login` in the container")]
-    public string OpenAiApiKey { get; set; } = "";
+    public string? OpenAiApiKey { get; set; }
 
-    [Display(Name = "Gemini API key (Gemini CLI)", Order = 12,
+    [Display(Name = "Gemini API key (Gemini CLI, optional)", Order = 12,
         Prompt = "GEMINI_API_KEY — optional; headless auth for @google/gemini-cli (see Gemini CLI docs)")]
-    public string GeminiApiKey { get; set; } = "";
+    public string? GeminiApiKey { get; set; }
 
     [Display(Name = "PORT", Order = 13)]
     public string Port { get; set; } = "8000";
@@ -141,7 +140,7 @@ public class TendrilDeployView : ViewBase
                 m => m.Port, m => m.TendrilHome, m => m.VolumeId,
                 m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
                 m => m.Healthcheck, m => m.Cmd)
-            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo, m => m.GithubToken));
+            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo));
 
         QueryResult<Option<string>[]> QueryServers(IViewContext ctx, string q) =>
             ctx.UseQuery<Option<string>[], (string, string, int)>(
@@ -182,20 +181,6 @@ public class TendrilDeployView : ViewBase
             var anthropic = (m.AnthropicApiKey ?? "").Trim();
             var claudeOAuth = (m.ClaudeCodeOAuthToken ?? "").Trim();
             var github = (m.GithubToken ?? "").Trim();
-            if (string.IsNullOrEmpty(anthropic) && string.IsNullOrEmpty(claudeOAuth))
-            {
-                deployError.Set(
-                    "Provide either an Anthropic API key or a Claude subscription token (`claude setup-token` → CLAUDE_CODE_OAUTH_TOKEN). "
-                    + "GitHub token must also be non-empty. Sliplane rejects empty env values.");
-                return;
-            }
-
-            if (string.IsNullOrEmpty(github))
-            {
-                deployError.Set(
-                    "GitHub token must be non-empty (spaces-only is treated as empty). Sliplane rejects empty env values.");
-                return;
-            }
 
             isDeploying.Set(true);
             try
@@ -219,7 +204,8 @@ public class TendrilDeployView : ViewBase
                     envVars.Add(new EnvironmentVariable("ANTHROPIC_API_KEY", anthropic, Secret: true));
                 if (claudeOAuth.Length > 0)
                     envVars.Add(new EnvironmentVariable("CLAUDE_CODE_OAUTH_TOKEN", claudeOAuth, Secret: true));
-                envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
+                if (github.Length > 0)
+                    envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
                 var openAi = (m.OpenAiApiKey ?? "").Trim();
                 if (openAi.Length > 0)
                     envVars.Add(new EnvironmentVariable("OPENAI_API_KEY", openAi, Secret: true));
@@ -272,8 +258,8 @@ public class TendrilDeployView : ViewBase
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
             | Text.Lead(
-                "Pick server, service name, GitHub token, and **either** an Anthropic API key **or** a Claude subscription token from `claude setup-token`. "
-                + "Optional: OpenAI (Codex) and Gemini API keys. Build settings use user-secrets / defaults.");
+                "Pick server and service name. **All tokens are optional** — leave blank to set secrets later in Sliplane; only non-empty values are sent (Sliplane rejects empty env vars). "
+                + "Build settings use user-secrets / defaults.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -113,7 +113,7 @@ public class TendrilDeployView : ViewBase
         var validationFailed = UseState(false);
         var isDeploying = UseState(false);
 
-        var (onSubmit, formView, validationView, loading) = UseForm(() => model.Value.ToForm("Deploy Tendril")
+        var (onSubmit, formView, validationView, loading) = UseForm(() => model.ToForm("Deploy Tendril")
             .Place(m => m.ServerId, m => m.Name)
             .Builder(m => m.ServerId,
                 s => s.ToAsyncSelectInput(QueryServers, LookupServer, placeholder: "Search server…"))

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -41,13 +41,21 @@ public class TendrilDeployFormModel
     [Required(ErrorMessage = "Enter your GitHub token")]
     public string GithubToken { get; set; } = "";
 
-    [Display(Name = "PORT", Order = 10)]
+    [Display(Name = "OpenAI API key (Codex CLI)", Order = 10,
+        Prompt = "OPENAI_API_KEY — optional; enables OpenAI Codex without `codex login` in the container")]
+    public string OpenAiApiKey { get; set; } = "";
+
+    [Display(Name = "Gemini API key (Gemini CLI)", Order = 11,
+        Prompt = "GEMINI_API_KEY — optional; headless auth for @google/gemini-cli (see Gemini CLI docs)")]
+    public string GeminiApiKey { get; set; } = "";
+
+    [Display(Name = "PORT", Order = 12)]
     public string Port { get; set; } = "8000";
 
-    [Display(Name = "TENDRIL_HOME", Order = 11)]
+    [Display(Name = "TENDRIL_HOME", Order = 13)]
     public string TendrilHome { get; set; } = "/data/tendril";
 
-    [Display(Name = "Volume ID (optional)", Order = 12,
+    [Display(Name = "Volume ID (optional)", Order = 14,
         Prompt = "Sliplane persistent volume — mount at TENDRIL_HOME")]
     public string? VolumeId { get; set; }
 
@@ -100,6 +108,8 @@ public class TendrilDeployView : ViewBase
                 VolumeId = ui.VolumeId,
                 AnthropicApiKey = config["TendrilDeploy:AnthropicApiKey"]?.Trim() ?? "",
                 GithubToken = config["TendrilDeploy:GithubToken"]?.Trim() ?? "",
+                OpenAiApiKey = config["TendrilDeploy:OpenAiApiKey"]?.Trim() ?? "",
+                GeminiApiKey = config["TendrilDeploy:GeminiApiKey"]?.Trim() ?? "",
                 AutoDeploy = true,
                 NetworkPublic = true,
                 NetworkProtocol = "http",
@@ -120,6 +130,8 @@ public class TendrilDeployView : ViewBase
             .Builder(m => m.Name, s => s.ToTextInput().Placeholder("e.g. ivy-tendril"))
             .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-api03-…"))
             .Builder(m => m.GithubToken, b => b.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT"))
+            .Builder(m => m.OpenAiApiKey, b => b.ToPasswordInput(placeholder: "sk-… (optional)"))
+            .Builder(m => m.GeminiApiKey, b => b.ToPasswordInput(placeholder: "optional — Gemini API key"))
             .Remove(m => m.ProjectId, m => m.GitRepo, m => m.Branch, m => m.DockerfilePath, m => m.DockerContext,
                 m => m.Port, m => m.TendrilHome, m => m.VolumeId,
                 m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
@@ -193,6 +205,12 @@ public class TendrilDeployView : ViewBase
 
                 envVars.Add(new EnvironmentVariable("ANTHROPIC_API_KEY", anthropic, Secret: true));
                 envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
+                var openAi = (m.OpenAiApiKey ?? "").Trim();
+                if (openAi.Length > 0)
+                    envVars.Add(new EnvironmentVariable("OPENAI_API_KEY", openAi, Secret: true));
+                var gemini = (m.GeminiApiKey ?? "").Trim();
+                if (gemini.Length > 0)
+                    envVars.Add(new EnvironmentVariable("GEMINI_API_KEY", gemini, Secret: true));
                 envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
                 envVars.Add(new EnvironmentVariable("TENDRIL_HOME", home, Secret: false));
 
@@ -238,7 +256,9 @@ public class TendrilDeployView : ViewBase
 
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
-            | Text.Lead("Pick server, service name, and tokens. Build settings use user-secrets / defaults.");
+            | Text.Lead(
+                "Pick server, service name, and required tokens (Anthropic + GitHub). Optional: OpenAI (Codex) and Gemini API keys. "
+                + "Build settings use user-secrets / defaults.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -248,13 +248,6 @@ public class TendrilDeployView : ViewBase
             }
         }
 
-        var calloutNoDockerfile = new Callout(
-            Text.Markdown(
-                "**Git, Docker, PORT, TENDRIL_HOME, volume** come from **dotnet user-secrets** (`TendrilDeploy:*`) and app defaults — they are not shown in this form. " +
-                "Change them with `dotnet user-secrets set …` or use a `?repo=` GitHub URL (see README). " +
-                "Image: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** → [`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)."),
-            variant: CalloutVariant.Warning).Width(Size.Full());
-
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
             | Text.Lead(
@@ -273,7 +266,6 @@ public class TendrilDeployView : ViewBase
 
         var cardContent = Layout.Vertical()
             | headerSection
-            | calloutNoDockerfile
             | new Separator()
             | formView
             | new Spacer()

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -31,26 +31,6 @@ public class TendrilDeployFormModel
     [Display(Name = "Docker context", Order = 7)]
     public string DockerContext { get; set; } = ".";
 
-    [Display(Name = "Anthropic API key (optional)", Order = 8,
-        Prompt = "ANTHROPIC_API_KEY from Claude Console — use this **or** “Claude subscription token” below (not both needed). If both are set, the API key takes precedence in Claude Code.")]
-    public string? AnthropicApiKey { get; set; }
-
-    [Display(Name = "Claude subscription token (optional)", Order = 9,
-        Prompt = "Run `claude setup-token` locally (Pro / Max / Team / Enterprise), then paste here — sent as CLAUDE_CODE_OAUTH_TOKEN for headless hosts with no browser login.")]
-    public string? ClaudeCodeOAuthToken { get; set; }
-
-    [Display(Name = "GitHub token (optional)", Order = 10,
-        Prompt = "GITHUB_TOKEN for gh / PRs — add in Sliplane later if you skip it here; empty values are not sent")]
-    public string? GithubToken { get; set; }
-
-    [Display(Name = "OpenAI API key (Codex CLI, optional)", Order = 11,
-        Prompt = "OPENAI_API_KEY — optional; enables OpenAI Codex without `codex login` in the container")]
-    public string? OpenAiApiKey { get; set; }
-
-    [Display(Name = "Gemini API key (Gemini CLI, optional)", Order = 12,
-        Prompt = "GEMINI_API_KEY — optional; headless auth for @google/gemini-cli (see Gemini CLI docs)")]
-    public string? GeminiApiKey { get; set; }
-
     [Display(Name = "PORT", Order = 13)]
     public string Port { get; set; } = "8000";
 
@@ -108,17 +88,18 @@ public class TendrilDeployView : ViewBase
                 Port = ui.Port,
                 TendrilHome = ui.TendrilHome,
                 VolumeId = ui.VolumeId,
-                AnthropicApiKey = config["TendrilDeploy:AnthropicApiKey"]?.Trim() ?? "",
-                ClaudeCodeOAuthToken = config["TendrilDeploy:ClaudeCodeOAuthToken"]?.Trim() ?? "",
-                GithubToken = config["TendrilDeploy:GithubToken"]?.Trim() ?? "",
-                OpenAiApiKey = config["TendrilDeploy:OpenAiApiKey"]?.Trim() ?? "",
-                GeminiApiKey = config["TendrilDeploy:GeminiApiKey"]?.Trim() ?? "",
                 AutoDeploy = true,
                 NetworkPublic = true,
                 NetworkProtocol = "http",
                 Healthcheck = "/",
             };
         });
+
+        var anthropicKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:AnthropicApiKey"));
+        var claudeOAuthToken = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:ClaudeCodeOAuthToken"));
+        var githubToken = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GithubToken"));
+        var openAiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:OpenAiApiKey"));
+        var geminiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GeminiApiKey"));
 
         var reloadCounter = UseState(0);
         var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
@@ -131,11 +112,6 @@ public class TendrilDeployView : ViewBase
             .Builder(m => m.ServerId,
                 s => s.ToAsyncSelectInput(QueryServers, LookupServer, placeholder: "Search server…"))
             .Builder(m => m.Name, s => s.ToTextInput().Placeholder("e.g. ivy-tendril"))
-            .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-… or leave empty if using subscription token"))
-            .Builder(m => m.ClaudeCodeOAuthToken, b => b.ToPasswordInput(placeholder: "from `claude setup-token` (optional)"))
-            .Builder(m => m.GithubToken, b => b.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT"))
-            .Builder(m => m.OpenAiApiKey, b => b.ToPasswordInput(placeholder: "sk-… (optional)"))
-            .Builder(m => m.GeminiApiKey, b => b.ToPasswordInput(placeholder: "optional — Gemini API key"))
             .Remove(m => m.ProjectId, m => m.GitRepo, m => m.Branch, m => m.DockerfilePath, m => m.DockerContext,
                 m => m.Port, m => m.TendrilHome, m => m.VolumeId,
                 m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
@@ -178,9 +154,11 @@ public class TendrilDeployView : ViewBase
 
             var m = model.Value;
 
-            var anthropic = (m.AnthropicApiKey ?? "").Trim();
-            var claudeOAuth = (m.ClaudeCodeOAuthToken ?? "").Trim();
-            var github = (m.GithubToken ?? "").Trim();
+            var anthropic = (anthropicKey.Value ?? "").Trim();
+            var claudeOAuth = (claudeOAuthToken.Value ?? "").Trim();
+            var github = (githubToken.Value ?? "").Trim();
+            var openAi = (openAiKey.Value ?? "").Trim();
+            var gemini = (geminiKey.Value ?? "").Trim();
 
             isDeploying.Set(true);
             try
@@ -206,10 +184,8 @@ public class TendrilDeployView : ViewBase
                     envVars.Add(new EnvironmentVariable("CLAUDE_CODE_OAUTH_TOKEN", claudeOAuth, Secret: true));
                 if (github.Length > 0)
                     envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
-                var openAi = (m.OpenAiApiKey ?? "").Trim();
                 if (openAi.Length > 0)
                     envVars.Add(new EnvironmentVariable("OPENAI_API_KEY", openAi, Secret: true));
-                var gemini = (m.GeminiApiKey ?? "").Trim();
                 if (gemini.Length > 0)
                     envVars.Add(new EnvironmentVariable("GEMINI_API_KEY", gemini, Secret: true));
                 envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
@@ -248,11 +224,65 @@ public class TendrilDeployView : ViewBase
             }
         }
 
+        var claudeExpandable = new Expandable(
+            "Claude (Anthropic) — Claude Code",
+            Layout.Vertical().Gap(3).Width(Size.Full())
+                | Text.Muted("Claude Code inside the container.")
+                | Text.Markdown(
+                    "**API key:** create one in [Claude Console](https://console.anthropic.com/) → API keys. Pasted value is sent to Sliplane as **`ANTHROPIC_API_KEY`**.")
+                | Text.Markdown(
+                    "**Subscription token (no API billing):** on your laptop run **`claude setup-token`** (needs Pro / Max / Team / Enterprise), paste the token here → **`CLAUDE_CODE_OAUTH_TOKEN`**. If both key and token are set, Claude Code prefers the **API key**.")
+                | Text.Muted("Leave blank to configure later in the Sliplane service env.")
+                | anthropicKey.ToPasswordInput(placeholder: "sk-ant-api03-…").WithField().Label("Anthropic API key (optional)")
+                | claudeOAuthToken.ToPasswordInput(placeholder: "from claude setup-token").WithField().Label("Claude subscription token (optional)")
+        ).Open().Icon(Icons.Bot).Width(Size.Full());
+
+        var githubExpandable = new Expandable(
+            "GitHub — gh CLI",
+            Layout.Vertical().Gap(3).Width(Size.Full())
+                | Text.Muted("Repos, PRs, branches via GitHub CLI.")
+                | Text.Markdown(
+                    "**Where to get:** GitHub → **Settings → Developer settings** → Personal access tokens (classic or fine-grained). Scopes: at minimum **repo** if Tendril should push branches/open PRs.")
+                | Text.Markdown("**Sliplane env:** **`GITHUB_TOKEN`** (secret). The container runs `gh auth` using this variable.")
+                | Text.Muted("Optional — add later in Sliplane if you skip it here.")
+                | githubToken.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT").WithField().Label("GitHub token (optional)")
+        ).Icon(Icons.Github).Width(Size.Full());
+
+        var openAiExpandable = new Expandable(
+            "OpenAI Codex CLI",
+            Layout.Vertical().Gap(3).Width(Size.Full())
+                | Text.Muted("@openai/codex in the container image.")
+                | Text.Markdown(
+                    "**Where to get:** [OpenAI Platform](https://platform.openai.com/api-keys) → API keys.")
+                | Text.Markdown(
+                    "**Sliplane env:** **`OPENAI_API_KEY`**. Avoids running interactive **`codex login`** in the container.")
+                | Text.Muted("Optional.")
+                | openAiKey.ToPasswordInput(placeholder: "sk-…").WithField().Label("OpenAI API key (optional)")
+        ).Icon(Icons.Code).Width(Size.Full());
+
+        var geminiExpandable = new Expandable(
+            "Google Gemini CLI",
+            Layout.Vertical().Gap(3).Width(Size.Full())
+                | Text.Muted("@google/gemini-cli in the container image.")
+                | Text.Markdown(
+                    "**Where to get:** Google AI Studio / Gemini API key (see [Gemini CLI docs](https://github.com/google-gemini/gemini-cli) for the exact variable names for your version).")
+                | Text.Markdown("**This form sends:** **`GEMINI_API_KEY`** when non-empty.")
+                | Text.Muted("Optional.")
+                | geminiKey.ToPasswordInput(placeholder: "Gemini API key").WithField().Label("Gemini API key (optional)")
+        ).Icon(Icons.Sparkles).Width(Size.Full());
+
+        var agentSections = Layout.Vertical().Gap(2).Width(Size.Full())
+            | Text.H4("Agents & credentials").Muted()
+            | claudeExpandable
+            | githubExpandable
+            | openAiExpandable
+            | geminiExpandable;
+
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
             | Text.Lead(
-                "Pick server and service name. **All tokens are optional** — leave blank to set secrets later in Sliplane; only non-empty values are sent (Sliplane rejects empty env vars). "
-                + "Build settings use user-secrets / defaults.");
+                "Choose **server** and **service name**, then open each section below for **where to get** each secret and **which env var** it becomes. "
+                + "Empty fields are omitted (Sliplane rejects empty env values). Git / Dockerfile / volume defaults: user-secrets or `?repo=`.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)
@@ -264,10 +294,12 @@ public class TendrilDeployView : ViewBase
                 ? new Callout(validationView, "Please fix the following", CalloutVariant.Error)
                 : validationView);
 
-        var cardContent = Layout.Vertical()
+        var cardContent = Layout.Vertical().Width(Size.Full())
             | headerSection
             | new Separator()
             | formView
+            | new Separator()
+            | agentSections
             | new Spacer()
             | actionsRow;
 
@@ -292,7 +324,7 @@ public class TendrilDeployView : ViewBase
         if (deployError.Value != null)
             cardContent = cardContent | new Callout(deployError.Value, variant: CalloutVariant.Error);
 
-        var card = new Card(cardContent).Width(Size.Fraction(0.42f));
+        var card = new Card(cardContent).Width(Size.Fraction(0.5f));
         var manageServicesUrl = config["Sliplane:ManageServicesUrl"]?.Trim();
         if (string.IsNullOrEmpty(manageServicesUrl))
             manageServicesUrl = "https://ivy-sliplane-management.sliplane.app/";
@@ -302,6 +334,12 @@ public class TendrilDeployView : ViewBase
         var manageFloat = new FloatingPanel(manageBtn, Align.BottomRight).Offset(new Thickness(0, 0, 20, 10));
 
         return new Fragment(Layout.Center() | card, manageFloat);
+    }
+
+    private static string? SecretPrefill(IConfiguration c, string key)
+    {
+        var v = c[key]?.Trim();
+        return string.IsNullOrEmpty(v) ? null : v;
     }
 
     private static string DeriveServiceName(string repoUrl, string dockerContext = ".")

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -118,16 +118,11 @@ public class TendrilDeployView : ViewBase
             .Builder(m => m.ServerId,
                 s => s.ToAsyncSelectInput(QueryServers, LookupServer, placeholder: "Search server…"))
             .Builder(m => m.Name, s => s.ToTextInput().Placeholder("e.g. ivy-tendril"))
-            .Builder(m => m.GitRepo, s => s.ToTextInput().Placeholder("https://github.com/owner/repo"))
-            .Builder(m => m.Branch, s => s.ToTextInput())
-            .Builder(m => m.DockerfilePath, s => s.ToTextInput().Placeholder(TendrilDeploymentPaths.DefaultDockerfilePath))
-            .Builder(m => m.DockerContext, s => s.ToTextInput().Placeholder("."))
             .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-api03-…"))
             .Builder(m => m.GithubToken, b => b.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT"))
-            .Builder(m => m.Port, b => b.ToTextInput())
-            .Builder(m => m.TendrilHome, b => b.ToTextInput())
-            .Builder(m => m.VolumeId, b => b.ToTextInput().Placeholder("optional"))
-            .Remove(m => m.ProjectId, m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
+            .Remove(m => m.ProjectId, m => m.GitRepo, m => m.Branch, m => m.DockerfilePath, m => m.DockerContext,
+                m => m.Port, m => m.TendrilHome, m => m.VolumeId,
+                m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
                 m => m.Healthcheck, m => m.Cmd)
             .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo, m => m.AnthropicApiKey,
                 m => m.GithubToken));
@@ -236,13 +231,14 @@ public class TendrilDeployView : ViewBase
 
         var calloutNoDockerfile = new Callout(
             Text.Markdown(
-                "Default image: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** branch `development`, Dockerfile **[`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)**. " +
-                "**Secrets** below are sent to Sliplane as env vars on deploy. Optionally pre-fill Git/PORT/TENDRIL_HOME and keys from **dotnet user-secrets** (`TendrilDeploy:*` — see README)."),
+                "**Git, Docker, PORT, TENDRIL_HOME, volume** come from **dotnet user-secrets** (`TendrilDeploy:*`) and app defaults — they are not shown in this form. " +
+                "Change them with `dotnet user-secrets set …` or use a `?repo=` GitHub URL (see README). " +
+                "Image: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** → [`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)."),
             variant: CalloutVariant.Warning).Width(Size.Full());
 
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
-            | Text.Lead("Enter runtime secrets here so the container gets Claude and GitHub CLI working without interactive login.");
+            | Text.Lead("Pick server, service name, and tokens. Build settings use user-secrets / defaults.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -31,31 +31,34 @@ public class TendrilDeployFormModel
     [Display(Name = "Docker context", Order = 7)]
     public string DockerContext { get; set; } = ".";
 
-    [Display(Name = "Anthropic API key", Order = 8,
-        Prompt = "ANTHROPIC_API_KEY (Claude) — sent to Sliplane as a secret env var")]
-    [Required(ErrorMessage = "Enter your Anthropic API key")]
+    [Display(Name = "Anthropic API key (optional)", Order = 8,
+        Prompt = "ANTHROPIC_API_KEY from Claude Console — use this **or** “Claude subscription token” below (not both needed). If both are set, the API key takes precedence in Claude Code.")]
     public string AnthropicApiKey { get; set; } = "";
 
-    [Display(Name = "GitHub token", Order = 9,
+    [Display(Name = "Claude subscription token (optional)", Order = 9,
+        Prompt = "Run `claude setup-token` locally (Pro / Max / Team / Enterprise), then paste here — sent as CLAUDE_CODE_OAUTH_TOKEN for headless hosts with no browser login.")]
+    public string ClaudeCodeOAuthToken { get; set; } = "";
+
+    [Display(Name = "GitHub token", Order = 10,
         Prompt = "GITHUB_TOKEN for gh / PRs — sent to Sliplane as a secret env var")]
     [Required(ErrorMessage = "Enter your GitHub token")]
     public string GithubToken { get; set; } = "";
 
-    [Display(Name = "OpenAI API key (Codex CLI)", Order = 10,
+    [Display(Name = "OpenAI API key (Codex CLI)", Order = 11,
         Prompt = "OPENAI_API_KEY — optional; enables OpenAI Codex without `codex login` in the container")]
     public string OpenAiApiKey { get; set; } = "";
 
-    [Display(Name = "Gemini API key (Gemini CLI)", Order = 11,
+    [Display(Name = "Gemini API key (Gemini CLI)", Order = 12,
         Prompt = "GEMINI_API_KEY — optional; headless auth for @google/gemini-cli (see Gemini CLI docs)")]
     public string GeminiApiKey { get; set; } = "";
 
-    [Display(Name = "PORT", Order = 12)]
+    [Display(Name = "PORT", Order = 13)]
     public string Port { get; set; } = "8000";
 
-    [Display(Name = "TENDRIL_HOME", Order = 13)]
+    [Display(Name = "TENDRIL_HOME", Order = 14)]
     public string TendrilHome { get; set; } = "/data/tendril";
 
-    [Display(Name = "Volume ID (optional)", Order = 14,
+    [Display(Name = "Volume ID (optional)", Order = 15,
         Prompt = "Sliplane persistent volume — mount at TENDRIL_HOME")]
     public string? VolumeId { get; set; }
 
@@ -107,6 +110,7 @@ public class TendrilDeployView : ViewBase
                 TendrilHome = ui.TendrilHome,
                 VolumeId = ui.VolumeId,
                 AnthropicApiKey = config["TendrilDeploy:AnthropicApiKey"]?.Trim() ?? "",
+                ClaudeCodeOAuthToken = config["TendrilDeploy:ClaudeCodeOAuthToken"]?.Trim() ?? "",
                 GithubToken = config["TendrilDeploy:GithubToken"]?.Trim() ?? "",
                 OpenAiApiKey = config["TendrilDeploy:OpenAiApiKey"]?.Trim() ?? "",
                 GeminiApiKey = config["TendrilDeploy:GeminiApiKey"]?.Trim() ?? "",
@@ -128,7 +132,8 @@ public class TendrilDeployView : ViewBase
             .Builder(m => m.ServerId,
                 s => s.ToAsyncSelectInput(QueryServers, LookupServer, placeholder: "Search server…"))
             .Builder(m => m.Name, s => s.ToTextInput().Placeholder("e.g. ivy-tendril"))
-            .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-api03-…"))
+            .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-… or leave empty if using subscription token"))
+            .Builder(m => m.ClaudeCodeOAuthToken, b => b.ToPasswordInput(placeholder: "from `claude setup-token` (optional)"))
             .Builder(m => m.GithubToken, b => b.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT"))
             .Builder(m => m.OpenAiApiKey, b => b.ToPasswordInput(placeholder: "sk-… (optional)"))
             .Builder(m => m.GeminiApiKey, b => b.ToPasswordInput(placeholder: "optional — Gemini API key"))
@@ -136,8 +141,7 @@ public class TendrilDeployView : ViewBase
                 m => m.Port, m => m.TendrilHome, m => m.VolumeId,
                 m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
                 m => m.Healthcheck, m => m.Cmd)
-            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo, m => m.AnthropicApiKey,
-                m => m.GithubToken));
+            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo, m => m.GithubToken));
 
         QueryResult<Option<string>[]> QueryServers(IViewContext ctx, string q) =>
             ctx.UseQuery<Option<string>[], (string, string, int)>(
@@ -176,12 +180,20 @@ public class TendrilDeployView : ViewBase
             var m = model.Value;
 
             var anthropic = (m.AnthropicApiKey ?? "").Trim();
+            var claudeOAuth = (m.ClaudeCodeOAuthToken ?? "").Trim();
             var github = (m.GithubToken ?? "").Trim();
-            if (string.IsNullOrEmpty(anthropic) || string.IsNullOrEmpty(github))
+            if (string.IsNullOrEmpty(anthropic) && string.IsNullOrEmpty(claudeOAuth))
             {
                 deployError.Set(
-                    "Anthropic API key and GitHub token must be non-empty (spaces-only is treated as empty). "
-                    + "Sliplane rejects empty env values.");
+                    "Provide either an Anthropic API key or a Claude subscription token (`claude setup-token` → CLAUDE_CODE_OAUTH_TOKEN). "
+                    + "GitHub token must also be non-empty. Sliplane rejects empty env values.");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(github))
+            {
+                deployError.Set(
+                    "GitHub token must be non-empty (spaces-only is treated as empty). Sliplane rejects empty env values.");
                 return;
             }
 
@@ -203,7 +215,10 @@ public class TendrilDeployView : ViewBase
                 var port = string.IsNullOrWhiteSpace(m.Port) ? "8000" : m.Port.Trim();
                 var home = string.IsNullOrWhiteSpace(m.TendrilHome) ? "/data/tendril" : m.TendrilHome.Trim();
 
-                envVars.Add(new EnvironmentVariable("ANTHROPIC_API_KEY", anthropic, Secret: true));
+                if (anthropic.Length > 0)
+                    envVars.Add(new EnvironmentVariable("ANTHROPIC_API_KEY", anthropic, Secret: true));
+                if (claudeOAuth.Length > 0)
+                    envVars.Add(new EnvironmentVariable("CLAUDE_CODE_OAUTH_TOKEN", claudeOAuth, Secret: true));
                 envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
                 var openAi = (m.OpenAiApiKey ?? "").Trim();
                 if (openAi.Length > 0)
@@ -257,8 +272,8 @@ public class TendrilDeployView : ViewBase
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
             | Text.Lead(
-                "Pick server, service name, and required tokens (Anthropic + GitHub). Optional: OpenAI (Codex) and Gemini API keys. "
-                + "Build settings use user-secrets / defaults.");
+                "Pick server, service name, GitHub token, and **either** an Anthropic API key **or** a Claude subscription token from `claude setup-token`. "
+                + "Optional: OpenAI (Codex) and Gemini API keys. Build settings use user-secrets / defaults.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -31,13 +31,23 @@ public class TendrilDeployFormModel
     [Display(Name = "Docker context", Order = 7)]
     public string DockerContext { get; set; } = ".";
 
-    [Display(Name = "PORT", Order = 8)]
+    [Display(Name = "Anthropic API key", Order = 8,
+        Prompt = "ANTHROPIC_API_KEY (Claude) — sent to Sliplane as a secret env var")]
+    [Required(ErrorMessage = "Enter your Anthropic API key")]
+    public string AnthropicApiKey { get; set; } = "";
+
+    [Display(Name = "GitHub token", Order = 9,
+        Prompt = "GITHUB_TOKEN for gh / PRs — sent to Sliplane as a secret env var")]
+    [Required(ErrorMessage = "Enter your GitHub token")]
+    public string GithubToken { get; set; } = "";
+
+    [Display(Name = "PORT", Order = 10)]
     public string Port { get; set; } = "8000";
 
-    [Display(Name = "TENDRIL_HOME", Order = 9)]
+    [Display(Name = "TENDRIL_HOME", Order = 11)]
     public string TendrilHome { get; set; } = "/data/tendril";
 
-    [Display(Name = "Volume ID (optional)", Order = 10,
+    [Display(Name = "Volume ID (optional)", Order = 12,
         Prompt = "Sliplane persistent volume — mount at TENDRIL_HOME")]
     public string? VolumeId { get; set; }
 
@@ -69,23 +79,32 @@ public class TendrilDeployView : ViewBase
         var config = UseService<IConfiguration>();
         var dockerfileResolver = UseService<GitHubDockerfilePathResolver>();
 
-        var model = UseState(() => new TendrilDeployFormModel
+        var model = UseState(() =>
         {
-            ServerId = _defaultServerId,
-            ProjectId = _defaultProjectId,
-            GitRepo = _draft.RepoUrl,
-            Branch = string.IsNullOrWhiteSpace(_draft.Branch) ? TendrilDeployDefaults.DefaultBranch : _draft.Branch,
-            DockerContext = string.IsNullOrWhiteSpace(_draft.DockerContext) ? "." : _draft.DockerContext,
-            DockerfilePath = string.IsNullOrWhiteSpace(_draft.DockerfilePath)
-                ? TendrilDeploymentPaths.DefaultDockerfilePath
-                : _draft.DockerfilePath,
-            Name = DeriveServiceName(_draft.RepoUrl, _draft.DockerContext),
-            Port = "8000",
-            TendrilHome = "/data/tendril",
-            AutoDeploy = true,
-            NetworkPublic = true,
-            NetworkProtocol = "http",
-            Healthcheck = "/",
+            var ui = TendrilDeploySettingsReader.Read(
+                config,
+                _draft,
+                TendrilDeployDefaults.DefaultBranch,
+                TendrilDeploymentPaths.DefaultDockerfilePath);
+            return new TendrilDeployFormModel
+            {
+                ServerId = _defaultServerId,
+                ProjectId = _defaultProjectId,
+                GitRepo = ui.GitRepo,
+                Branch = ui.Branch,
+                DockerContext = ui.DockerContext,
+                DockerfilePath = ui.DockerfilePath,
+                Name = DeriveServiceName(ui.GitRepo, ui.DockerContext),
+                Port = ui.Port,
+                TendrilHome = ui.TendrilHome,
+                VolumeId = ui.VolumeId,
+                AnthropicApiKey = config["TendrilDeploy:AnthropicApiKey"]?.Trim() ?? "",
+                GithubToken = config["TendrilDeploy:GithubToken"]?.Trim() ?? "",
+                AutoDeploy = true,
+                NetworkPublic = true,
+                NetworkProtocol = "http",
+                Healthcheck = "/",
+            };
         });
 
         var reloadCounter = UseState(0);
@@ -103,12 +122,15 @@ public class TendrilDeployView : ViewBase
             .Builder(m => m.Branch, s => s.ToTextInput())
             .Builder(m => m.DockerfilePath, s => s.ToTextInput().Placeholder(TendrilDeploymentPaths.DefaultDockerfilePath))
             .Builder(m => m.DockerContext, s => s.ToTextInput().Placeholder("."))
+            .Builder(m => m.AnthropicApiKey, b => b.ToPasswordInput(placeholder: "sk-ant-api03-…"))
+            .Builder(m => m.GithubToken, b => b.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT"))
             .Builder(m => m.Port, b => b.ToTextInput())
             .Builder(m => m.TendrilHome, b => b.ToTextInput())
             .Builder(m => m.VolumeId, b => b.ToTextInput().Placeholder("optional"))
             .Remove(m => m.ProjectId, m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
                 m => m.Healthcheck, m => m.Cmd)
-            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo));
+            .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo, m => m.AnthropicApiKey,
+                m => m.GithubToken));
 
         QueryResult<Option<string>[]> QueryServers(IViewContext ctx, string q) =>
             ctx.UseQuery<Option<string>[], (string, string, int)>(
@@ -146,6 +168,16 @@ public class TendrilDeployView : ViewBase
 
             var m = model.Value;
 
+            var anthropic = (m.AnthropicApiKey ?? "").Trim();
+            var github = (m.GithubToken ?? "").Trim();
+            if (string.IsNullOrEmpty(anthropic) || string.IsNullOrEmpty(github))
+            {
+                deployError.Set(
+                    "Anthropic API key and GitHub token must be non-empty (spaces-only is treated as empty). "
+                    + "Sliplane rejects empty env values.");
+                return;
+            }
+
             isDeploying.Set(true);
             try
             {
@@ -164,6 +196,8 @@ public class TendrilDeployView : ViewBase
                 var port = string.IsNullOrWhiteSpace(m.Port) ? "8000" : m.Port.Trim();
                 var home = string.IsNullOrWhiteSpace(m.TendrilHome) ? "/data/tendril" : m.TendrilHome.Trim();
 
+                envVars.Add(new EnvironmentVariable("ANTHROPIC_API_KEY", anthropic, Secret: true));
+                envVars.Add(new EnvironmentVariable("GITHUB_TOKEN", github, Secret: true));
                 envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
                 envVars.Add(new EnvironmentVariable("TENDRIL_HOME", home, Secret: false));
 
@@ -203,12 +237,12 @@ public class TendrilDeployView : ViewBase
         var calloutNoDockerfile = new Callout(
             Text.Markdown(
                 "Default image: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** branch `development`, Dockerfile **[`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)**. " +
-                "Add **ANTHROPIC_API_KEY** and **GITHUB_TOKEN** in the Sliplane service environment after deploy if you did not set them there."),
+                "**Secrets** below are sent to Sliplane as env vars on deploy. Optionally pre-fill Git/PORT/TENDRIL_HOME and keys from **dotnet user-secrets** (`TendrilDeploy:*` — see README)."),
             variant: CalloutVariant.Warning).Width(Size.Full());
 
         var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
             | Text.H1("Deploy Tendril to Sliplane")
-            | Text.Lead("Pick server and Git settings, then deploy. Runtime secrets are configured in Sliplane, not in this form.");
+            | Text.Lead("Enter runtime secrets here so the container gets Claude and GitHub CLI working without interactive login.");
 
         var actionsRow = Layout.Vertical()
             | (Layout.Horizontal().AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/GlobalUsings.cs
+++ b/project-demos/tendril-deploy/GlobalUsings.cs
@@ -1,0 +1,9 @@
+global using Ivy;
+global using Ivy.Core;
+global using Microsoft.Extensions.Configuration;
+global using Microsoft.Extensions.DependencyInjection;
+global using System.ComponentModel.DataAnnotations;
+global using System.Globalization;
+global using System.Text.Json;
+
+namespace TendrilDeploy;

--- a/project-demos/tendril-deploy/Models/SliplaneModels.cs
+++ b/project-demos/tendril-deploy/Models/SliplaneModels.cs
@@ -1,0 +1,99 @@
+namespace TendrilDeploy.Models;
+
+using System.Text.Json.Serialization;
+
+// ─── Projects ────────────────────────────────────────────────────────────────
+
+public record SliplaneProject(string Id, string Name);
+
+// ─── Servers ─────────────────────────────────────────────────────────────────
+
+public record SliplaneServer(
+    string Id,
+    string Name,
+    string Status,
+    [property: JsonPropertyName("location")] string Region,
+    [property: JsonPropertyName("instanceType")] string Plan,
+    string? Ipv4,
+    string? Ipv6,
+    DateTime CreatedAt
+);
+
+// ─── Services ────────────────────────────────────────────────────────────────
+
+public record SliplaneService(
+    string Id,
+    string Name,
+    string Status,
+    string? Image,
+    string? GitRepo,
+    string? GitBranch,
+    int? Port,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt,
+    List<SliplaneServiceDomain>? Domains,
+    SliplaneServiceResources? Resources,
+    [property: JsonPropertyName("network")] SliplaneServiceNetwork? Network,
+    [property: JsonPropertyName("deployment")] SliplaneServiceDeployment? Deployment,
+    [property: JsonPropertyName("serverId")] string? ServerId,
+    [property: JsonPropertyName("healthcheck")] string? Healthcheck = null,
+    [property: JsonPropertyName("cmd")] string? Cmd = null,
+    [property: JsonPropertyName("env")] List<EnvironmentVariable>? Env = null,
+    [property: JsonPropertyName("volumes")] List<SliplaneServiceVolumeInfo>? Volumes = null,
+    [property: JsonPropertyName("webhook")] string? Webhook = null
+);
+
+public record SliplaneServiceDomain(string Id, string Domain, bool IsCustom);
+
+public record SliplaneServiceVolumeInfo(string Id, string Name, string MountPath);
+
+public record SliplaneServiceResources(double CpuLimit, int MemoryLimit);
+
+public record SliplaneServiceNetwork(
+    bool Public,
+    string Protocol,
+    string ManagedDomain,
+    string InternalDomain,
+    [property: JsonPropertyName("customDomains")] List<SliplaneServiceCustomDomain>? CustomDomains
+);
+
+public record SliplaneServiceCustomDomain(string Id, string Domain, string Status);
+
+public record SliplaneServiceDeployment(
+    string Url,
+    string DockerfilePath,
+    string DockerContext,
+    bool AutoDeploy,
+    string Branch
+);
+
+public record SliplaneServiceEvent(string Type, string Message, DateTime CreatedAt);
+
+/// <summary>POST /projects/{projectId}/services — matches the Sliplane API spec.</summary>
+public record CreateServiceRequest(
+    string Name,
+    string ServerId,
+    ServiceNetworkRequest Network,
+    RepositoryDeployment Deployment,
+    string? Cmd = null,
+    string? Healthcheck = null,
+    List<EnvironmentVariable>? Env = null,
+    List<ServiceVolumeMount>? Volumes = null
+);
+
+public record ServiceVolumeMount(
+    [property: JsonPropertyName("id")] string VolumeId,
+    [property: JsonPropertyName("mountPath")] string MountPath
+);
+
+public record ServiceNetworkRequest(bool Public = true, string Protocol = "http");
+
+public record RepositoryDeployment(
+    string Url,
+    string Branch = "main",
+    bool AutoDeploy = true,
+    string DockerfilePath = "Dockerfile",
+    string DockerContext = "."
+);
+
+public record EnvironmentVariable(string Key, string Value, bool Secret = false);

--- a/project-demos/tendril-deploy/Program.cs
+++ b/project-demos/tendril-deploy/Program.cs
@@ -1,0 +1,46 @@
+using Ivy.Auth.Sliplane;
+using TendrilDeploy.Apps;
+using TendrilDeploy.Services;
+
+CultureInfo.DefaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
+
+var server = new Server();
+
+server.Services.AddHttpClient("Ivy", client =>
+{
+    client.DefaultRequestHeaders.Add("Accept", "application/json");
+    client.DefaultRequestHeaders.Add("User-Agent", "Ivy-TendrilDeploy/1.0");
+});
+
+server.Services.AddHttpClient("GitHubRaw", client =>
+{
+    client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Ivy-TendrilDeploy/1.0");
+});
+
+server.Services.AddSingleton<GitHubDockerfilePathResolver>();
+server.Services.AddSingleton(server.Configuration);
+server.Services.AddHttpContextAccessor();
+server.Services.AddScoped<DeploymentDraftStore>();
+server.Services.AddScoped<SliplaneApiClient>();
+
+Server.ConfigureAuthCookieOptions = options =>
+{
+    options.Expires = DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(30));
+};
+
+server.Services.AddSingleton<Microsoft.AspNetCore.Hosting.IStartupFilter, RepoCaptureFilter>();
+
+#if DEBUG
+server.UseHotReload();
+#endif
+server.AddAppsFromAssembly();
+server.AddConnectionsFromAssembly();
+
+server.UseAuth<SliplaneAuthProvider>();
+
+var appShellSettings = new AppShellSettings()
+    .DefaultApp<TendrilDeployApp>()
+    .UseTabs(preventDuplicates: true);
+server.UseAppShell(appShellSettings);
+
+await server.RunAsync();

--- a/project-demos/tendril-deploy/README.md
+++ b/project-demos/tendril-deploy/README.md
@@ -1,0 +1,31 @@
+# Tendril on Sliplane (demo)
+
+Ivy app in the same spirit as [`sliplane-deploy`](../sliplane-deploy): sign in with **Sliplane**, pick a server, and **create a Git-based service**. This UI does **not** collect Anthropic/GitHub secrets — set **ANTHROPIC_API_KEY** and **GITHUB_TOKEN** in the Sliplane service environment after deploy (or edit the service there).
+
+Default Git source: **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** branch `development`, Dockerfile **[`.github/docker/Dockerfile.tendril`](https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development/.github/docker)** (same layout as upstream [Ivy-Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril)).
+
+This folder contains **only** the Ivy deploy UI.
+
+## Flow
+
+1. Run `dotnet run` or `dotnet watch` in this folder (defaults to **port 5021** in `Properties/launchSettings.json`).
+   - Port in use: `dotnet watch --find-available-port`, or stop the other process.
+2. **Sign in with Sliplane** (or set `Sliplane:ApiToken` in user secrets / config).
+3. Confirm **Git repository**, **branch**, Dockerfile path, and Docker context (defaults match the fork above).
+4. Optionally set **Volume ID** for persistent storage at **TENDRIL_HOME**.
+5. **Deploy** — then add runtime secrets in Sliplane if needed.
+
+The Sliplane API ([ctrl.sliplane.io](https://ctrl.sliplane.io)) rejects environment variables with empty keys or values. This app only sends **PORT** and **TENDRIL_HOME** (+ any resolver extras such as **IVY_APP_DIR** when applicable).
+
+### Pre-fill from `?repo=`
+
+`/tendril-deploy-app?repo=https://github.com/ArtemLazarchuk/Ivy-Tendril/tree/development`
+
+## Configuration
+
+| Key | Purpose |
+|-----|--------|
+| `Sliplane:ApiToken` | Optional static API token (otherwise OAuth session) |
+| `Sliplane:ManageServicesUrl` | Optional override for the “Manage services” link |
+
+For **Tendril** itself, see [Ivy-Tendril](https://github.com/Ivy-Interactive/Ivy-Tendril).

--- a/project-demos/tendril-deploy/Services/DeploymentDraftStore.cs
+++ b/project-demos/tendril-deploy/Services/DeploymentDraftStore.cs
@@ -1,0 +1,122 @@
+namespace TendrilDeploy.Services;
+
+using TendrilDeploy;
+
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Parsed info from a GitHub URL (repo page or tree URL).
+/// </summary>
+public record DeployDraft(
+    string RepoUrl,
+    string Branch = "main",
+    string DockerContext = ".",
+    string DockerfilePath = TendrilDeploymentPaths.DefaultDockerfilePath);
+
+/// <summary>
+/// Per-user store for the last deploy draft.
+/// Key: Sliplane access-token cookie (logged-in) or anonymous browser cookie (pre-login).
+/// </summary>
+public class DeploymentDraftStore
+{
+    private static readonly ConcurrentDictionary<string, DeployDraft> _store = new();
+
+    public const string CookieName = "tendril-deploy-repo-key";
+
+    private readonly IHttpContextAccessor _http;
+
+    public DeploymentDraftStore(IHttpContextAccessor http) => _http = http;
+
+    public DeployDraft? LastDraft => GetDraft();
+
+    /// <summary>
+    /// Returns the draft and immediately removes it from the store (one-shot pre-fill).
+    /// </summary>
+    public DeployDraft? ReadAndClearDraft()
+    {
+        var key = GetCurrentKey();
+        if (key is null) return null;
+        _store.TryRemove(key, out var draft);
+        return draft;
+    }
+
+    public void SaveDraft(DeployDraft draft)
+    {
+        _store[GetOrCreateKey()] = draft;
+    }
+
+    /// <summary>
+    /// Parses a GitHub URL into a <see cref="DeployDraft"/>.
+    /// Supports:
+    ///   https://github.com/{owner}/{repo}/tree/{branch}/{subpath}  → repo + branch + docker context
+    ///   https://github.com/{owner}/{repo}                          → repo only
+    /// </summary>
+    public static DeployDraft ParseGitHubUrl(string input)
+    {
+        input = input.Trim().TrimEnd('/');
+
+        var treeMatch = Regex.Match(input,
+            @"^https://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/tree/(?<branch>[^/]+)(?:/(?<path>.+))?$");
+
+        if (treeMatch.Success)
+        {
+            var repoUrl = $"https://github.com/{treeMatch.Groups["owner"].Value}/{treeMatch.Groups["repo"].Value}";
+            var branch = treeMatch.Groups["branch"].Value;
+            var subPath = treeMatch.Groups["path"].Value.TrimEnd('/');
+
+            if (string.IsNullOrWhiteSpace(subPath))
+                return new DeployDraft(repoUrl, branch);
+
+            return new DeployDraft(
+                RepoUrl: repoUrl,
+                Branch: branch,
+                DockerContext: subPath,
+                DockerfilePath: $"{subPath}/Dockerfile");
+        }
+
+        return new DeployDraft(input);
+    }
+
+    private DeployDraft? GetDraft()
+    {
+        var key = GetCurrentKey();
+        return key is not null && _store.TryGetValue(key, out var d) ? d : null;
+    }
+
+    private string? GetCurrentKey()
+    {
+        var ctx = _http.HttpContext;
+        if (ctx is null) return null;
+
+        var token = ctx.Request.Cookies[".ivy.auth.token"];
+        if (!string.IsNullOrWhiteSpace(token)) return "token:" + token;
+
+        return ctx.Request.Cookies.TryGetValue(CookieName, out var k) && !string.IsNullOrWhiteSpace(k) ? k : null;
+    }
+
+    private string GetOrCreateKey()
+    {
+        var ctx = _http.HttpContext;
+
+        if (ctx is not null)
+        {
+            var token = ctx.Request.Cookies[".ivy.auth.token"];
+            if (!string.IsNullOrWhiteSpace(token)) return "token:" + token;
+
+            if (ctx.Request.Cookies.TryGetValue(CookieName, out var existing) && !string.IsNullOrWhiteSpace(existing))
+                return existing;
+        }
+
+        var newKey = "anon:" + Guid.NewGuid().ToString("N");
+        ctx?.Response.Cookies.Append(CookieName, newKey, new CookieOptions
+        {
+            HttpOnly = true,
+            SameSite = SameSiteMode.Lax,
+            Expires = DateTimeOffset.UtcNow.AddHours(2),
+        });
+
+        return newKey;
+    }
+}

--- a/project-demos/tendril-deploy/Services/GitHubDockerfilePathResolver.cs
+++ b/project-demos/tendril-deploy/Services/GitHubDockerfilePathResolver.cs
@@ -1,0 +1,138 @@
+namespace TendrilDeploy.Services;
+
+using System.Net;
+using System.Text.RegularExpressions;
+using TendrilDeploy;
+using TendrilDeploy.Models;
+
+/// <summary>
+/// Result of resolving which Dockerfile path, Docker context, and extra env vars to send to Sliplane.
+/// </summary>
+public record DockerfileResolution(
+    string DockerfilePath,
+    string DockerContext,
+    IReadOnlyList<EnvironmentVariable>? AdditionalEnv = null);
+
+/// <summary>
+/// When the app folder has no Dockerfile, falls back to <c>.github/docker/Dockerfile.ivy-default</c>.
+/// For monorepo subfolders the context is switched to repo root (<c>"."</c>) so the shared Dockerfile
+/// is inside the build context, and <c>IVY_APP_DIR</c> is passed as an env/build-arg so the Dockerfile
+/// knows which subfolder to build.
+/// </summary>
+public class GitHubDockerfilePathResolver
+{
+    private static readonly Regex GitHubRepoRegex = new(
+        @"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+?)(?:\.git)?/?$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
+
+    public GitHubDockerfilePathResolver(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+    {
+        _httpClientFactory = httpClientFactory;
+        _configuration = configuration;
+    }
+
+    public static bool TryParseGitHubRepo(string? gitRepoUrl, out string owner, out string repo)
+    {
+        owner = repo = "";
+        if (string.IsNullOrWhiteSpace(gitRepoUrl)) return false;
+        var trimmed = gitRepoUrl.Trim().TrimEnd('/');
+        var m = GitHubRepoRegex.Match(trimmed);
+        if (!m.Success) return false;
+        owner = m.Groups["owner"].Value;
+        repo = m.Groups["repo"].Value;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves Dockerfile path, Docker context and optional extra env vars for creating a Sliplane service.
+    /// </summary>
+    public async Task<DockerfileResolution> ResolveAsync(
+        string? gitRepoUrl,
+        string branch,
+        string dockerfilePath,
+        string dockerContext,
+        CancellationToken cancellationToken = default)
+    {
+        var contextTrim = string.IsNullOrWhiteSpace(dockerContext) ? "." : dockerContext.Trim();
+        var path = string.IsNullOrWhiteSpace(dockerfilePath)
+            ? TendrilDeploymentPaths.DefaultDockerfilePath
+            : dockerfilePath.Trim();
+        if (!TryParseGitHubRepo(gitRepoUrl, out var owner, out var repo))
+            return new DockerfileResolution(path, contextTrim);
+
+        var branchTrim = string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim();
+
+        // 1. If the requested Dockerfile exists on GitHub, use it as-is.
+        if (await ExistsOnGitHubRawAsync(owner, repo, branchTrim, path, cancellationToken).ConfigureAwait(false))
+            return new DockerfileResolution(path, contextTrim);
+
+        // 2. Try the shared default Dockerfile.
+        var fallback = (_configuration["Sliplane:DefaultDockerfilePath"] ?? ".github/docker/Dockerfile.ivy-default").Trim();
+        if (string.IsNullOrEmpty(fallback) || string.Equals(fallback, path, StringComparison.Ordinal))
+            return new DockerfileResolution(path, contextTrim);
+
+        if (!await ExistsOnGitHubRawAsync(owner, repo, branchTrim, fallback, cancellationToken).ConfigureAwait(false))
+            return new DockerfileResolution(path, contextTrim);
+
+        // 3. Shared Dockerfile exists. Switch context to repo root so the Dockerfile is inside the
+        //    build context (avoids Sliplane rewriting to ../../… which uploads as 2B).
+        //    Pass IVY_APP_DIR so the Dockerfile knows which subfolder contains the *.csproj.
+        var appDir = NormalizeRepoRelativePath(contextTrim);
+        List<EnvironmentVariable>? extraEnv = null;
+        if (appDir.Length > 0 && appDir != ".")
+            extraEnv = [new EnvironmentVariable("IVY_APP_DIR", appDir, Secret: false)];
+
+        return new DockerfileResolution(
+            DockerfilePath: fallback,
+            DockerContext: ".",
+            AdditionalEnv: extraEnv);
+    }
+
+    /// <summary>Normalize to forward-slash path without leading ./ or trailing /.</summary>
+    private static string NormalizeRepoRelativePath(string dockerContext)
+    {
+        var t = dockerContext.Replace('\\', '/').Trim().Trim('/');
+        while (t.StartsWith("./", StringComparison.Ordinal))
+            t = t[2..];
+        return string.IsNullOrEmpty(t) ? "." : t;
+    }
+
+    private async Task<bool> ExistsOnGitHubRawAsync(string owner, string repo, string branch, string repoRelativePath, CancellationToken cancellationToken)
+    {
+        var url = BuildRawUrl(owner, repo, branch, repoRelativePath);
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("GitHubRaw");
+            using (var head = new HttpRequestMessage(HttpMethod.Head, url))
+            {
+                using var headResponse = await client.SendAsync(head, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (headResponse.StatusCode == HttpStatusCode.OK) return true;
+                if (headResponse.StatusCode == HttpStatusCode.NotFound) return false;
+            }
+
+            using (var get = new HttpRequestMessage(HttpMethod.Get, url))
+            {
+                using var getResponse = await client.SendAsync(get, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                if (getResponse.StatusCode == HttpStatusCode.OK) return true;
+                if (getResponse.StatusCode == HttpStatusCode.NotFound) return false;
+            }
+
+            // Rate limits, private repo without token, etc. — do not treat as "missing".
+            return true;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private static string BuildRawUrl(string owner, string repo, string branch, string repoRelativePath)
+    {
+        var normalized = repoRelativePath.Replace('\\', '/').TrimStart('/');
+        var encodedPath = string.Join("/", normalized.Split('/', StringSplitOptions.RemoveEmptyEntries).Select(Uri.EscapeDataString));
+        return $"https://raw.githubusercontent.com/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(repo)}/{Uri.EscapeDataString(branch)}/{encodedPath}";
+    }
+}

--- a/project-demos/tendril-deploy/Services/RepoCaptureFilter.cs
+++ b/project-demos/tendril-deploy/Services/RepoCaptureFilter.cs
@@ -1,0 +1,33 @@
+namespace TendrilDeploy.Services;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Captures ?repo= from the initial GET before Ivy SPA strips query params.
+/// Parses GitHub URLs (including /tree/branch/subpath) and stores a <see cref="DeployDraft"/>.
+/// </summary>
+public class RepoCaptureFilter : IStartupFilter
+{
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+    {
+        return app =>
+        {
+            app.Use(async (context, nextMiddleware) =>
+            {
+                var raw = context.Request.Query["repo"].ToString();
+                if (!string.IsNullOrWhiteSpace(raw))
+                {
+                    var draft = DeploymentDraftStore.ParseGitHubUrl(Uri.UnescapeDataString(raw));
+                    var store = context.RequestServices.GetRequiredService<DeploymentDraftStore>();
+                    store.SaveDraft(draft);
+                }
+
+                await nextMiddleware(context);
+            });
+
+            next(app);
+        };
+    }
+}

--- a/project-demos/tendril-deploy/Services/ServiceRequestFactory.cs
+++ b/project-demos/tendril-deploy/Services/ServiceRequestFactory.cs
@@ -1,0 +1,57 @@
+namespace TendrilDeploy.Services;
+
+using TendrilDeploy;
+using TendrilDeploy.Models;
+
+internal static class ServiceRequestFactory
+{
+    public static CreateServiceRequest BuildCreateRequest(
+        string name,
+        string serverId,
+        string gitRepo,
+        string branch,
+        string dockerfilePath,
+        string dockerContext,
+        bool autoDeploy,
+        bool networkPublic,
+        string networkProtocol,
+        string? cmd,
+        string? healthcheck,
+        IReadOnlyCollection<EnvironmentVariable>? env,
+        IReadOnlyCollection<(string VolumeId, string MountPath)>? volumeMounts)
+    {
+        var envList = env is { Count: > 0 }
+            ? env
+                .Select(e => new EnvironmentVariable(
+                    Key: (e.Key ?? "").Trim(),
+                    Value: (e.Value ?? "").Trim(),
+                    Secret: e.Secret))
+                .Where(e => e.Key.Length > 0 && e.Value.Length > 0)
+                .ToList()
+            : null;
+        if (envList is { Count: 0 })
+            envList = null;
+        var volumes = volumeMounts is { Count: > 0 }
+            ? volumeMounts.Select(v => new ServiceVolumeMount(v.VolumeId, v.MountPath)).ToList()
+            : null;
+
+        return new CreateServiceRequest(
+            Name: name.Trim(),
+            ServerId: serverId,
+            Network: new ServiceNetworkRequest(Public: networkPublic, Protocol: networkProtocol),
+            Deployment: new RepositoryDeployment(
+                Url: gitRepo.Trim(),
+                Branch: string.IsNullOrWhiteSpace(branch) ? "main" : branch.Trim(),
+                AutoDeploy: autoDeploy,
+                DockerfilePath: string.IsNullOrWhiteSpace(dockerfilePath)
+                    ? TendrilDeploymentPaths.DefaultDockerfilePath
+                    : dockerfilePath.Trim(),
+                DockerContext: string.IsNullOrWhiteSpace(dockerContext) ? "." : dockerContext.Trim()
+            ),
+            Cmd: string.IsNullOrWhiteSpace(cmd) ? null : cmd.Trim(),
+            Healthcheck: string.IsNullOrWhiteSpace(healthcheck) ? null : healthcheck.Trim(),
+            Env: envList,
+            Volumes: volumes
+        );
+    }
+}

--- a/project-demos/tendril-deploy/Services/SliplaneApiClient.cs
+++ b/project-demos/tendril-deploy/Services/SliplaneApiClient.cs
@@ -1,0 +1,143 @@
+namespace TendrilDeploy.Services;
+
+using TendrilDeploy.Models;
+using System.Net.Http.Headers;
+using System.Text;
+
+/// <summary>
+/// HTTP client for the Sliplane REST API (https://ctrl.sliplane.io/v0).
+/// Deploy app uses: projects, servers, create service, service events.
+/// </summary>
+public class SliplaneApiClient
+{
+    private const string BaseUrl = "https://ctrl.sliplane.io/v0";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public SliplaneApiClient(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<List<SliplaneProject>> GetProjectsAsync(string apiToken)
+    {
+        var response = await SendAsync(HttpMethod.Get, "/projects", apiToken);
+        return await ParseArrayAsync<SliplaneProject>(response, "projects") ?? [];
+    }
+
+    public async Task<SliplaneProject?> CreateProjectAsync(string apiToken, string name)
+    {
+        var body = new { name };
+        var response = await SendAsync(HttpMethod.Post, "/projects", apiToken, body);
+        return await ParseObjectAsync<SliplaneProject>(response);
+    }
+
+    public async Task<List<SliplaneServer>> GetServersAsync(string apiToken)
+    {
+        var response = await SendAsync(HttpMethod.Get, "/servers", apiToken);
+        return await ParseArrayAsync<SliplaneServer>(response, "servers") ?? [];
+    }
+
+    public async Task<SliplaneService?> CreateServiceAsync(string apiToken, string projectId, CreateServiceRequest request)
+    {
+        var response = await SendAsync(HttpMethod.Post, $"/projects/{projectId}/services", apiToken, request);
+
+        if (response == null)
+        {
+            throw new InvalidOperationException("Sliplane API did not respond when creating the service. Check your network connection and API token.");
+        }
+
+        var responseBody = string.Empty;
+        try { responseBody = await response.Content.ReadAsStringAsync(); } catch { }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = $"Sliplane API returned {(int)response.StatusCode} {response.StatusCode} when creating the service.";
+            if (!string.IsNullOrWhiteSpace(responseBody))
+                message += $" Details: {responseBody}";
+
+            throw new InvalidOperationException(message);
+        }
+
+        return string.IsNullOrWhiteSpace(responseBody)
+            ? null
+            : JsonSerializer.Deserialize<SliplaneService>(responseBody,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    public async Task<SliplaneService?> GetServiceAsync(string apiToken, string projectId, string serviceId)
+    {
+        var response = await SendAsync(HttpMethod.Get, $"/projects/{projectId}/services/{serviceId}", apiToken);
+        return await ParseObjectAsync<SliplaneService>(response);
+    }
+
+    public async Task<List<SliplaneServiceEvent>> GetServiceEventsAsync(string apiToken, string projectId, string serviceId)
+    {
+        var response = await SendAsync(HttpMethod.Get, $"/projects/{projectId}/services/{serviceId}/events", apiToken);
+        return await ParseArrayAsync<SliplaneServiceEvent>(response, "events") ?? [];
+    }
+
+    private HttpClient CreateClient() => _httpClientFactory.CreateClient("Ivy");
+
+    private async Task<HttpResponseMessage?> SendAsync(HttpMethod method, string path, string apiToken, object? body = null)
+    {
+        try
+        {
+            using var client = CreateClient();
+            using var request = new HttpRequestMessage(method, $"{BaseUrl}{path}");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
+
+            if (body != null)
+            {
+                request.Content = new StringContent(
+                    JsonSerializer.Serialize(body, new JsonSerializerOptions
+                    {
+                        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+                    }),
+                    Encoding.UTF8,
+                    "application/json"
+                );
+            }
+
+            return await client.SendAsync(request);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private async Task<T?> ParseObjectAsync<T>(HttpResponseMessage? response)
+    {
+        if (response == null || !response.IsSuccessStatusCode) return default;
+        try
+        {
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonSerializer.Deserialize<T>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch { return default; }
+    }
+
+    private async Task<List<T>?> ParseArrayAsync<T>(HttpResponseMessage? response, string? arrayKey = null)
+    {
+        if (response == null || !response.IsSuccessStatusCode) return null;
+        try
+        {
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+
+            JsonElement root = doc.RootElement;
+
+            if (arrayKey != null && root.ValueKind == JsonValueKind.Object && root.TryGetProperty(arrayKey, out var prop))
+            {
+                root = prop;
+            }
+
+            if (root.ValueKind != JsonValueKind.Array) return null;
+
+            return JsonSerializer.Deserialize<List<T>>(root.GetRawText(), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch { return null; }
+    }
+}

--- a/project-demos/tendril-deploy/Services/TendrilDeploySettingsReader.cs
+++ b/project-demos/tendril-deploy/Services/TendrilDeploySettingsReader.cs
@@ -1,0 +1,48 @@
+namespace TendrilDeploy.Services;
+
+/// <summary>Non-secret deploy form defaults from <c>IConfiguration</c> (e.g. dotnet user-secrets under <c>TendrilDeploy:*</c>).</summary>
+public readonly record struct TendrilDeployUiDefaults(
+    string GitRepo,
+    string Branch,
+    string DockerfilePath,
+    string DockerContext,
+    string Port,
+    string TendrilHome,
+    string? VolumeId);
+
+public static class TendrilDeploySettingsReader
+{
+    /// <summary>Fills UI defaults: config value wins when non-empty after trim; otherwise <paramref name="draft"/> / built-in fallbacks.</summary>
+    public static TendrilDeployUiDefaults Read(
+        IConfiguration config,
+        DeployDraft draft,
+        string defaultBranch,
+        string defaultDockerfilePath)
+    {
+        string Co(string key, string fallback)
+        {
+            var v = config[key]?.Trim();
+            return string.IsNullOrEmpty(v) ? fallback : v;
+        }
+
+        string? CoOpt(string key)
+        {
+            var v = config[key]?.Trim();
+            return string.IsNullOrEmpty(v) ? null : v;
+        }
+
+        var branchFb = string.IsNullOrWhiteSpace(draft.Branch) ? defaultBranch : draft.Branch.Trim();
+        var ctxFb = string.IsNullOrWhiteSpace(draft.DockerContext) ? "." : draft.DockerContext.Trim();
+        var dfFb = string.IsNullOrWhiteSpace(draft.DockerfilePath) ? defaultDockerfilePath : draft.DockerfilePath.Trim();
+        var repoFb = string.IsNullOrWhiteSpace(draft.RepoUrl) ? "" : draft.RepoUrl.Trim();
+
+        return new TendrilDeployUiDefaults(
+            GitRepo: Co("TendrilDeploy:GitRepo", repoFb),
+            Branch: Co("TendrilDeploy:Branch", branchFb),
+            DockerfilePath: Co("TendrilDeploy:DockerfilePath", dfFb),
+            DockerContext: Co("TendrilDeploy:DockerContext", ctxFb),
+            Port: Co("TendrilDeploy:Port", "8000"),
+            TendrilHome: Co("TendrilDeploy:TendrilHome", "/data/tendril"),
+            VolumeId: CoOpt("TendrilDeploy:VolumeId"));
+    }
+}

--- a/project-demos/tendril-deploy/TendrilDeploy.csproj
+++ b/project-demos/tendril-deploy/TendrilDeploy.csproj
@@ -9,11 +9,11 @@
     <UserSecretsId>tendril-deploy-sliplane-001</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
+    <PackageReference Include="Ivy" Version="1.2.50" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.50">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.50" />
   </ItemGroup>
 </Project>

--- a/project-demos/tendril-deploy/TendrilDeploy.csproj
+++ b/project-demos/tendril-deploy/TendrilDeploy.csproj
@@ -9,11 +9,11 @@
     <UserSecretsId>tendril-deploy-sliplane-001</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.50" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.50">
+    <PackageReference Include="Ivy" Version="1.2.44" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.44">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.50" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.44" />
   </ItemGroup>
 </Project>

--- a/project-demos/tendril-deploy/TendrilDeploy.csproj
+++ b/project-demos/tendril-deploy/TendrilDeploy.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>CS8618;CS8603;CS8602;CS8604;CS9113</NoWarn>
+    <RootNamespace>TendrilDeploy</RootNamespace>
+    <UserSecretsId>tendril-deploy-sliplane-001</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Ivy" Version="1.2.37-pre-20260412104447" />
+    <PackageReference Include="Ivy.Analyser" Version="1.2.37-pre-20260412104447">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.37-pre-20260412104447" />
+  </ItemGroup>
+</Project>

--- a/project-demos/tendril-deploy/TendrilDeploymentPaths.cs
+++ b/project-demos/tendril-deploy/TendrilDeploymentPaths.cs
@@ -1,0 +1,7 @@
+namespace TendrilDeploy;
+
+/// <summary>Default Git paths for Tendril → Sliplane deploy (see Ivy-Tendril repo layout).</summary>
+public static class TendrilDeploymentPaths
+{
+    public const string DefaultDockerfilePath = ".github/docker/Dockerfile.tendril";
+}

--- a/project-demos/tendril-deploy/tendril-deploy.sln
+++ b/project-demos/tendril-deploy/tendril-deploy.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TendrilDeploy", "TendrilDeploy.csproj", "{8F4A2C10-9E3B-4D7A-B1F0-2C6E8A9D5B14}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8F4A2C10-9E3B-4D7A-B1F0-2C6E8A9D5B14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F4A2C10-9E3B-4D7A-B1F0-2C6E8A9D5B14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F4A2C10-9E3B-4D7A-B1F0-2C6E8A9D5B14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F4A2C10-9E3B-4D7A-B1F0-2C6E8A9D5B14}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION

## Summary

Adds **`project-demos/tendril-deploy`**, an Ivy application in the same spirit as `sliplane-deploy`: sign in with **Sliplane**, pick a **server** and **service name**, optionally provide **runtime secrets**, and create a **Git-based** service that builds from **[ArtemLazarchuk/Ivy-Tendril](https://github.com/ArtemLazarchuk/Ivy-Tendril)** (`development` by default) using **`.github/docker/Dockerfile.tendril`**.

Use this UI for **local one-click checks** (API keys via form or user-secrets) and to **provision the hosted Tendril instance on Sliplane** (secrets end up as the service’s environment variables).

---

## Where it deploys

- **Target platform:** [Sliplane](https://sliplane.app) (API: `ctrl.sliplane.io`).
- **Default image source:** Git repo **`ArtemLazarchuk/Ivy-Tendril`**, branch **`development`**, Dockerfile **`.github/docker/Dockerfile.tendril`** (override via `?repo=` or `TendrilDeploy:*` user-secrets).
- **Runtime (container):** Tendril web (`tendril --web`); configure **`PORT`** and **`TENDRIL_HOME`** (defaults `8000` and `/data/tendril`).

---

## Secrets & configuration

### Required to use the deploy UI

| Secret / config | How to set | Purpose |
|-----------------|------------|---------|
| **Sliplane session** | Sign in through the app (OAuth) | Access projects/servers/API |
| **`Sliplane:ApiToken`** (optional) | `dotnet user-secrets set "Sliplane:ApiToken" "…"` or config | Static token instead of browser OAuth |


### Non-secret deploy defaults (user-secrets)

| Key | Example |
|-----|---------|
| `TendrilDeploy:GitRepo` | `https://github.com/ArtemLazarchuk/Ivy-Tendril` |
| `TendrilDeploy:Branch` | `development` |
| `TendrilDeploy:DockerfilePath` | `.github/docker/Dockerfile.tendril` |
| `TendrilDeploy:DockerContext` | `.` |
| `TendrilDeploy:Port` | `8000` |
| `TendrilDeploy:TendrilHome` | `/data/tendril` |
| `Sliplane:Secret` | *....* |
| `Sliplane:ClientSecret` | *....* |
| `Sliplane:ClientId` | *....* |




https://github.com/user-attachments/assets/0913ef8f-d309-4453-8623-f40f6be47303

