### PR TITLE
[tendril-deploy]: add deploy button SVG asset for Tendril deployment

### DIFF
--- a/project-demos/tendril-deploy/Assets/deploy-button.svg
+++ b/project-demos/tendril-deploy/Assets/deploy-button.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="44" viewBox="0 0 320 44">
+  <rect width="320" height="44" rx="8" fill="#00CC92"/>
+
+  <!-- Group: icon (20px) + gap (12px) + text (~220px) -->
+  <g transform="translate(34, 12)">
+    <!-- Rocket icon 20x20 -->
+    <g transform="scale(0.833)" stroke="white" stroke-width="1.7"
+       stroke-linecap="round" stroke-linejoin="round" fill="none">
+      <path d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+      <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+      <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+    </g>
+
+    <!-- Text starts after icon (20px) + gap (12px) -->
+    <text
+      x="32" y="15"
+      font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      font-size="15"
+      font-weight="600"
+      fill="white"
+      letter-spacing="0.2"
+    >Host your Tendril on Sliplane</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
Add Sliplane deploy button SVG for the **tendril-deploy** demo.

## Changes
- New asset: `project-demos/tendril-deploy/Assets/deploy-button.svg`
- Label: **Host your Tendril on Sliplane** (same style as `sliplane-manage` button)

<img width="372" height="83" alt="Знімок екрана 2026-05-05 о 22 19 38" src="https://github.com/user-attachments/assets/283ff08c-ee54-4067-8fd4-6d6a04f775d2" />
