### PR TITLE
[tendril-deploy]: wizard, clone bootstrap, Basic Auth, Copilot GH_TOKEN

### DIFF
--- a/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
@@ -5,7 +5,7 @@ using TendrilDeploy.Models;
 using TendrilDeploy.Services;
 
 /// <summary>
-/// Tendril deploy wizard: (1) Sliplane server + service name, (2) optional API secrets, then deploy + status.
+/// Tendril deploy wizard: (1) server + service name → (2) optional API secrets → (3) optional workspace repos to clone under <c>TENDRIL_HOME</c>, then deploy + status.
 /// <c>?repo=</c> is captured by <see cref="RepoCaptureFilter"/> the same way as sliplane-deploy.
 /// </summary>
 [App(

--- a/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
+++ b/project-demos/tendril-deploy/Apps/TendrilDeployApp.cs
@@ -5,7 +5,7 @@ using TendrilDeploy.Models;
 using TendrilDeploy.Services;
 
 /// <summary>
-/// One-click Tendril deploy to Sliplane from Git (default fork with <c>.github/docker/Dockerfile.tendril</c>).
+/// Tendril deploy wizard: (1) Sliplane server + service name, (2) optional API secrets, then deploy + status.
 /// <c>?repo=</c> is captured by <see cref="RepoCaptureFilter"/> the same way as sliplane-deploy.
 /// </summary>
 [App(

--- a/project-demos/tendril-deploy/Apps/Views/TendrilBootstrapRepoRowView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilBootstrapRepoRowView.cs
@@ -1,0 +1,60 @@
+namespace TendrilDeploy.Apps.Views;
+
+internal sealed record TendrilBootstrapRepoEntry(Guid Id, string CloneUrl);
+
+internal sealed class TendrilBootstrapRepoRowView : ViewBase
+{
+    private readonly Guid _rowId;
+    private readonly IState<List<TendrilBootstrapRepoEntry>> _repos;
+
+    public TendrilBootstrapRepoRowView(Guid rowId, IState<List<TendrilBootstrapRepoEntry>> repos)
+    {
+        _rowId = rowId;
+        _repos = repos;
+    }
+
+    public override object? Build()
+    {
+        var cloneUrl = UseState(() =>
+            _repos.Value.FirstOrDefault(r => r.Id == _rowId)?.CloneUrl ?? "");
+
+        UseEffect(() =>
+        {
+            var u = cloneUrl.Value.Trim();
+            _repos.Set(list =>
+            {
+                var ix = list.FindIndex(e => e.Id == _rowId);
+                if (ix < 0)
+                    return list;
+                var cur = list[ix];
+                var next = cur with { CloneUrl = u };
+                if (cur == next)
+                    return list;
+                var copy = list.ToList();
+                copy[ix] = next;
+                return copy;
+            });
+        }, cloneUrl.ToTrigger());
+
+        var moreThanOne = _repos.Value.Count > 1;
+
+        return Layout.Vertical().Gap(1).Width(Size.Full())
+            | Text.Muted("GitHub URL")
+            | (Layout.Horizontal().Gap(1).Center().Width(Size.Full())
+                | (Layout.Vertical().Width(Size.Grow())
+                    | cloneUrl.ToTextInput()
+                        .Prefix(Icons.Github)
+                        .Placeholder("https://github.com/org/repository.git")
+                        .Width(Size.Full()))
+                | new Button().Icon(Icons.Trash2).Variant(ButtonVariant.Ghost).Large()
+                    .OnClick(_ =>
+                    {
+                        if (!moreThanOne)
+                            cloneUrl.Set("");
+                        else
+                            _repos.Set(list => list.Where(e => e.Id != _rowId).ToList());
+
+                        return ValueTask.CompletedTask;
+                    }));
+    }
+}

--- a/project-demos/tendril-deploy/Apps/Views/TendrilBootstrapRepoRowView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilBootstrapRepoRowView.cs
@@ -38,23 +38,23 @@ internal sealed class TendrilBootstrapRepoRowView : ViewBase
 
         var moreThanOne = _repos.Value.Count > 1;
 
-        return Layout.Vertical().Gap(1).Width(Size.Full())
-            | Text.Muted("GitHub URL")
-            | (Layout.Horizontal().Gap(1).Center().Width(Size.Full())
-                | (Layout.Vertical().Width(Size.Grow())
-                    | cloneUrl.ToTextInput()
-                        .Prefix(Icons.Github)
-                        .Placeholder("https://github.com/org/repository.git")
-                        .Width(Size.Full()))
-                | new Button().Icon(Icons.Trash2).Variant(ButtonVariant.Ghost).Large()
-                    .OnClick(_ =>
-                    {
-                        if (!moreThanOne)
-                            cloneUrl.Set("");
-                        else
-                            _repos.Set(list => list.Where(e => e.Id != _rowId).ToList());
+        // Label lives once on the parent step (TendrilDeployView); rows are only input + remove.
+        return Layout.Horizontal().Gap(1).Center().Width(Size.Full())
+            | (Layout.Vertical().Width(Size.Grow())
+                | cloneUrl.ToTextInput()
+                    .Prefix(Icons.Github)
+                    .Placeholder("https://github.com/org/repository.git")
+                    .Width(Size.Full()))
+            | new Button().Icon(Icons.Trash2).Variant(ButtonVariant.Ghost).Large()
+                .Tooltip("Remove this row")
+                .OnClick(_ =>
+                {
+                    if (!moreThanOne)
+                        cloneUrl.Set("");
+                    else
+                        _repos.Set(list => list.Where(e => e.Id != _rowId).ToList());
 
-                        return ValueTask.CompletedTask;
-                    }));
+                    return ValueTask.CompletedTask;
+                });
     }
 }

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -354,8 +354,10 @@ public class TendrilDeployView : ViewBase
 
         object repoSections = Layout.Vertical().Gap(4).Width(Size.Full())
             | Text.H4("Repositories")
-            | Text.Muted("Enter only HTTPS or SSH GitHub repository URLs — leave rows blank if you skip this step.")
-            | (Layout.Vertical().Gap(3).Width(Size.Full())
+            | Text.Muted(
+                "One GitHub clone URL per row (HTTPS or SSH). Leave a row empty if you do not need that clone. "
+                    + "Use Add for more repositories.")
+            | (Layout.Vertical().Gap(2).Width(Size.Full())
                 | repoCloneRows.Value.Select(e => (object)new TendrilBootstrapRepoRowView(e.Id, repoCloneRows))
                     .ToArray())
             | new Button("Add").Icon(Icons.Plus).Outline()

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -102,6 +102,7 @@ public class TendrilDeployView : ViewBase
         var geminiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GeminiApiKey"));
 
         var reloadCounter = UseState(0);
+        var stepIndex = UseState(0);
         var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
         var deployError = UseState<string?>(() => null);
         var validationFailed = UseState(false);
@@ -140,6 +141,18 @@ public class TendrilDeployView : ViewBase
 
         _ = QueryServers(Context, "");
         _ = LookupServer(Context, model.Value.ServerId);
+
+        async ValueTask AdvanceFromStep0Async()
+        {
+            validationFailed.Set(false);
+            if (!await onSubmit())
+            {
+                validationFailed.Set(true);
+                return;
+            }
+
+            stepIndex.Set(1);
+        }
 
         async ValueTask HandleDeploy()
         {
@@ -272,43 +285,105 @@ public class TendrilDeployView : ViewBase
         ).Icon(Icons.Sparkles).Width(Size.Full());
 
         var agentSections = Layout.Vertical().Gap(2).Width(Size.Full())
-            | Text.H4("Agents & credentials").Muted()
             | claudeExpandable
             | githubExpandable
             | openAiExpandable
             | geminiExpandable;
 
-        var headerSection = Layout.Vertical().AlignContent(Align.Center).Gap(4)
-            | Text.H1("Deploy Tendril to Sliplane")
-            | Text.Lead(
-                "Choose **server** and **service name**, then open each section below for **where to get** each secret and **which env var** it becomes. "
-                + "Empty fields are omitted (Sliplane rejects empty env values). Git / Dockerfile / volume defaults: user-secrets or `?repo=`.");
+        var stepperItems = new[]
+        {
+            new StepperItem("1", stepIndex.Value > 0 ? Icons.Check : null, "Welcome", "Server & name"),
+            new StepperItem("2", deployedService.Value != null ? Icons.Check : null, "Secrets", "API keys"),
+        };
 
-        var actionsRow = Layout.Vertical()
-            | (Layout.Horizontal().AlignContent(Align.Center)
-                | new Button("Deploy").Primary().Large()
-                    .Loading(loading || isDeploying.Value).Disabled(loading || isDeploying.Value)
-                    .Width(Size.Fraction(0.5f))
-                    .OnClick(async _ => await HandleDeploy()))
-            | (validationFailed.Value
-                ? new Callout(validationView, "Please fix the following", CalloutVariant.Error)
-                : validationView);
+        ValueTask OnStepperSelect(Event<Stepper, int> e)
+        {
+            if (e.Value < stepIndex.Value)
+                stepIndex.Set(e.Value);
+            return ValueTask.CompletedTask;
+        }
 
-        var cardContent = Layout.Vertical().Width(Size.Full())
-            | headerSection
-            | new Separator()
-            | formView
-            | new Separator()
-            | agentSections
-            | new Spacer()
-            | actionsRow;
+        var welcomeNoteCallout = new Callout(
+            Layout.Vertical().Gap(3)
+                | Text.Block(
+                    "Ivy Tendril is a coding orchestrator powered by agents like Claude Code, Codex, Gemini, or Copilot. "
+                    + "It is built to help you ship a lot of work quickly on your own infrastructure.")
+                | Text.Block("Please be aware that Tendril can consume tokens rapidly.").Bold(),
+            "Note",
+            CalloutVariant.Info);
+
+        var secretsHintCallout = new Callout(
+            Text.Markdown(
+                "**Optional** keys for your agents—each is a **secret** env var on Sliplane. "
+                + "Empty fields are ignored. Repo, Dockerfile, **PORT**, **TENDRIL_HOME**, and volume come from config or **`?repo=`**, not below."),
+            "Secrets",
+            CalloutVariant.Info);
+
+        object validationBlock = validationFailed.Value
+            ? new Callout(validationView, "Please fix the following", CalloutVariant.Error)
+            : new Empty();
+
+        var titleBlock = stepIndex.Value == 0
+            ? (object)(Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("Welcome to Ivy Tendril").Align(TextAlignment.Center))
+            : (object)(Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("API keys").Align(TextAlignment.Center));
+
+        var stepBody = stepIndex.Value == 0
+            ? (object)(Layout.Vertical().Gap(4).Width(Size.Full())
+                | welcomeNoteCallout
+                | formView
+                | validationBlock)
+            : (object)(Layout.Vertical().Gap(4).Width(Size.Full())
+                | secretsHintCallout
+                | agentSections);
+
+        object footerRow = stepIndex.Value == 0
+            ? (object)(Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)
+                | new Button("Get started")
+                    .Icon(Icons.ChevronRight, Align.Right)
+                    .Primary()
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Full())
+                    .Loading(loading)
+                    .Disabled(loading)
+                    .OnClick(async _ => await AdvanceFromStep0Async()))
+            : (object)(Layout.Horizontal().Width(Size.Full()).Gap(4)
+                | new Button("Back")
+                    .Icon(Icons.ChevronLeft)
+                    .Variant(ButtonVariant.Outline)
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .OnClick(_ => stepIndex.Set(0))
+                | new Spacer()
+                | new Button("Deploy")
+                    .Icon(Icons.Rocket, Align.Right)
+                    .Primary()
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .Loading(loading || isDeploying.Value)
+                    .Disabled(loading || isDeploying.Value)
+                    .OnClick(async _ => await HandleDeploy()));
+
+        var stepperRow = Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)
+            | new Stepper(OnStepperSelect, stepIndex.Value, stepperItems).Width(Size.Full());
+
+        var mainFlow = Layout.Vertical().Width(Size.Full()).Gap(4).AlignContent(Align.Stretch)
+            | stepperRow
+            | titleBlock
+            | stepBody
+            | footerRow;
+
+        var pageBody = mainFlow;
 
         if (isDeploying.Value && deployedService.Value == null)
         {
-            cardContent = cardContent
-                | new Separator()
+            pageBody = pageBody
                 | new Callout(
-                    Layout.Vertical()
+                    Layout.Vertical().Gap(3)
                         | Text.Block("Creating Tendril service on Sliplane…").Bold()
                         | new Progress().Indeterminate().Goal("Please wait…"),
                     "Deploying",
@@ -316,15 +391,20 @@ public class TendrilDeployView : ViewBase
         }
         else if (deployedService.Value is { } deployed)
         {
-            cardContent = cardContent
-                | new Separator()
+            pageBody = pageBody
                 | new TendrilDeployStatusView(_apiToken, deployed.ProjectId, deployed.Service);
         }
 
         if (deployError.Value != null)
-            cardContent = cardContent | new Callout(deployError.Value, variant: CalloutVariant.Error);
+            pageBody = pageBody | new Callout(deployError.Value, variant: CalloutVariant.Error);
 
-        var card = new Card(cardContent).Width(Size.Fraction(0.5f));
+        var pageColumn = Layout.Vertical()
+            .Width(Size.Fraction(0.52f))
+            .Gap(2)
+            .Padding(new Thickness(16, 16, 16, 16))
+            .AlignContent(Align.Stretch)
+            | pageBody;
+
         var manageServicesUrl = config["Sliplane:ManageServicesUrl"]?.Trim();
         if (string.IsNullOrEmpty(manageServicesUrl))
             manageServicesUrl = "https://ivy-sliplane-management.sliplane.app/";
@@ -333,7 +413,11 @@ public class TendrilDeployView : ViewBase
             .Outline().Large().BorderRadius(BorderRadius.Full);
         var manageFloat = new FloatingPanel(manageBtn, Align.BottomRight).Offset(new Thickness(0, 0, 20, 10));
 
-        return new Fragment(Layout.Center() | card, manageFloat);
+        return new Fragment(
+            Layout.TopCenter()
+                .Padding(new Thickness(0, 12, 0, 0))
+                | pageColumn,
+            manageFloat);
     }
 
     private static string? SecretPrefill(IConfiguration c, string key)

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -112,6 +112,7 @@ public class TendrilDeployView : ViewBase
         var githubToken = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GithubToken"));
         var openAiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:OpenAiApiKey"));
         var geminiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GeminiApiKey"));
+        var copilotGhToken = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:CopilotGhToken"));
 
         var basicAuthModel = UseState(() => new TendrilBasicAuthFormModel());
         var basicAuthValidationFailed = UseState(false);
@@ -220,6 +221,7 @@ public class TendrilDeployView : ViewBase
             var github = (githubToken.Value ?? "").Trim();
             var openAi = (openAiKey.Value ?? "").Trim();
             var gemini = (geminiKey.Value ?? "").Trim();
+            var copilotGh = (copilotGhToken.Value ?? "").Trim();
 
             (string Users, string HashSecret, string JwtSecret) basicAuthEnv;
             try
@@ -264,6 +266,8 @@ public class TendrilDeployView : ViewBase
                     envVars.Add(new EnvironmentVariable("OPENAI_API_KEY", openAi, Secret: true));
                 if (gemini.Length > 0)
                     envVars.Add(new EnvironmentVariable("GEMINI_API_KEY", gemini, Secret: true));
+                if (copilotGh.Length > 0)
+                    envVars.Add(new EnvironmentVariable("GH_TOKEN", copilotGh, Secret: true));
                 envVars.Add(new EnvironmentVariable("BasicAuth__Users", basicAuthEnv.Users, Secret: true));
                 envVars.Add(new EnvironmentVariable("BasicAuth__HashSecret", basicAuthEnv.HashSecret,
                     Secret: true));
@@ -361,11 +365,25 @@ public class TendrilDeployView : ViewBase
                 | geminiKey.ToPasswordInput(placeholder: "Gemini API key").WithField().Label("Gemini API key (optional)")
         ).Icon(Icons.Sparkles).Width(Size.Full());
 
+        var copilotExpandable = new Expandable(
+            "GitHub Copilot CLI",
+            Layout.Vertical().Gap(3).Width(Size.Full())
+                | Text.Muted("Copilot in the terminal authenticates with GitHub (PAT), not a separate Copilot API key.")
+                | Text.Markdown(
+                    "**Where to get:** GitHub → **Settings → Developer settings** → Personal access tokens (classic or fine-grained). The account needs an active **GitHub Copilot** subscription (or org-assigned Copilot). Grant the scopes the [Copilot CLI docs](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli) require for your setup (often overlaps with **repo** / **read:user**). Copy the token and paste it below.")
+                | Text.Markdown(
+                    "**This form sends:** **`GH_TOKEN`** when non-empty. GitHub’s CLI stack treats **`GH_TOKEN`** like **`GITHUB_TOKEN`**; use the **GitHub — gh CLI** section above for **`GITHUB_TOKEN`**, or paste the **same PAT** here if you only want Copilot-oriented tooling to see **`GH_TOKEN`**.")
+                | Text.Muted("Optional.")
+                | copilotGhToken.ToPasswordInput(placeholder: "ghp_… or fine-grained PAT").WithField()
+                    .Label("GitHub token for Copilot CLI (optional)")
+        ).Icon(Icons.Terminal).Width(Size.Full());
+
         var agentSections = Layout.Vertical().Gap(2).Width(Size.Full())
             | claudeExpandable
             | githubExpandable
             | openAiExpandable
-            | geminiExpandable;
+            | geminiExpandable
+            | copilotExpandable;
 
         var basicAuthHintCallout = new Callout(
             Text.Markdown(

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -108,6 +108,10 @@ public class TendrilDeployView : ViewBase
         /// so we freeze the validated step-0 model and deploy from this snapshot.
         /// </summary>
         var validatedDeployForm = UseState<TendrilDeployFormModel?>(() => null);
+        var repoCloneRows = UseState(() => new List<TendrilBootstrapRepoEntry>
+        {
+            new(Guid.NewGuid(), "")
+        });
         var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
         var deployError = UseState<string?>(() => null);
         var validationFailed = UseState(false);
@@ -174,6 +178,19 @@ public class TendrilDeployView : ViewBase
                 return;
             }
 
+            List<EnvironmentVariable> cloneEnvVars;
+            try
+            {
+                cloneEnvVars = TendrilCloneBootstrap.BuildCloneEnvVars(
+                    repoCloneRows.Value
+                        .Select(e => new TendrilCloneBootstrap.Row(e.CloneUrl))
+                        .ToList());
+            }
+            catch (ArgumentException ex)
+            {
+                deployError.Set(ex.Message);
+                return;
+            }
 
             var anthropic = (anthropicKey.Value ?? "").Trim();
             var claudeOAuth = (claudeOAuthToken.Value ?? "").Trim();
@@ -211,6 +228,12 @@ public class TendrilDeployView : ViewBase
                     envVars.Add(new EnvironmentVariable("GEMINI_API_KEY", gemini, Secret: true));
                 envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
                 envVars.Add(new EnvironmentVariable("TENDRIL_HOME", home, Secret: false));
+                foreach (var ev in cloneEnvVars)
+                    envVars.Add(ev);
+
+                var cmdForService = cloneEnvVars.Count > 0
+                    ? TendrilCloneBootstrap.BuildServiceCmdWrapped()
+                    : null;
 
                 List<(string VolumeId, string MountPath)>? volumes = null;
                 if (!string.IsNullOrWhiteSpace(m.VolumeId))
@@ -227,7 +250,9 @@ public class TendrilDeployView : ViewBase
                         autoDeploy: m.AutoDeploy,
                         networkPublic: m.NetworkPublic,
                         networkProtocol: m.NetworkProtocol,
-                        cmd: m.Cmd ?? string.Empty,
+                        cmd: string.IsNullOrEmpty(cmdForService)
+                            ? (m.Cmd ?? string.Empty)
+                            : cmdForService,
                         healthcheck: m.Healthcheck,
                         env: envVars,
                         volumeMounts: volumes));
@@ -301,7 +326,8 @@ public class TendrilDeployView : ViewBase
         var stepperItems = new[]
         {
             new StepperItem("1", stepIndex.Value > 0 ? Icons.Check : null, "Welcome", "Server & name"),
-            new StepperItem("2", deployedService.Value != null ? Icons.Check : null, "Secrets", "API keys"),
+            new StepperItem("2", stepIndex.Value > 1 ? Icons.Check : null, "Secrets", "API keys"),
+            new StepperItem("3", deployedService.Value != null ? Icons.Check : null, "Repositories", "Workspaces"),
         };
 
         ValueTask OnStepperSelect(Event<Stepper, int> e)
@@ -310,12 +336,39 @@ public class TendrilDeployView : ViewBase
             {
                 stepIndex.Set(e.Value);
                 if (e.Value == 0)
+                {
                     validatedDeployForm.Set(null);
+                    repoCloneRows.Set([new TendrilBootstrapRepoEntry(Guid.NewGuid(), "")]);
+                }
             }
 
             return ValueTask.CompletedTask;
         }
 
+        var reposHintCallout = new Callout(
+            Text.Markdown(
+                "**GitHub only:** each row clones with **`git clone --depth 1`** into **`$TENDRIL_HOME/repos/&lt;owner&gt;/&lt;repo&gt;`** (path parsed from your URL). "
+                    + "**Default branch** on the remote. For private repos, set **`GITHUB_TOKEN`** on the Secrets step."),
+            "Repositories",
+            CalloutVariant.Info);
+
+        object repoSections = Layout.Vertical().Gap(4).Width(Size.Full())
+            | Text.H4("Repositories")
+            | Text.Muted("Enter only HTTPS or SSH GitHub repository URLs — leave rows blank if you skip this step.")
+            | (Layout.Vertical().Gap(3).Width(Size.Full())
+                | repoCloneRows.Value.Select(e => (object)new TendrilBootstrapRepoRowView(e.Id, repoCloneRows))
+                    .ToArray())
+            | new Button("Add").Icon(Icons.Plus).Outline()
+                .OnClick(_ =>
+                {
+                    repoCloneRows.Set(xs =>
+                    {
+                        var copy = xs.ToList();
+                        copy.Add(new TendrilBootstrapRepoEntry(Guid.NewGuid(), ""));
+                        return copy;
+                    });
+                    return ValueTask.CompletedTask;
+                });
         var welcomeNoteCallout = new Callout(
             Layout.Vertical().Gap(3)
                 | Text.Block(
@@ -336,23 +389,33 @@ public class TendrilDeployView : ViewBase
             ? new Callout(validationView, "Please fix the following", CalloutVariant.Error)
             : new Empty();
 
-        var titleBlock = stepIndex.Value == 0
-            ? (object)(Layout.Vertical().Gap(2).AlignContent(Align.Center)
-                | Text.H1("Welcome to Ivy Tendril").Align(TextAlignment.Center))
-            : (object)(Layout.Vertical().Gap(2).AlignContent(Align.Center)
-                | Text.H1("API keys").Align(TextAlignment.Center));
+        object titleBlock = stepIndex.Value switch
+        {
+            0 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("Welcome to Ivy Tendril").Align(TextAlignment.Center),
+            1 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("API keys").Align(TextAlignment.Center),
+            _ => Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("Repositories").Align(TextAlignment.Center),
+        };
 
-        var stepBody = stepIndex.Value == 0
-            ? (object)(Layout.Vertical().Gap(4).Width(Size.Full())
+        object stepBody = stepIndex.Value switch
+        {
+            0 => Layout.Vertical().Gap(4).Width(Size.Full())
                 | welcomeNoteCallout
                 | formView
-                | validationBlock)
-            : (object)(Layout.Vertical().Gap(4).Width(Size.Full())
+                | validationBlock,
+            1 => Layout.Vertical().Gap(4).Width(Size.Full())
                 | secretsHintCallout
-                | agentSections);
+                | agentSections,
+            _ => Layout.Vertical().Gap(4).Width(Size.Full())
+                | reposHintCallout
+                | repoSections,
+        };
 
-        object footerRow = stepIndex.Value == 0
-            ? (object)(Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)
+        object footerRow = stepIndex.Value switch
+        {
+            0 => Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)
                 | new Button("Get started")
                     .Icon(Icons.ChevronRight, Align.Right)
                     .Primary()
@@ -361,8 +424,8 @@ public class TendrilDeployView : ViewBase
                     .Width(Size.Full())
                     .Loading(loading)
                     .Disabled(loading)
-                    .OnClick(async _ => await AdvanceFromStep0Async()))
-            : (object)(Layout.Horizontal().Width(Size.Full()).Gap(4)
+                    .OnClick(async _ => await AdvanceFromStep0Async()),
+            1 => Layout.Horizontal().Width(Size.Full()).Gap(4)
                 | new Button("Back")
                     .Icon(Icons.ChevronLeft)
                     .Variant(ButtonVariant.Outline)
@@ -373,6 +436,32 @@ public class TendrilDeployView : ViewBase
                     {
                         stepIndex.Set(0);
                         validatedDeployForm.Set(null);
+                        repoCloneRows.Set([new TendrilBootstrapRepoEntry(Guid.NewGuid(), "")]);
+                        return ValueTask.CompletedTask;
+                    })
+                | new Spacer()
+                | new Button("Continue")
+                    .Icon(Icons.ChevronRight, Align.Right)
+                    .Primary()
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .OnClick(_ =>
+                    {
+                        stepIndex.Set(2);
+                        return ValueTask.CompletedTask;
+                    }),
+            _ => Layout.Horizontal().Width(Size.Full()).Gap(4)
+                | new Button("Back")
+                    .Icon(Icons.ChevronLeft)
+                    .Variant(ButtonVariant.Outline)
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .OnClick(_ =>
+                    {
+                        stepIndex.Set(1);
+                        return ValueTask.CompletedTask;
                     })
                 | new Spacer()
                 | new Button("Deploy")
@@ -383,7 +472,8 @@ public class TendrilDeployView : ViewBase
                     .Width(Size.Fraction(0.31f))
                     .Loading(loading || isDeploying.Value)
                     .Disabled(loading || isDeploying.Value)
-                    .OnClick(async _ => await HandleDeploy()));
+                    .OnClick(async _ => await HandleDeploy()),
+        };
 
         var stepperRow = Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)
             | new Stepper(OnStepperSelect, stepIndex.Value, stepperItems).Width(Size.Full());

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -103,6 +103,11 @@ public class TendrilDeployView : ViewBase
 
         var reloadCounter = UseState(0);
         var stepIndex = UseState(0);
+        /// <summary>
+        /// Step 1 hides the main form controls; Ivy form validation relies on mounted inputs,
+        /// so we freeze the validated step-0 model and deploy from this snapshot.
+        /// </summary>
+        var validatedDeployForm = UseState<TendrilDeployFormModel?>(() => null);
         var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
         var deployError = UseState<string?>(() => null);
         var validationFailed = UseState(false);
@@ -148,9 +153,11 @@ public class TendrilDeployView : ViewBase
             if (!await onSubmit())
             {
                 validationFailed.Set(true);
+                validatedDeployForm.Set(null);
                 return;
             }
 
+            validatedDeployForm.Set(CloneFormModel(model.Value));
             stepIndex.Set(1);
         }
 
@@ -159,13 +166,14 @@ public class TendrilDeployView : ViewBase
             deployError.Set(null);
             deployedService.Set(null);
             validationFailed.Set(false);
-            if (!await onSubmit())
+            var m = validatedDeployForm.Value;
+            if (m == null)
             {
-                validationFailed.Set(true);
+                deployError.Set("Form state expired. Go Back, then continue from step 1 again.");
+                stepIndex.Set(0);
                 return;
             }
 
-            var m = model.Value;
 
             var anthropic = (anthropicKey.Value ?? "").Trim();
             var claudeOAuth = (claudeOAuthToken.Value ?? "").Trim();
@@ -299,7 +307,12 @@ public class TendrilDeployView : ViewBase
         ValueTask OnStepperSelect(Event<Stepper, int> e)
         {
             if (e.Value < stepIndex.Value)
+            {
                 stepIndex.Set(e.Value);
+                if (e.Value == 0)
+                    validatedDeployForm.Set(null);
+            }
+
             return ValueTask.CompletedTask;
         }
 
@@ -356,7 +369,11 @@ public class TendrilDeployView : ViewBase
                     .Large()
                     .BorderRadius(BorderRadius.Full)
                     .Width(Size.Fraction(0.31f))
-                    .OnClick(_ => stepIndex.Set(0))
+                    .OnClick(_ =>
+                    {
+                        stepIndex.Set(0);
+                        validatedDeployForm.Set(null);
+                    })
                 | new Spacer()
                 | new Button("Deploy")
                     .Icon(Icons.Rocket, Align.Right)
@@ -419,6 +436,25 @@ public class TendrilDeployView : ViewBase
                 | pageColumn,
             manageFloat);
     }
+
+    private static TendrilDeployFormModel CloneFormModel(TendrilDeployFormModel src) => new()
+    {
+        ServerId = src.ServerId,
+        ProjectId = src.ProjectId,
+        Name = src.Name,
+        GitRepo = src.GitRepo,
+        Branch = src.Branch,
+        DockerfilePath = src.DockerfilePath,
+        DockerContext = src.DockerContext,
+        Port = src.Port,
+        TendrilHome = src.TendrilHome,
+        VolumeId = src.VolumeId,
+        AutoDeploy = src.AutoDeploy,
+        NetworkPublic = src.NetworkPublic,
+        NetworkProtocol = src.NetworkProtocol,
+        Healthcheck = src.Healthcheck,
+        Cmd = src.Cmd,
+    };
 
     private static string? SecretPrefill(IConfiguration c, string key)
     {

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -347,16 +347,22 @@ public class TendrilDeployView : ViewBase
 
         var reposHintCallout = new Callout(
             Text.Markdown(
-                "**GitHub only:** each row clones with **`git clone --depth 1`** into **`$TENDRIL_HOME/repos/&lt;owner&gt;/&lt;repo&gt;`** (path parsed from your URL). "
-                    + "**Default branch** on the remote. For private repos, set **`GITHUB_TOKEN`** on the Secrets step."),
+                """
+                Each filled row is one repo cloned when the container starts. In Tendril project settings, **Your repository folder** must be the **path inside the container** (the folder that contains `.git`), not the clone URL.
+
+                **Example**
+
+                - `TENDRIL_HOME` is `/data/tendril`
+                - This row is `https://github.com/acme/hello-world`
+                - After startup the repo is at `/data/tendril/repos/acme/hello-world`
+                - So in **Your repository folder** enter: `/data/tendril/repos/acme/hello-world`
+                """.ReplaceLineEndings("\n")),
             "Repositories",
             CalloutVariant.Info);
 
         object repoSections = Layout.Vertical().Gap(4).Width(Size.Full())
             | Text.H4("Repositories")
-            | Text.Muted(
-                "One GitHub clone URL per row (HTTPS or SSH). Leave a row empty if you do not need that clone. "
-                    + "Use Add for more repositories.")
+            | Text.Block("One URL per row. Leave empty to skip. Add adds another row.")
             | (Layout.Vertical().Gap(2).Width(Size.Full())
                 | repoCloneRows.Value.Select(e => (object)new TendrilBootstrapRepoRowView(e.Id, repoCloneRows))
                     .ToArray())

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -48,6 +48,18 @@ public class TendrilDeployFormModel
     public string? Cmd { get; set; }
 }
 
+public class TendrilBasicAuthFormModel
+{
+    [Display(Name = "Username", Prompt = "e.g. operator")]
+    [Required(ErrorMessage = "Username is required")]
+    public string Username { get; set; } = "";
+
+    [Display(Name = "Password")]
+    [Required(ErrorMessage = "Password is required")]
+    [MinLength(8, ErrorMessage = "Password must be at least 8 characters")]
+    public string Password { get; set; } = "";
+}
+
 public class TendrilDeployView : ViewBase
 {
     private readonly string _apiToken;
@@ -101,6 +113,10 @@ public class TendrilDeployView : ViewBase
         var openAiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:OpenAiApiKey"));
         var geminiKey = UseState<string?>(() => SecretPrefill(config, "TendrilDeploy:GeminiApiKey"));
 
+        var basicAuthModel = UseState(() => new TendrilBasicAuthFormModel());
+        var basicAuthValidationFailed = UseState(false);
+        var basicAuthStepError = UseState<string?>(() => null);
+
         var reloadCounter = UseState(0);
         var stepIndex = UseState(0);
         /// <summary>
@@ -127,6 +143,12 @@ public class TendrilDeployView : ViewBase
                 m => m.AutoDeploy, m => m.NetworkPublic, m => m.NetworkProtocol,
                 m => m.Healthcheck, m => m.Cmd)
             .Required(m => m.ProjectId, m => m.Name, m => m.ServerId, m => m.GitRepo));
+
+        var (onBasicAuthSubmit, basicAuthFormView, basicAuthValidationView, _) = UseForm(() => basicAuthModel
+            .ToForm("Basic auth")
+            .Builder(m => m.Password,
+                s => s.ToPasswordInput(placeholder: $"At least {TendrilBasicAuthBootstrap.MinPasswordLength} characters"))
+            .Required(m => m.Username, m => m.Password));
 
         QueryResult<Option<string>[]> QueryServers(IViewContext ctx, string q) =>
             ctx.UseQuery<Option<string>[], (string, string, int)>(
@@ -168,6 +190,7 @@ public class TendrilDeployView : ViewBase
         async ValueTask HandleDeploy()
         {
             deployError.Set(null);
+            basicAuthStepError.Set(null);
             deployedService.Set(null);
             validationFailed.Set(false);
             var m = validatedDeployForm.Value;
@@ -198,6 +221,21 @@ public class TendrilDeployView : ViewBase
             var openAi = (openAiKey.Value ?? "").Trim();
             var gemini = (geminiKey.Value ?? "").Trim();
 
+            (string Users, string HashSecret, string JwtSecret) basicAuthEnv;
+            try
+            {
+                basicAuthEnv = TendrilBasicAuthBootstrap.BuildSecrets(
+                    basicAuthModel.Value.Username ?? "", basicAuthModel.Value.Password ?? "");
+            }
+            catch (ArgumentException ex)
+            {
+                deployError.Set(ex.Message);
+                basicAuthStepError.Set(ex.Message);
+                basicAuthValidationFailed.Set(true);
+                stepIndex.Set(3);
+                return;
+            }
+
             isDeploying.Set(true);
             try
             {
@@ -226,6 +264,12 @@ public class TendrilDeployView : ViewBase
                     envVars.Add(new EnvironmentVariable("OPENAI_API_KEY", openAi, Secret: true));
                 if (gemini.Length > 0)
                     envVars.Add(new EnvironmentVariable("GEMINI_API_KEY", gemini, Secret: true));
+                envVars.Add(new EnvironmentVariable("BasicAuth__Users", basicAuthEnv.Users, Secret: true));
+                envVars.Add(new EnvironmentVariable("BasicAuth__HashSecret", basicAuthEnv.HashSecret,
+                    Secret: true));
+                envVars.Add(new EnvironmentVariable("BasicAuth__JwtSecret", basicAuthEnv.JwtSecret,
+                    Secret: true));
+
                 envVars.Add(new EnvironmentVariable("PORT", port, Secret: false));
                 envVars.Add(new EnvironmentVariable("TENDRIL_HOME", home, Secret: false));
                 foreach (var ev in cloneEnvVars)
@@ -323,11 +367,33 @@ public class TendrilDeployView : ViewBase
             | openAiExpandable
             | geminiExpandable;
 
+        var basicAuthHintCallout = new Callout(
+            Text.Markdown(
+                """
+                These secrets are added to the **Sliplane service you create** (the repo you deploy), **not** this deploy wizard.
+                We set `BasicAuth__Users`, `BasicAuth__HashSecret`, and `BasicAuth__JwtSecret` on that service.
+
+                For login on the deployed app, its `Program.cs` must call `server.UseAuth<BasicAuthProvider>()`.
+                """.ReplaceLineEndings("\n")),
+            "Basic authentication",
+            CalloutVariant.Info);
+
+        object basicAuthSections = Layout.Vertical().Gap(3).Width(Size.Full())
+            | basicAuthHintCallout
+            | basicAuthFormView
+            | (basicAuthValidationFailed.Value
+                ? new Callout(basicAuthValidationView, "Please fill required auth fields", CalloutVariant.Error)
+                : new Empty())
+            | (basicAuthStepError.Value != null
+                ? new Callout(basicAuthStepError.Value, variant: CalloutVariant.Error)
+                : new Empty());
+
         var stepperItems = new[]
         {
             new StepperItem("1", stepIndex.Value > 0 ? Icons.Check : null, "Welcome", "Server & name"),
             new StepperItem("2", stepIndex.Value > 1 ? Icons.Check : null, "Secrets", "API keys"),
-            new StepperItem("3", deployedService.Value != null ? Icons.Check : null, "Repositories", "Workspaces"),
+            new StepperItem("3", stepIndex.Value > 2 ? Icons.Check : null, "Repositories", "Workspaces"),
+            new StepperItem("4", deployedService.Value != null ? Icons.Check : null, "Login", "Basic auth"),
         };
 
         ValueTask OnStepperSelect(Event<Stepper, int> e)
@@ -403,8 +469,10 @@ public class TendrilDeployView : ViewBase
                 | Text.H1("Welcome to Ivy Tendril").Align(TextAlignment.Center),
             1 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
                 | Text.H1("API keys").Align(TextAlignment.Center),
-            _ => Layout.Vertical().Gap(2).AlignContent(Align.Center)
+            2 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
                 | Text.H1("Repositories").Align(TextAlignment.Center),
+            _ => Layout.Vertical().Gap(2).AlignContent(Align.Center)
+                | Text.H1("Protect your deployment").Align(TextAlignment.Center),
         };
 
         object stepBody = stepIndex.Value switch
@@ -416,9 +484,11 @@ public class TendrilDeployView : ViewBase
             1 => Layout.Vertical().Gap(4).Width(Size.Full())
                 | secretsHintCallout
                 | agentSections,
-            _ => Layout.Vertical().Gap(4).Width(Size.Full())
+            2 => Layout.Vertical().Gap(4).Width(Size.Full())
                 | reposHintCallout
                 | repoSections,
+            _ => Layout.Vertical().Gap(4).Width(Size.Full())
+                | basicAuthSections,
         };
 
         object footerRow = stepIndex.Value switch
@@ -456,10 +526,11 @@ public class TendrilDeployView : ViewBase
                     .Width(Size.Fraction(0.31f))
                     .OnClick(_ =>
                     {
+                        basicAuthStepError.Set(null);
                         stepIndex.Set(2);
                         return ValueTask.CompletedTask;
                     }),
-            _ => Layout.Horizontal().Width(Size.Full()).Gap(4)
+            2 => Layout.Horizontal().Width(Size.Full()).Gap(4)
                 | new Button("Back")
                     .Icon(Icons.ChevronLeft)
                     .Variant(ButtonVariant.Outline)
@@ -472,6 +543,31 @@ public class TendrilDeployView : ViewBase
                         return ValueTask.CompletedTask;
                     })
                 | new Spacer()
+                | new Button("Continue")
+                    .Icon(Icons.ChevronRight, Align.Right)
+                    .Primary()
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .OnClick(async _ =>
+                    {
+                        basicAuthValidationFailed.Set(false);
+                        stepIndex.Set(3);
+                        await Task.CompletedTask;
+                    }),
+            _ => Layout.Horizontal().Width(Size.Full()).Gap(4)
+                | new Button("Back")
+                    .Icon(Icons.ChevronLeft)
+                    .Variant(ButtonVariant.Outline)
+                    .Large()
+                    .BorderRadius(BorderRadius.Full)
+                    .Width(Size.Fraction(0.31f))
+                    .OnClick(_ =>
+                    {
+                        stepIndex.Set(2);
+                        return ValueTask.CompletedTask;
+                    })
+                | new Spacer()
                 | new Button("Deploy")
                     .Icon(Icons.Rocket, Align.Right)
                     .Primary()
@@ -480,7 +576,18 @@ public class TendrilDeployView : ViewBase
                     .Width(Size.Fraction(0.31f))
                     .Loading(loading || isDeploying.Value)
                     .Disabled(loading || isDeploying.Value)
-                    .OnClick(async _ => await HandleDeploy()),
+                    .OnClick(async _ =>
+                    {
+                        basicAuthStepError.Set(null);
+                        basicAuthValidationFailed.Set(false);
+                        if (!await onBasicAuthSubmit())
+                        {
+                            basicAuthValidationFailed.Set(true);
+                            return;
+                        }
+
+                        await HandleDeploy();
+                    }),
         };
 
         var stepperRow = Layout.Vertical().Width(Size.Full()).AlignContent(Align.Center)

--- a/project-demos/tendril-deploy/Services/TendrilBasicAuthBootstrap.cs
+++ b/project-demos/tendril-deploy/Services/TendrilBasicAuthBootstrap.cs
@@ -1,0 +1,47 @@
+namespace TendrilDeploy.Services;
+
+using System.Security.Cryptography;
+using System.Text;
+using Isopoh.Cryptography.Argon2;
+
+/// <summary>
+/// Builds Ivy BasicAuth env values for deployment: Argon2id hashes with pepper (Ivy <c>BasicAuthProvider</c> verifies with
+/// <see cref="Argon2.Verify"/> using UTF-8 password bytes and <see cref="Argon2Config.Secret"/>).
+/// </summary>
+public static class TendrilBasicAuthBootstrap
+{
+    public const int MinPasswordLength = 8;
+
+    /// <summary>Returns env-ready values for BasicAuth:Users, BasicAuth:HashSecret, BasicAuth:JwtSecret.</summary>
+    public static (string UsersValue, string HashSecretBase64, string JwtSecretBase64) BuildSecrets(string username, string password)
+    {
+        var u = (username ?? "").Trim();
+        var p = password ?? "";
+        if (u.Length == 0)
+            throw new ArgumentException("Username is required.");
+        if (u.IndexOfAny([';', ':']) >= 0)
+            throw new ArgumentException("Username cannot contain ':' or ';'.");
+        if (p.Length < MinPasswordLength)
+            throw new ArgumentException($"Password must be at least {MinPasswordLength} characters.");
+
+        Span<byte> hashKey = stackalloc byte[32];
+        Span<byte> jwtKey = stackalloc byte[32];
+        RandomNumberGenerator.Fill(hashKey);
+        RandomNumberGenerator.Fill(jwtKey);
+        var hashSecretB64 = Convert.ToBase64String(hashKey);
+        var jwtSecretB64 = Convert.ToBase64String(jwtKey);
+
+        var hashSecretBytes = Convert.FromBase64String(hashSecretB64);
+        var pwdHash = Argon2.Hash(
+            Encoding.UTF8.GetBytes(p),
+            hashSecretBytes,
+            timeCost: 3,
+            memoryCost: 65536,
+            parallelism: 1,
+            type: Argon2Type.HybridAddressing,
+            hashLength: 32);
+
+        var usersValue = $"{u}:{pwdHash}";
+        return (usersValue, hashSecretB64, jwtSecretB64);
+    }
+}

--- a/project-demos/tendril-deploy/Services/TendrilCloneBootstrap.cs
+++ b/project-demos/tendril-deploy/Services/TendrilCloneBootstrap.cs
@@ -1,0 +1,277 @@
+namespace TendrilDeploy.Services;
+
+using System.Globalization;
+using System.Linq;
+
+/// <summary>
+/// Maps URLs to indexed env vars and a POSIX <c>sh</c> prelude that shallow-clones into <c>TENDRIL_HOME</c> before <c>tendril --web</c>.
+/// Target folder is derived as <c>repos/&lt;owner&gt;/&lt;repository&gt;</c> under <c>TENDRIL_HOME</c> (remote default branch, <c>git clone --depth 1</c>).
+/// </summary>
+public static class TendrilCloneBootstrap
+{
+    public const string CountEnvKey = "TENDRIL_CLONE_COUNT";
+
+    public static string RepoUrlEnv(int index) =>
+        $"TENDRIL_CLONE_{index.ToString(CultureInfo.InvariantCulture)}_URL";
+
+    public static string RepoPathEnv(int index) =>
+        $"TENDRIL_CLONE_{index.ToString(CultureInfo.InvariantCulture)}_PATH";
+
+    /// <summary>Only the GitHub remote URL comes from UI; workspace path under <c>TENDRIL_HOME</c> is derived.</summary>
+    public sealed record Row(string CloneUrl);
+
+    public static IEnumerable<Row> RowsWithCloneIntent(IEnumerable<Row> rows) =>
+        rows.Where(r => !string.IsNullOrWhiteSpace(r.CloneUrl));
+
+    public static List<Models.EnvironmentVariable> BuildCloneEnvVars(IReadOnlyCollection<Row> rows)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var resolved = new List<(string Url, string RelPath)>();
+
+        foreach (var r in RowsWithCloneIntent(rows))
+        {
+            var u = r.CloneUrl.Trim();
+            if (!seen.Add(u))
+                continue;
+
+            EnsureGitHubRemoteUrl(u);
+            if (!TryDeriveReposRelativePath(u, out var relPath, out var err))
+                throw new ArgumentException(err ?? "Could not derive a workspace folder from the GitHub URL.");
+            resolved.Add((u, relPath));
+        }
+
+        if (resolved.Count == 0)
+            return [];
+
+        var list = new List<Models.EnvironmentVariable>
+        {
+            new(CountEnvKey, resolved.Count.ToString(CultureInfo.InvariantCulture), Secret: false)
+        };
+
+        for (var i = 0; i < resolved.Count; i++)
+        {
+            list.Add(new Models.EnvironmentVariable(RepoUrlEnv(i), resolved[i].Url, Secret: false));
+            list.Add(new Models.EnvironmentVariable(RepoPathEnv(i), resolved[i].RelPath, Secret: false));
+        }
+
+        return list;
+    }
+
+    /// <inheritdoc cref="IsGitHubRepoRemote" />
+    public static bool TryDeriveReposRelativePath(string trimmedGitHubUrl, out string relativePath,
+        out string? error)
+    {
+        relativePath = "";
+        error = null;
+        var t = (trimmedGitHubUrl ?? "").Trim();
+        if (t.Length == 0)
+        {
+            error = "GitHub URL is empty.";
+            return false;
+        }
+
+        if (!TryParseOwnerRepo(t, out var owner, out var repo))
+        {
+            error = "Could not read owner/name from URL — use https://github.com/org/repository.";
+            return false;
+        }
+
+        if (!SafePathSegment(owner) || !SafePathSegment(repo))
+        {
+            error = "Derived owner or repository name contains invalid path characters.";
+            return false;
+        }
+
+        relativePath = $"repos/{owner}/{repo}";
+        return true;
+    }
+
+    private static bool SafePathSegment(string s) =>
+        s.Length > 0 && !s.Contains('/', StringComparison.Ordinal) && !s.Contains("..", StringComparison.Ordinal);
+
+    private static bool TryParseOwnerRepo(string t, out string owner, out string repo)
+    {
+        owner = "";
+        repo = "";
+
+        if (t.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+        {
+            var tail = t["git@github.com:".Length..].TrimStart('/');
+            var slash = tail.IndexOf('/');
+            if (slash < 1 || slash >= tail.Length - 1)
+                return false;
+            owner = tail[..slash];
+            repo = TrimGitSuffix(tail[(slash + 1)..]);
+            return owner.Length > 0 && repo.Length > 0;
+        }
+
+        if (t.StartsWith("ssh://git@github.com/", StringComparison.OrdinalIgnoreCase))
+        {
+            var tail = t["ssh://git@github.com/".Length..].TrimStart('/');
+            var parts = tail.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length < 2)
+                return false;
+            owner = parts[0];
+            repo = TrimGitSuffix(parts[1]);
+            return true;
+        }
+
+        if (!Uri.TryCreate(t, UriKind.Absolute, out var uri))
+            return false;
+
+        if (!uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
+            && !uri.Host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var pathParts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (pathParts.Length < 2)
+            return false;
+
+        owner = pathParts[0];
+        repo = TrimGitSuffix(pathParts[1]);
+
+        foreach (var p in pathParts)
+        {
+            if (string.Equals(p, "..", StringComparison.Ordinal))
+                return false;
+        }
+
+        return owner.Length > 0 && repo.Length > 0;
+    }
+
+    private static string TrimGitSuffix(string name)
+    {
+        var n = name.Trim();
+        return n.EndsWith(".git", StringComparison.OrdinalIgnoreCase) ? n[..^".git".Length] : n;
+    }
+
+    public static bool IsGitHubRepoRemote(string url, out string? reason)
+    {
+        reason = null;
+        var t = (url ?? "").Trim();
+        if (t.Length == 0)
+        {
+            reason = "URL is empty.";
+            return false;
+        }
+
+        if (t.StartsWith("git@github.com:", StringComparison.OrdinalIgnoreCase))
+        {
+            var tail = t.Substring("git@github.com:".Length).TrimStart('/');
+            if (tail.Replace(".git", "", StringComparison.OrdinalIgnoreCase).Split('/').Length < 2)
+            {
+                reason =
+                    "SSH URL must look like git@github.com:org/repository or git@github.com:org/repository.git.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (t.StartsWith("ssh://git@github.com/", StringComparison.OrdinalIgnoreCase))
+        {
+            var pathPart = t.Substring("ssh://git@github.com/".Length).TrimStart('/');
+            var seg = pathPart.Replace(".git", "", StringComparison.OrdinalIgnoreCase)
+                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (seg.Length < 2)
+            {
+                reason = "SSH URL must include owner and repo, e.g. ssh://git@github.com/org/repository.git.";
+                return false;
+            }
+
+            return true;
+        }
+
+        if (!Uri.TryCreate(t, UriKind.Absolute, out var uri))
+        {
+            reason = "Enter a GitHub URL (https://github.com/org/repo) or SSH (git@github.com:org/repo.git).";
+            return false;
+        }
+
+        var hostOk = uri.Host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Host.Equals("www.github.com", StringComparison.OrdinalIgnoreCase);
+        if (!hostOk || (uri.Scheme != Uri.UriSchemeHttps && uri.Scheme != Uri.UriSchemeHttp))
+        {
+            reason =
+                "Only GitHub clones are supported. Use https://github.com/org/repository or git@github.com:org/repository.git.";
+            return false;
+        }
+
+        var parts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            reason = "GitHub URL must include organization (or user) and repository, e.g. https://github.com/org/repo.";
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static void EnsureGitHubRemoteUrl(string trimmedUrl)
+    {
+        if (!IsGitHubRepoRemote(trimmedUrl, out var reason))
+            throw new ArgumentException(reason ?? "Not a GitHub repository URL.");
+    }
+
+    /// <summary>POSIX sh prelude: clones then <c>exec tendril --web</c>.</summary>
+    public static readonly string ShellStartupPrelude = BuildShellStartupPrelude();
+
+    private static string BuildShellStartupPrelude() =>
+        """
+set -eu
+HOME="${HOMEDIR:-/root}"
+home="${TENDRIL_HOME:-/data/tendril}"
+home="${home%/}"
+
+COUNT_RAW="${TENDRIL_CLONE_COUNT:-0}"
+case "${COUNT_RAW}" in ''|'-'*|*[!0-9]*) COUNT=0 ;; *) COUNT="${COUNT_RAW}" ;; esac
+
+i=0
+while [ "${i}" -lt "${COUNT}" ]; do
+  unk="TENDRIL_CLONE_${i}_URL"
+  pnk="TENDRIL_CLONE_${i}_PATH"
+  eval "clone_url=\$$unk"
+  eval "rel_path=\$$pnk"
+
+  if [ -z "${clone_url}" ] || [ -z "${rel_path}" ]; then
+    echo "tendril-bootstrap: clone index ${i}: missing URL or PATH env" >&2
+    exit 1
+  fi
+  case "${rel_path}" in *..*)
+    echo "tendril-bootstrap: path must not contain '..': '${rel_path}'" >&2
+    exit 1 ;;
+  esac
+
+  dest="${home}/${rel_path}"
+  dest="${dest#//}"
+  case "${dest}" in
+    "${home}"|"${home}"/*) ;;
+    *)
+      echo "tendril-bootstrap: path escapes TENDRIL_HOME: '${rel_path}'" >&2
+      exit 1 ;;
+  esac
+
+  if [ -d "${dest}/.git" ]; then
+    i=$((i + 1))
+    continue
+  fi
+
+  mkdir -p "$(dirname "${dest}")"
+  git clone --depth 1 "${clone_url}" "${dest}"
+  i=$((i + 1))
+done
+exec tendril --web
+""".Replace("\r\n", "\n");
+
+    public static string BuildServiceCmdWrapped() =>
+        "sh -lc " + QuoteForSingleQuotedShell(ShellStartupPrelude);
+
+    public static string QuoteForSingleQuotedShell(string s)
+    {
+        if (string.IsNullOrEmpty(s))
+            return "''";
+
+        var nl = s.Replace("\r\n", "\n").Replace('\r', '\n');
+        return "'" + nl.Replace("'", "'\"'\"'") + "'";
+    }
+}

--- a/project-demos/tendril-deploy/Services/TendrilCloneBootstrap.cs
+++ b/project-demos/tendril-deploy/Services/TendrilCloneBootstrap.cs
@@ -219,7 +219,7 @@ public static class TendrilCloneBootstrap
     private static string BuildShellStartupPrelude() =>
         """
 set -eu
-HOME="${HOMEDIR:-/root}"
+HOME="${HOMEDIR:-$(getent passwd "$(id -u)" | cut -d: -f6)}"
 home="${TENDRIL_HOME:-/data/tendril}"
 home="${home%/}"
 

--- a/project-demos/tendril-deploy/TendrilDeploy.csproj
+++ b/project-demos/tendril-deploy/TendrilDeploy.csproj
@@ -9,6 +9,7 @@
     <UserSecretsId>tendril-deploy-sliplane-001</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Isopoh.Cryptography.Argon2" Version="2.0.0" />
     <PackageReference Include="Ivy" Version="1.2.44" />
     <PackageReference Include="Ivy.Analyser" Version="1.2.44">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Extends the Tendril deploy demo with a **step-based wizard** for Sliplane: service defaults, optional agent API secrets, GitHub workspace clones under `TENDRIL_HOME`, required **Basic Auth** env for the deployed service, and optional **GitHub Copilot CLI** token via `GH_TOKEN`.

## What changed

- **Wizard flow:** welcome → secrets (expandable sections per CLI) → repository clone rows → Basic Auth form → deploy + status.
- **Clone bootstrap:** `TendrilCloneBootstrap` maps GitHub URLs to `TENDRIL_CLONE_*` env vars and a `sh` prelude that shallow-clones into `repos/<owner>/<repo>` before `exec tendril --web`. `HOME` is resolved dynamically for POSIX `sh` (`HOMEDIR` / `getent`).
- **Basic Auth:** `TendrilBasicAuthBootstrap` builds `BasicAuth__Users`, `BasicAuth__HashSecret`, and `BasicAuth__JwtSecret` (Argon2id) for the **deployed** Ivy app; wizard UI documents that the target repo must call `server.UseAuth<BasicAuthProvider>()`.
- **Copilot:** optional PAT field → Sliplane secret **`GH_TOKEN`** (alongside existing **`GITHUB_TOKEN`** for gh CLI), with expandable help text.
- **UI:** `TendrilBootstrapRepoRowView` for per-row clone URLs; copy updates for “Your repository folder” vs container paths.

## Notes for reviewers

- Empty clone rows are skipped; duplicate URLs are deduplicated.
- Basic Auth is **required** in the wizard (no skip).

https://github.com/user-attachments/assets/3f209fee-5319-4220-8c6d-778a002cb32d

