### PR TITLE
[cli]: add unified Ivy CLI (ivy-examples)

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+nupkg/
+*.user
+.vs/

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,12 +1,12 @@
 # Ivy CLI
 
-Unified command-line tool for Ivy Interactive infrastructure. Manage Sliplane servers, services, projects, and deploy Tendril instances — all from one `ivy` command.
+Unified command-line tool for Ivy Interactive infrastructure. Manage Sliplane servers, services, projects, and deploy Tendril instances — all from one `ivy-examples` command.
 
 ## Installation
 
 ```bash
 # From source (in cli/src/)
-dotnet tool install -g --add-source ./nupkg Ivy.Cli
+dotnet tool install -g --add-source ./nupkg Ivy.Cli   # global command: ivy-examples
 
 # Or run directly without installing
 dotnet run -- <command> [options]
@@ -32,47 +32,47 @@ export SLIPLANE_API_KEY=your-sliplane-token    # also needed for status/servers/
 
 ## Commands
 
-Commands are grouped by project: `ivy sliplane …` for Sliplane resources and `ivy tendril …` for Tendril deployments. CLI-wide settings live under `ivy config …`.
+Commands are grouped by project: `ivy-examples sliplane …` for Sliplane resources and `ivy-examples tendril …` for Tendril deployments. CLI-wide settings live under `ivy-examples config …`.
 
 ### Sliplane
 
 ```bash
-ivy sliplane me                                          # current identity
+ivy-examples sliplane me                                          # current identity
 
-ivy sliplane projects list
-ivy sliplane projects create --name my-project
-ivy sliplane projects delete --project-id abc123
+ivy-examples sliplane projects list
+ivy-examples sliplane projects create --name my-project
+ivy-examples sliplane projects delete --project-id abc123
 
-ivy sliplane servers list
-ivy sliplane servers get --server-id srv_123
-ivy sliplane servers create --name my-server --instance-type base --location fsn
-ivy sliplane servers metrics --server-id srv_123 --range 1h
+ivy-examples sliplane servers list
+ivy-examples sliplane servers get --server-id srv_123
+ivy-examples sliplane servers create --name my-server --instance-type base --location fsn
+ivy-examples sliplane servers metrics --server-id srv_123 --range 1h
 
-ivy sliplane services list                               # across all projects
-ivy sliplane services list --project-id proj_123
-ivy sliplane services get --project-id proj_123 --service-id svc_456
-ivy sliplane services create --project-id proj_123 --name my-app --server-id srv_123 --repo https://github.com/org/repo --public
-ivy sliplane services deploy --project-id proj_123 --service-id svc_456
-ivy sliplane services logs --project-id proj_123 --service-id svc_456
-ivy sliplane services pause --project-id proj_123 --service-id svc_456
-ivy sliplane services delete --project-id proj_123 --service-id svc_456
+ivy-examples sliplane services list                               # across all projects
+ivy-examples sliplane services list --project-id proj_123
+ivy-examples sliplane services get --project-id proj_123 --service-id svc_456
+ivy-examples sliplane services create --project-id proj_123 --name my-app --server-id srv_123 --repo https://github.com/org/repo --public
+ivy-examples sliplane services deploy --project-id proj_123 --service-id svc_456
+ivy-examples sliplane services logs --project-id proj_123 --service-id svc_456
+ivy-examples sliplane services pause --project-id proj_123 --service-id svc_456
+ivy-examples sliplane services delete --project-id proj_123 --service-id svc_456
 
-ivy sliplane credentials list
-ivy sliplane credentials create --name ghcr-creds --type ghcr --username myuser --token ghp_xxx
+ivy-examples sliplane credentials list
+ivy-examples sliplane credentials create --name ghcr-creds --type ghcr --username myuser --token ghp_xxx
 
-ivy sliplane oauth list
-ivy sliplane oauth get --client-id oauth_123
+ivy-examples sliplane oauth list
+ivy-examples sliplane oauth get --client-id oauth_123
 ```
 
 ### Tendril
 
 ```bash
 # List available Sliplane targets
-ivy tendril servers
-ivy tendril projects
+ivy-examples tendril servers
+ivy-examples tendril projects
 
 # Deploy a new Tendril instance
-ivy tendril deploy \
+ivy-examples tendril deploy \
   --project-id proj_123 \
   --server-id srv_456 \
   --name tendril-artem \
@@ -83,7 +83,7 @@ ivy tendril deploy \
   --repo https://github.com/Ivy-Interactive/Ivy-Examples
 
 # Check deployment status
-ivy tendril status \
+ivy-examples tendril status \
   --project-id proj_123 \
   --service-id svc_789
 ```
@@ -128,6 +128,6 @@ dotnet run -- --help
 ```bash
 cd cli/src
 dotnet pack -c Release -o ../nupkg
-dotnet tool install -g --add-source ../nupkg Ivy.Cli
-ivy --help
+dotnet tool install -g --add-source ../nupkg Ivy.Cli   # global command: ivy-examples
+ivy-examples --help
 ```

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,114 @@
+# Ivy CLI
+
+Unified command-line tool for Ivy Interactive infrastructure. Manage Sliplane servers, services, projects, and deploy Tendril instances — all from one `ivy` command.
+
+## Installation
+
+```bash
+# From source (in cli/src/)
+dotnet tool install -g --add-source ./nupkg Ivy.Cli
+
+# Or run directly without installing
+dotnet run -- <command> [options]
+```
+
+## Authentication
+
+### Sliplane commands
+
+```bash
+export SLIPLANE_API_KEY=your-sliplane-api-token
+# Optional for legacy tokens:
+export SLIPLANE_ORG_ID=your-org-id
+```
+
+### Tendril commands
+
+```bash
+export TENDRIL_BASE_URL=https://your-tendril-deploy.sliplane.app
+export TENDRIL_API_KEY=your-internal-api-key   # optional if server has no key set
+export SLIPLANE_API_KEY=your-sliplane-token    # also needed for status/servers/projects
+```
+
+## Commands
+
+### Sliplane
+
+```bash
+ivy me                                          # current identity
+
+ivy projects list
+ivy projects create --name my-project
+ivy projects delete --project-id abc123
+
+ivy servers list
+ivy servers get --server-id srv_123
+ivy servers create --name my-server --instance-type base --location fsn
+ivy servers metrics --server-id srv_123 --range 1h
+
+ivy services list                               # across all projects
+ivy services list --project-id proj_123
+ivy services get --project-id proj_123 --service-id svc_456
+ivy services create --project-id proj_123 --name my-app --server-id srv_123 --repo https://github.com/org/repo --public
+ivy services deploy --project-id proj_123 --service-id svc_456
+ivy services logs --project-id proj_123 --service-id svc_456
+ivy services pause --project-id proj_123 --service-id svc_456
+ivy services delete --project-id proj_123 --service-id svc_456
+
+ivy credentials list
+ivy credentials create --name ghcr-creds --type ghcr --username myuser --token ghp_xxx
+
+ivy oauth list
+ivy oauth get --client-id oauth_123
+```
+
+### Tendrils
+
+```bash
+# List available Sliplane targets
+ivy tendrils servers
+ivy tendrils projects
+
+# Deploy a new Tendril instance
+ivy tendrils deploy \
+  --project-id proj_123 \
+  --server-id srv_456 \
+  --name tendril-artem \
+  --username artem \
+  --password supersecret \
+  --anthropic-key sk-ant-xxx \
+  --github-token ghp_xxx \
+  --repo https://github.com/Ivy-Interactive/Ivy-Examples
+
+# Check deployment status
+ivy tendrils status \
+  --project-id proj_123 \
+  --service-id svc_789
+```
+
+## Output
+
+All commands output YAML — easy to read and pipe into other tools.
+
+## Adding new commands
+
+1. Create a new folder under `src/Commands/YourThing/`
+2. Add a class inheriting `AsyncCommand<Settings>` (copy any existing command as template)
+3. Register it in `Program.cs` with `config.AddBranch("yourthing", ...)` or `config.AddCommand<>()`
+
+## Building
+
+```bash
+cd cli/src
+dotnet build
+dotnet run -- --help
+```
+
+## Packaging as dotnet tool
+
+```bash
+cd cli/src
+dotnet pack -c Release -o ../nupkg
+dotnet tool install -g --add-source ../nupkg Ivy.Cli
+ivy --help
+```

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,45 +32,47 @@ export SLIPLANE_API_KEY=your-sliplane-token    # also needed for status/servers/
 
 ## Commands
 
+Commands are grouped by project: `ivy sliplane …` for Sliplane resources and `ivy tendril …` for Tendril deployments. CLI-wide settings live under `ivy config …`.
+
 ### Sliplane
 
 ```bash
-ivy me                                          # current identity
+ivy sliplane me                                          # current identity
 
-ivy projects list
-ivy projects create --name my-project
-ivy projects delete --project-id abc123
+ivy sliplane projects list
+ivy sliplane projects create --name my-project
+ivy sliplane projects delete --project-id abc123
 
-ivy servers list
-ivy servers get --server-id srv_123
-ivy servers create --name my-server --instance-type base --location fsn
-ivy servers metrics --server-id srv_123 --range 1h
+ivy sliplane servers list
+ivy sliplane servers get --server-id srv_123
+ivy sliplane servers create --name my-server --instance-type base --location fsn
+ivy sliplane servers metrics --server-id srv_123 --range 1h
 
-ivy services list                               # across all projects
-ivy services list --project-id proj_123
-ivy services get --project-id proj_123 --service-id svc_456
-ivy services create --project-id proj_123 --name my-app --server-id srv_123 --repo https://github.com/org/repo --public
-ivy services deploy --project-id proj_123 --service-id svc_456
-ivy services logs --project-id proj_123 --service-id svc_456
-ivy services pause --project-id proj_123 --service-id svc_456
-ivy services delete --project-id proj_123 --service-id svc_456
+ivy sliplane services list                               # across all projects
+ivy sliplane services list --project-id proj_123
+ivy sliplane services get --project-id proj_123 --service-id svc_456
+ivy sliplane services create --project-id proj_123 --name my-app --server-id srv_123 --repo https://github.com/org/repo --public
+ivy sliplane services deploy --project-id proj_123 --service-id svc_456
+ivy sliplane services logs --project-id proj_123 --service-id svc_456
+ivy sliplane services pause --project-id proj_123 --service-id svc_456
+ivy sliplane services delete --project-id proj_123 --service-id svc_456
 
-ivy credentials list
-ivy credentials create --name ghcr-creds --type ghcr --username myuser --token ghp_xxx
+ivy sliplane credentials list
+ivy sliplane credentials create --name ghcr-creds --type ghcr --username myuser --token ghp_xxx
 
-ivy oauth list
-ivy oauth get --client-id oauth_123
+ivy sliplane oauth list
+ivy sliplane oauth get --client-id oauth_123
 ```
 
-### Tendrils
+### Tendril
 
 ```bash
 # List available Sliplane targets
-ivy tendrils servers
-ivy tendrils projects
+ivy tendril servers
+ivy tendril projects
 
 # Deploy a new Tendril instance
-ivy tendrils deploy \
+ivy tendril deploy \
   --project-id proj_123 \
   --server-id srv_456 \
   --name tendril-artem \
@@ -81,7 +83,7 @@ ivy tendrils deploy \
   --repo https://github.com/Ivy-Interactive/Ivy-Examples
 
 # Check deployment status
-ivy tendrils status \
+ivy tendril status \
   --project-id proj_123 \
   --service-id svc_789
 ```
@@ -94,7 +96,24 @@ All commands output YAML — easy to read and pipe into other tools.
 
 1. Create a new folder under `src/Commands/YourThing/`
 2. Add a class inheriting `AsyncCommand<Settings>` (copy any existing command as template)
-3. Register it in `Program.cs` with `config.AddBranch("yourthing", ...)` or `config.AddCommand<>()`
+3. Register it in `Program.cs` under the appropriate top-level branch (`sliplane`, `tendril`, …) with `branch.AddBranch("yourthing", ...)` or `branch.AddCommand<>()`. Add a new top-level branch only when introducing a new project namespace.
+
+### Description style
+
+Keep `WithDescription(...)` strings short, imperative, and consistent. Don't put usage examples there — those belong in this README.
+
+| Verb              | Description pattern         | Example                       |
+| ----------------- | --------------------------- | ----------------------------- |
+| top-level branch  | `<Action> <project> <scope>`| `Manage Sliplane resources`   |
+| sub-branch        | `Manage <resource-plural>`  | `Manage servers`              |
+| `list`            | `List <resource-plural>`    | `List servers`                |
+| `get`             | `Get <resource>`            | `Get server`                  |
+| `create`          | `Create <resource>`         | `Create server`               |
+| `update`          | `Update <resource>`         | `Update server`               |
+| `delete`          | `Delete <resource>`         | `Delete server`               |
+| anything else     | `<Verb> <resource>`         | `Pause service`, `Rescale server` |
+
+Inside a sub-branch, omit the parent name (the path already shows it): write `List servers`, not `List Sliplane servers`.
 
 ## Building
 

--- a/cli/src/Commands/Config/ConfigClearCommand.cs
+++ b/cli/src/Commands/Config/ConfigClearCommand.cs
@@ -1,0 +1,24 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Config;
+
+/// <summary>ivy config clear — delete the entire ~/.ivy/config.json after confirmation.</summary>
+public sealed class ConfigClearCommand : Command<ConfigClearCommand.Settings>
+{
+    public sealed class Settings : CommandSettings { }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (!AnsiConsole.Confirm("[red]Delete all saved config[/] in [dim]~/.ivy/config.json[/]?", defaultValue: false))
+        {
+            AnsiConsole.MarkupLine("[dim]Cancelled.[/]");
+            return 0;
+        }
+
+        ConfigStore.Clear();
+        AnsiConsole.MarkupLine("[green]Config cleared.[/] All saved keys have been removed.");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Config/ConfigClearCommand.cs
+++ b/cli/src/Commands/Config/ConfigClearCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Config;
 
-/// <summary>ivy config clear — delete the entire ~/.ivy/config.json after confirmation.</summary>
+/// <summary>ivy-examples config clear — delete the entire ~/.ivy/config.json after confirmation.</summary>
 public sealed class ConfigClearCommand : Command<ConfigClearCommand.Settings>
 {
     public sealed class Settings : CommandSettings { }

--- a/cli/src/Commands/Config/ConfigGetCommand.cs
+++ b/cli/src/Commands/Config/ConfigGetCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Config;
 
-/// <summary>ivy config get sliplane_api_key — print a stored config value.</summary>
+/// <summary>ivy-examples config get sliplane_api_key — print a stored config value.</summary>
 public sealed class ConfigGetCommand : Command<ConfigGetCommand.Settings>
 {
     public sealed class Settings : CommandSettings

--- a/cli/src/Commands/Config/ConfigGetCommand.cs
+++ b/cli/src/Commands/Config/ConfigGetCommand.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Config;
+
+/// <summary>ivy config get sliplane_api_key — print a stored config value.</summary>
+public sealed class ConfigGetCommand : Command<ConfigGetCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        [Description("Config key to read (e.g. sliplane_api_key, tendril_base_url)")]
+        public required string Key { get; init; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var value = ConfigStore.Get(settings.Key);
+        if (value is null)
+            AnsiConsole.MarkupLine($"[yellow]{settings.Key}[/] is not set in [dim]~/.ivy/config.json[/].");
+        else
+            AnsiConsole.WriteLine(value);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Config/ConfigListCommand.cs
+++ b/cli/src/Commands/Config/ConfigListCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Config;
 
-/// <summary>ivy config list — show all stored config keys (values masked for secrets).</summary>
+/// <summary>ivy-examples config list — show all stored config keys (values masked for secrets).</summary>
 public sealed class ConfigListCommand : Command<ConfigListCommand.Settings>
 {
     public sealed class Settings : CommandSettings { }
@@ -44,7 +44,7 @@ public sealed class ConfigListCommand : Command<ConfigListCommand.Settings>
         if (!anySet)
         {
             AnsiConsole.MarkupLine("[dim]No values saved yet in ~/.ivy/config.json[/]");
-            AnsiConsole.MarkupLine("Run any command and answer [green]y[/] when asked to save, or use [dim]ivy config set <key> <value>[/].");
+            AnsiConsole.MarkupLine($"Run any command and answer [green]y[/] when asked to save, or use [dim]{CliBrand.ToolCommandName} config set <key> <value>[/].");
             return 0;
         }
 

--- a/cli/src/Commands/Config/ConfigListCommand.cs
+++ b/cli/src/Commands/Config/ConfigListCommand.cs
@@ -1,0 +1,55 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Config;
+
+/// <summary>ivy config list — show all stored config keys (values masked for secrets).</summary>
+public sealed class ConfigListCommand : Command<ConfigListCommand.Settings>
+{
+    public sealed class Settings : CommandSettings { }
+    private static readonly HashSet<string> SecretKeys =
+    [
+        "sliplane_api_key",
+        "tendril_api_key"
+    ];
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        var table = new Table()
+            .Border(TableBorder.Rounded)
+            .AddColumn("Key")
+            .AddColumn("Value");
+
+        var keys = new[]
+        {
+            "sliplane_api_key",
+            "sliplane_org_id",
+            "tendril_base_url",
+            "tendril_api_key"
+        };
+
+        bool anySet = false;
+        foreach (var key in keys)
+        {
+            var raw = ConfigStore.Get(key);
+            if (raw is null) continue;
+            anySet = true;
+            var display = SecretKeys.Contains(key)
+                ? "[dim]" + raw[..Math.Min(8, raw.Length)] + "..." + "[/]"
+                : raw;
+            table.AddRow($"[yellow]{key}[/]", display);
+        }
+
+        if (!anySet)
+        {
+            AnsiConsole.MarkupLine("[dim]No values saved yet in ~/.ivy/config.json[/]");
+            AnsiConsole.MarkupLine("Run any command and answer [green]y[/] when asked to save, or use [dim]ivy config set <key> <value>[/].");
+            return 0;
+        }
+
+        AnsiConsole.MarkupLine("[dim]~/.ivy/config.json[/]");
+        AnsiConsole.Write(table);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Config/ConfigSetCommand.cs
+++ b/cli/src/Commands/Config/ConfigSetCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Config;
+
+/// <summary>ivy config set sliplane_api_key sk-xxx — store a value in ~/.ivy/config.json.</summary>
+public sealed class ConfigSetCommand : Command<ConfigSetCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        [Description("Config key to set (e.g. sliplane_api_key, tendril_base_url, tendril_api_key)")]
+        public required string Key { get; init; }
+
+        [CommandArgument(1, "<VALUE>")]
+        [Description("Value to store")]
+        public required string Value { get; init; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        ConfigStore.Set(settings.Key, settings.Value);
+        AnsiConsole.MarkupLine($"[green]Saved[/] [dim]{settings.Key}[/] to [dim]~/.ivy/config.json[/].");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Config/ConfigSetCommand.cs
+++ b/cli/src/Commands/Config/ConfigSetCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Config;
 
-/// <summary>ivy config set sliplane_api_key sk-xxx — store a value in ~/.ivy/config.json.</summary>
+/// <summary>ivy-examples config set sliplane_api_key sk-xxx — store a value in ~/.ivy/config.json.</summary>
 public sealed class ConfigSetCommand : Command<ConfigSetCommand.Settings>
 {
     public sealed class Settings : CommandSettings

--- a/cli/src/Commands/Config/ConfigUnsetCommand.cs
+++ b/cli/src/Commands/Config/ConfigUnsetCommand.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Config;
+
+/// <summary>ivy config unset sliplane_api_key — remove a single key from ~/.ivy/config.json.</summary>
+public sealed class ConfigUnsetCommand : Command<ConfigUnsetCommand.Settings>
+{
+    public sealed class Settings : CommandSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        [Description("Config key to remove (e.g. sliplane_api_key)")]
+        public required string Key { get; init; }
+    }
+
+    public override int Execute(CommandContext context, Settings settings)
+    {
+        if (ConfigStore.Remove(settings.Key))
+            AnsiConsole.MarkupLine($"[green]Removed[/] [dim]{settings.Key}[/] from [dim]~/.ivy/config.json[/].");
+        else
+            AnsiConsole.MarkupLine($"[yellow]{settings.Key}[/] was not set — nothing to remove.");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Config/ConfigUnsetCommand.cs
+++ b/cli/src/Commands/Config/ConfigUnsetCommand.cs
@@ -5,7 +5,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Config;
 
-/// <summary>ivy config unset sliplane_api_key — remove a single key from ~/.ivy/config.json.</summary>
+/// <summary>ivy-examples config unset sliplane_api_key — remove a single key from ~/.ivy/config.json.</summary>
 public sealed class ConfigUnsetCommand : Command<ConfigUnsetCommand.Settings>
 {
     public sealed class Settings : CommandSettings

--- a/cli/src/Commands/NuGet/NuGetDownloadsCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetDownloadsCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetDownloadsCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("downloads");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/NuGet/NuGetDownloadsHistoryCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetDownloadsHistoryCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetDownloadsHistoryCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("downloads/history");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/NuGet/NuGetStarredCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetStarredCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetStarredCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("starred");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/NuGet/NuGetStarsCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetStarsCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetStarsCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("stars");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/NuGet/NuGetSummaryCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetSummaryCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetSummaryCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("summary");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/NuGet/NuGetUnstarredCommand.cs
+++ b/cli/src/Commands/NuGet/NuGetUnstarredCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.NuGet;
+
+public sealed class NuGetUnstarredCommand : AsyncCommand<NuGetStatsSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, NuGetStatsSettings settings)
+    {
+        var client = settings.CreateNuGetStatsClient();
+        var doc = await client.GetAsync("unstarred");
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Credentials/CreateCredentialsCommand.cs
+++ b/cli/src/Commands/Sliplane/Credentials/CreateCredentialsCommand.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Credentials;
+
+public sealed class CreateCredentialsCommand : AsyncCommand<CreateCredentialsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--name <NAME>")]
+        [Description("A name to identify these credentials")]
+        public required string Name { get; init; }
+
+        [CommandOption("--type <TYPE>")]
+        [Description("Registry type: ghcr, dockerhub, dhi, generic")]
+        public required string Type { get; init; }
+
+        [CommandOption("--username <USERNAME>")]
+        [Description("Registry username")]
+        public required string Username { get; init; }
+
+        [CommandOption("--token <TOKEN>")]
+        [Description("Registry authentication token")]
+        public required string Token { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PostAsync("registry-credentials", new
+        {
+            name     = settings.Name,
+            type     = settings.Type,
+            username = settings.Username,
+            token    = settings.Token
+        });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Credentials/DeleteCredentialsCommand.cs
+++ b/cli/src/Commands/Sliplane/Credentials/DeleteCredentialsCommand.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Credentials;
+
+public sealed class DeleteCredentialsCommand : AsyncCommand<DeleteCredentialsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--credential-id <ID>")]
+        [Description("The ID of the registry credentials to delete")]
+        public required string CredentialId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.DeleteAsync($"registry-credentials/{settings.CredentialId}");
+        AnsiConsole.MarkupLine("[green]Credentials deleted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Credentials/GetCredentialsCommand.cs
+++ b/cli/src/Commands/Sliplane/Credentials/GetCredentialsCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Credentials;
+
+public sealed class GetCredentialsCommand : AsyncCommand<GetCredentialsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--credential-id <ID>")]
+        [Description("The ID of the registry credentials")]
+        public required string CredentialId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"registry-credentials/{settings.CredentialId}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Credentials/ListCredentialsCommand.cs
+++ b/cli/src/Commands/Sliplane/Credentials/ListCredentialsCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Credentials;
+
+public sealed class ListCredentialsCommand : AsyncCommand<ApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ApiSettings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync("registry-credentials");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Credentials/UpdateCredentialsCommand.cs
+++ b/cli/src/Commands/Sliplane/Credentials/UpdateCredentialsCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Credentials;
+
+public sealed class UpdateCredentialsCommand : AsyncCommand<UpdateCredentialsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--credential-id <ID>")]
+        [Description("The ID of the registry credentials to update")]
+        public required string CredentialId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("The new name for the credentials")]
+        public required string Name { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PatchAsync(
+            $"registry-credentials/{settings.CredentialId}", new { name = settings.Name });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/MeCommand.cs
+++ b/cli/src/Commands/Sliplane/MeCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane;
+
+public sealed class MeCommand : AsyncCommand<ApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ApiSettings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync("me");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/OAuth/GetOAuthClientCommand.cs
+++ b/cli/src/Commands/Sliplane/OAuth/GetOAuthClientCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.OAuth;
+
+public sealed class GetOAuthClientCommand : AsyncCommand<GetOAuthClientCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--client-id <ID>")]
+        [Description("The OAuth client ID")]
+        public required string ClientId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"oauth-clients/{settings.ClientId}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/OAuth/ListOAuthClientUsersCommand.cs
+++ b/cli/src/Commands/Sliplane/OAuth/ListOAuthClientUsersCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.OAuth;
+
+public sealed class ListOAuthClientUsersCommand : AsyncCommand<ListOAuthClientUsersCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--client-id <ID>")]
+        [Description("The OAuth client ID")]
+        public required string ClientId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"oauth-clients/{settings.ClientId}/users");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/OAuth/ListOAuthClientsCommand.cs
+++ b/cli/src/Commands/Sliplane/OAuth/ListOAuthClientsCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.OAuth;
+
+public sealed class ListOAuthClientsCommand : AsyncCommand<ApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ApiSettings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync("oauth-clients");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/OAuth/UpdateOAuthClientCommand.cs
+++ b/cli/src/Commands/Sliplane/OAuth/UpdateOAuthClientCommand.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.OAuth;
+
+public sealed class UpdateOAuthClientCommand : AsyncCommand<UpdateOAuthClientCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--client-id <ID>")]
+        [Description("The OAuth client ID to update")]
+        public required string ClientId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("Updated display name")]
+        public string? Name { get; init; }
+
+        [CommandOption("--image-url <URL>")]
+        [Description("Updated image URL (empty string to clear)")]
+        public string? ImageUrl { get; init; }
+
+        [CommandOption("--redirect-uri <URI>")]
+        [Description("Redirect URI (repeatable, replaces all)")]
+        public string[]? RedirectUris { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var body = new Dictionary<string, object>();
+        if (!string.IsNullOrEmpty(settings.Name))     body["name"]         = settings.Name;
+        if (settings.ImageUrl is not null)             body["imageUrl"]     = settings.ImageUrl;
+        if (settings.RedirectUris is not null)         body["redirectUris"] = settings.RedirectUris;
+        var result = await client.PatchAsync($"oauth-clients/{settings.ClientId}", body);
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Projects/CreateProjectCommand.cs
+++ b/cli/src/Commands/Sliplane/Projects/CreateProjectCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Projects;
+
+public sealed class CreateProjectCommand : AsyncCommand<CreateProjectCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--name <NAME>")]
+        [Description("The name of the project")]
+        public required string Name { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PostAsync("projects", new { name = settings.Name });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Projects/DeleteProjectCommand.cs
+++ b/cli/src/Commands/Sliplane/Projects/DeleteProjectCommand.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Projects;
+
+public sealed class DeleteProjectCommand : AsyncCommand<DeleteProjectCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project to delete")]
+        public required string ProjectId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.DeleteAsync($"projects/{settings.ProjectId}");
+        AnsiConsole.MarkupLine("[green]Project deleted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Projects/ListProjectsCommand.cs
+++ b/cli/src/Commands/Sliplane/Projects/ListProjectsCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Projects;
+
+public sealed class ListProjectsCommand : AsyncCommand<ApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ApiSettings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync("projects");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Projects/UpdateProjectCommand.cs
+++ b/cli/src/Commands/Sliplane/Projects/UpdateProjectCommand.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Projects;
+
+public sealed class UpdateProjectCommand : AsyncCommand<UpdateProjectCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project to update")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("The new name of the project")]
+        public required string Name { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PatchAsync($"projects/{settings.ProjectId}", new { name = settings.Name });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/CreateServerCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/CreateServerCommand.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class CreateServerCommand : AsyncCommand<CreateServerCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--name <NAME>")]
+        [Description("The name of the server")]
+        public required string Name { get; init; }
+
+        [CommandOption("--instance-type <TYPE>")]
+        [Description("Instance type: base, medium, large, x-large, xx-large, dedicated-base, ...")]
+        public required string InstanceType { get; init; }
+
+        [CommandOption("--location <LOCATION>")]
+        [Description("Location: sin, fsn, nbg, ash, hel, hil")]
+        public required string Location { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PostAsync("servers", new
+        {
+            name = settings.Name,
+            instanceType = settings.InstanceType,
+            location = settings.Location
+        });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/CreateServerVolumeCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/CreateServerVolumeCommand.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class CreateServerVolumeCommand : AsyncCommand<CreateServerVolumeCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server")]
+        public required string ServerId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("The name of the volume")]
+        public required string Name { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PostAsync($"servers/{settings.ServerId}/volumes", new { name = settings.Name });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/DeleteServerCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/DeleteServerCommand.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class DeleteServerCommand : AsyncCommand<DeleteServerCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server to delete")]
+        public required string ServerId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.DeleteAsync($"servers/{settings.ServerId}");
+        AnsiConsole.MarkupLine("[green]Server deleted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/GetServerCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/GetServerCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class GetServerCommand : AsyncCommand<GetServerCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server")]
+        public required string ServerId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"servers/{settings.ServerId}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/ListServerVolumesCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/ListServerVolumesCommand.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class ListServerVolumesCommand : AsyncCommand<ListServerVolumesCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server")]
+        public required string ServerId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"servers/{settings.ServerId}/volumes");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/ListServersCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/ListServersCommand.cs
@@ -1,0 +1,15 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class ListServersCommand : AsyncCommand<ApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, ApiSettings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync("servers");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/RescaleServerCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/RescaleServerCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class RescaleServerCommand : AsyncCommand<RescaleServerCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server to rescale")]
+        public required string ServerId { get; init; }
+
+        [CommandOption("--instance-type <TYPE>")]
+        [Description("New instance type (can only scale up)")]
+        public required string InstanceType { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.PostAsync($"servers/{settings.ServerId}", new { instanceType = settings.InstanceType });
+        AnsiConsole.MarkupLine("[green]Rescale request accepted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Servers/ServerMetricsCommand.cs
+++ b/cli/src/Commands/Sliplane/Servers/ServerMetricsCommand.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Servers;
+
+public sealed class ServerMetricsCommand : AsyncCommand<ServerMetricsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server")]
+        public required string ServerId { get; init; }
+
+        [CommandOption("--range <RANGE>")]
+        [Description("Predefined time range: 10min, 1h, 24h, 7d (default: 1h)")]
+        [DefaultValue("1h")]
+        public string? Range { get; init; }
+
+        [CommandOption("--from <TIMESTAMP>")]
+        [Description("From timestamp (Unix seconds)")]
+        public long? From { get; init; }
+
+        [CommandOption("--to <TIMESTAMP>")]
+        [Description("To timestamp (Unix seconds)")]
+        public long? To { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(settings.Range)) parts.Add($"range={settings.Range}");
+        if (settings.From.HasValue) parts.Add($"from={settings.From}");
+        if (settings.To.HasValue) parts.Add($"to={settings.To}");
+        var query = parts.Count > 0 ? "?" + string.Join("&", parts) : "";
+        var result = await client.GetAsync($"servers/{settings.ServerId}/metrics{query}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/AddDomainCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/AddDomainCommand.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class AddDomainCommand : AsyncCommand<AddDomainCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--domain <DOMAIN>")]
+        [Description("The custom domain to add")]
+        public required string Domain { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.PostAsync(
+            $"projects/{settings.ProjectId}/services/{settings.ServiceId}/domains",
+            new { domain = settings.Domain });
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/CreateServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/CreateServiceCommand.cs
@@ -1,0 +1,160 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class CreateServiceCommand : AsyncCommand<CreateServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("The name of the service")]
+        public required string Name { get; init; }
+
+        [CommandOption("--server-id <ID>")]
+        [Description("The ID of the server to run the service on")]
+        public required string ServerId { get; init; }
+
+        [CommandOption("--image <URL>")]
+        [Description("Container image URL (e.g. docker.io/library/nginx:latest)")]
+        public string? Image { get; init; }
+
+        [CommandOption("--repo <URL>")]
+        [Description("Repository URL (e.g. https://github.com/user/repo)")]
+        public string? Repo { get; init; }
+
+        [CommandOption("--branch <BRANCH>")]
+        [Description("Branch to deploy from (default: main)")]
+        public string? Branch { get; init; }
+
+        [CommandOption("--dockerfile <PATH>")]
+        [Description("Path to Dockerfile")]
+        public string? DockerfilePath { get; init; }
+
+        [CommandOption("--docker-context <PATH>")]
+        [Description("Docker build context (default: .)")]
+        public string? DockerContext { get; init; }
+
+        [CommandOption("--auto-deploy")]
+        [Description("Auto-deploy on push")]
+        public bool? AutoDeploy { get; init; }
+
+        [CommandOption("--deploy-include-paths <PATTERN>")]
+        [Description("Only deploy if changes in these paths (repeatable)")]
+        public string[]? DeployIncludePaths { get; init; }
+
+        [CommandOption("--deploy-ignore-paths <PATTERN>")]
+        [Description("Skip deploy if changes only in these paths (repeatable)")]
+        public string[]? DeployIgnorePaths { get; init; }
+
+        [CommandOption("--registry-credential-id <ID>")]
+        [Description("Registry credential ID for private images")]
+        public string? RegistryCredentialId { get; init; }
+
+        [CommandOption("--public")]
+        [Description("Make the service publicly accessible")]
+        public bool Public { get; init; }
+
+        [CommandOption("--protocol <PROTOCOL>")]
+        [Description("Network protocol: http, tcp, udp")]
+        public string? Protocol { get; init; }
+
+        [CommandOption("--healthcheck <PATH>")]
+        [Description("Health check path (default: /)")]
+        public string? Healthcheck { get; init; }
+
+        [CommandOption("--cmd <CMD>")]
+        [Description("Override Docker CMD")]
+        public string? Cmd { get; init; }
+
+        [CommandOption("--env <KEY=VALUE>")]
+        [Description("Environment variable (repeatable)")]
+        public string[]? Env { get; init; }
+
+        [CommandOption("--secret-env <KEY=VALUE>")]
+        [Description("Secret environment variable (repeatable)")]
+        public string[]? SecretEnv { get; init; }
+
+        [CommandOption("--volume <VOLUME>")]
+        [Description("Volume mount as id:/path or name:/path (repeatable)")]
+        public string[]? Volumes { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var body = BuildBody(settings);
+        var result = await client.PostAsync($"projects/{settings.ProjectId}/services", body);
+        YamlOutput.Write(result);
+        return 0;
+    }
+
+    private static Dictionary<string, object> BuildBody(Settings s)
+    {
+        var body = new Dictionary<string, object>
+        {
+            ["name"]     = s.Name,
+            ["serverId"] = s.ServerId
+        };
+
+        if (!string.IsNullOrEmpty(s.Image))
+        {
+            var dep = new Dictionary<string, object> { ["url"] = s.Image };
+            if (!string.IsNullOrEmpty(s.RegistryCredentialId))
+                dep["registryAuthenticationId"] = s.RegistryCredentialId;
+            body["deployment"] = dep;
+        }
+        else if (!string.IsNullOrEmpty(s.Repo))
+        {
+            var dep = new Dictionary<string, object> { ["url"] = s.Repo };
+            if (!string.IsNullOrEmpty(s.Branch))       dep["branch"]          = s.Branch;
+            if (!string.IsNullOrEmpty(s.DockerfilePath)) dep["dockerfilePath"] = s.DockerfilePath;
+            if (!string.IsNullOrEmpty(s.DockerContext))  dep["dockerContext"]  = s.DockerContext;
+            if (s.AutoDeploy.HasValue)                   dep["autoDeploy"]     = s.AutoDeploy.Value;
+            if (s.DeployIncludePaths is not null)         dep["includePaths"]   = s.DeployIncludePaths;
+            if (s.DeployIgnorePaths is not null)          dep["ignorePaths"]    = s.DeployIgnorePaths;
+            body["deployment"] = dep;
+        }
+
+        var network = new Dictionary<string, object> { ["public"] = s.Public };
+        if (!string.IsNullOrEmpty(s.Protocol)) network["protocol"] = s.Protocol;
+        body["network"] = network;
+
+        if (!string.IsNullOrEmpty(s.Healthcheck)) body["healthcheck"] = s.Healthcheck;
+        if (!string.IsNullOrEmpty(s.Cmd))          body["cmd"]        = s.Cmd;
+
+        var envVars = new List<Dictionary<string, object>>();
+        foreach (var e in s.Env ?? [])
+        {
+            var parts = e.Split('=', 2);
+            envVars.Add(new() { ["key"] = parts[0], ["value"] = parts.Length > 1 ? parts[1] : "", ["secret"] = false });
+        }
+        foreach (var e in s.SecretEnv ?? [])
+        {
+            var parts = e.Split('=', 2);
+            envVars.Add(new() { ["key"] = parts[0], ["value"] = parts.Length > 1 ? parts[1] : "", ["secret"] = true });
+        }
+        if (envVars.Count > 0) body["env"] = envVars;
+
+        if (s.Volumes is not null)
+        {
+            var vols = new List<Dictionary<string, object>>();
+            foreach (var v in s.Volumes)
+            {
+                var parts = v.Split(':', 2);
+                var vol = new Dictionary<string, object> { ["mountPath"] = parts[1] };
+                if (parts[0].StartsWith("volume_")) vol["id"]   = parts[0];
+                else                                 vol["name"] = parts[0];
+                vols.Add(vol);
+            }
+            body["volumes"] = vols;
+        }
+
+        return body;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/DeleteServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/DeleteServiceCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class DeleteServiceCommand : AsyncCommand<DeleteServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service to delete")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.DeleteAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}");
+        AnsiConsole.MarkupLine("[green]Service deleted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/DeployServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/DeployServiceCommand.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class DeployServiceCommand : AsyncCommand<DeployServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service to deploy")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--tag <TAG>")]
+        [Description("Image tag to deploy (for image-based services)")]
+        public string? Tag { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var body = !string.IsNullOrEmpty(settings.Tag)
+            ? (object)new { tag = settings.Tag }
+            : new { };
+        await client.PostAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}/deploy", body);
+        AnsiConsole.MarkupLine("[green]Deployment request accepted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/GetServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/GetServiceCommand.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class GetServiceCommand : AsyncCommand<GetServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/ListServicesCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/ListServicesCommand.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class ListServicesCommand : AsyncCommand<ListServicesCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project (lists across all projects if omitted)")]
+        public string? ProjectId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+
+        if (settings.ProjectId is not null)
+        {
+            var result = await client.GetAsync($"projects/{settings.ProjectId}/services");
+            YamlOutput.Write(result);
+            return 0;
+        }
+
+        var projects = await client.GetAsync("projects");
+        var allServices = new List<object?>();
+        foreach (var project in projects.RootElement.EnumerateArray())
+        {
+            var pid = project.GetProperty("id").GetString();
+            var services = await client.GetAsync($"projects/{pid}/services");
+            foreach (var svc in services.RootElement.EnumerateArray())
+                allServices.Add(JsonToObject(svc));
+        }
+        YamlOutput.WriteObject(allServices);
+        return 0;
+    }
+
+    private static object? JsonToObject(JsonElement e) => e.ValueKind switch
+    {
+        JsonValueKind.Object => e.EnumerateObject().ToDictionary(p => p.Name, p => JsonToObject(p.Value)),
+        JsonValueKind.Array  => e.EnumerateArray().Select(JsonToObject).ToList(),
+        JsonValueKind.String => e.GetString(),
+        JsonValueKind.Number => e.TryGetInt64(out var l) ? l : e.GetDouble(),
+        JsonValueKind.True   => (object)true,
+        JsonValueKind.False  => false,
+        _                    => null
+    };
+}

--- a/cli/src/Commands/Sliplane/Services/PauseServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/PauseServiceCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class PauseServiceCommand : AsyncCommand<PauseServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service to pause")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.PostAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}/pause");
+        AnsiConsole.MarkupLine("[green]Pause request accepted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/RemoveDomainCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/RemoveDomainCommand.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class RemoveDomainCommand : AsyncCommand<RemoveDomainCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--domain-id <ID>")]
+        [Description("The ID of the custom domain to remove")]
+        public required string DomainId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.DeleteAsync(
+            $"projects/{settings.ProjectId}/services/{settings.ServiceId}/domains/{settings.DomainId}");
+        AnsiConsole.MarkupLine("[green]Domain removed.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/ServiceEventsCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/ServiceEventsCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class ServiceEventsCommand : AsyncCommand<ServiceEventsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var result = await client.GetAsync(
+            $"projects/{settings.ProjectId}/services/{settings.ServiceId}/events");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/ServiceLogsCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/ServiceLogsCommand.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class ServiceLogsCommand : AsyncCommand<ServiceLogsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--from <TIMESTAMP>")]
+        [Description("From timestamp (Unix seconds)")]
+        public long? From { get; init; }
+
+        [CommandOption("--to <TIMESTAMP>")]
+        [Description("To timestamp (Unix seconds)")]
+        public long? To { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var parts = new List<string>();
+        if (settings.From.HasValue) parts.Add($"from={settings.From}");
+        if (settings.To.HasValue)   parts.Add($"to={settings.To}");
+        var query = parts.Count > 0 ? "?" + string.Join("&", parts) : "";
+        var result = await client.GetAsync(
+            $"projects/{settings.ProjectId}/services/{settings.ServiceId}/logs{query}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/ServiceMetricsCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/ServiceMetricsCommand.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class ServiceMetricsCommand : AsyncCommand<ServiceMetricsCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--range <RANGE>")]
+        [Description("Time range: 10min, 1h, 24h, 7d (default: 1h)")]
+        [DefaultValue("1h")]
+        public string? Range { get; init; }
+
+        [CommandOption("--from <TIMESTAMP>")]
+        [Description("From timestamp (Unix seconds)")]
+        public long? From { get; init; }
+
+        [CommandOption("--to <TIMESTAMP>")]
+        [Description("To timestamp (Unix seconds)")]
+        public long? To { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var parts = new List<string>();
+        if (!string.IsNullOrEmpty(settings.Range)) parts.Add($"range={settings.Range}");
+        if (settings.From.HasValue) parts.Add($"from={settings.From}");
+        if (settings.To.HasValue)   parts.Add($"to={settings.To}");
+        var query = parts.Count > 0 ? "?" + string.Join("&", parts) : "";
+        var result = await client.GetAsync(
+            $"projects/{settings.ProjectId}/services/{settings.ServiceId}/metrics{query}");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/UnpauseServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/UnpauseServiceCommand.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class UnpauseServiceCommand : AsyncCommand<UnpauseServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service to unpause")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        await client.PostAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}/unpause");
+        AnsiConsole.MarkupLine("[green]Unpause request accepted.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Sliplane/Services/UpdateServiceCommand.cs
+++ b/cli/src/Commands/Sliplane/Services/UpdateServiceCommand.cs
@@ -1,0 +1,134 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Sliplane.Services;
+
+public sealed class UpdateServiceCommand : AsyncCommand<UpdateServiceCommand.Settings>
+{
+    public sealed class Settings : ApiSettings
+    {
+        [CommandOption("--project-id <ID>")]
+        [Description("The ID of the project")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("The ID of the service")]
+        public required string ServiceId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("New name for the service")]
+        public string? Name { get; init; }
+
+        [CommandOption("--image <URL>")]
+        [Description("New container image URL")]
+        public string? Image { get; init; }
+
+        [CommandOption("--repo <URL>")]
+        [Description("New repository URL")]
+        public string? Repo { get; init; }
+
+        [CommandOption("--branch <BRANCH>")]
+        [Description("Branch to deploy from")]
+        public string? Branch { get; init; }
+
+        [CommandOption("--dockerfile <PATH>")]
+        [Description("Path to Dockerfile")]
+        public string? DockerfilePath { get; init; }
+
+        [CommandOption("--docker-context <PATH>")]
+        [Description("Docker build context")]
+        public string? DockerContext { get; init; }
+
+        [CommandOption("--auto-deploy")]
+        [Description("Auto-deploy on push")]
+        public bool? AutoDeploy { get; init; }
+
+        [CommandOption("--deploy-include-paths <PATTERN>")]
+        [Description("Only deploy if changes in these paths (repeatable, replaces all)")]
+        public string[]? DeployIncludePaths { get; init; }
+
+        [CommandOption("--deploy-ignore-paths <PATTERN>")]
+        [Description("Skip deploy if changes only in these paths (repeatable, replaces all)")]
+        public string[]? DeployIgnorePaths { get; init; }
+
+        [CommandOption("--registry-credential-id <ID>")]
+        [Description("Registry credential ID")]
+        public string? RegistryCredentialId { get; init; }
+
+        [CommandOption("--healthcheck <PATH>")]
+        [Description("Health check path")]
+        public string? Healthcheck { get; init; }
+
+        [CommandOption("--cmd <CMD>")]
+        [Description("Override Docker CMD")]
+        public string? Cmd { get; init; }
+
+        [CommandOption("--env <KEY=VALUE>")]
+        [Description("Environment variable (repeatable, replaces all)")]
+        public string[]? Env { get; init; }
+
+        [CommandOption("--secret-env <KEY=VALUE>")]
+        [Description("Secret environment variable (repeatable)")]
+        public string[]? SecretEnv { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateClient();
+        var body = await BuildBodyAsync(client, settings);
+        var result = await client.PatchAsync($"projects/{settings.ProjectId}/services/{settings.ServiceId}", body);
+        YamlOutput.Write(result);
+        return 0;
+    }
+
+    private static async Task<Dictionary<string, object>> BuildBodyAsync(SliplaneClient client, Settings s)
+    {
+        var body = new Dictionary<string, object>();
+        if (!string.IsNullOrEmpty(s.Name))        body["name"]        = s.Name;
+        if (!string.IsNullOrEmpty(s.Healthcheck)) body["healthcheck"] = s.Healthcheck;
+        if (!string.IsNullOrEmpty(s.Cmd))         body["cmd"]         = s.Cmd;
+
+        var dep = new Dictionary<string, object>();
+        bool needsUrl = s.AutoDeploy.HasValue || s.DeployIncludePaths is not null || s.DeployIgnorePaths is not null;
+
+        if (!string.IsNullOrEmpty(s.Image))
+        {
+            dep["url"] = s.Image;
+            if (!string.IsNullOrEmpty(s.RegistryCredentialId)) dep["registryAuthenticationId"] = s.RegistryCredentialId;
+        }
+        else if (!string.IsNullOrEmpty(s.Repo))
+        {
+            dep["url"] = s.Repo;
+            if (!string.IsNullOrEmpty(s.Branch))        dep["branch"]         = s.Branch;
+            if (!string.IsNullOrEmpty(s.DockerfilePath)) dep["dockerfilePath"] = s.DockerfilePath;
+            if (!string.IsNullOrEmpty(s.DockerContext))  dep["dockerContext"]  = s.DockerContext;
+        }
+        else if (needsUrl)
+        {
+            var current = await client.GetAsync($"projects/{s.ProjectId}/services/{s.ServiceId}");
+            dep["url"] = current.RootElement.GetProperty("deployment").GetProperty("url").GetString()!;
+        }
+
+        if (s.AutoDeploy.HasValue)           dep["autoDeploy"]  = s.AutoDeploy.Value;
+        if (s.DeployIncludePaths is not null) dep["includePaths"] = s.DeployIncludePaths;
+        if (s.DeployIgnorePaths is not null)  dep["ignorePaths"]  = s.DeployIgnorePaths;
+
+        if (dep.Count > 0) body["deployment"] = dep;
+
+        var envVars = new List<Dictionary<string, object>>();
+        foreach (var e in s.Env ?? [])
+        {
+            var parts = e.Split('=', 2);
+            envVars.Add(new() { ["key"] = parts[0], ["value"] = parts.Length > 1 ? parts[1] : "", ["secret"] = false });
+        }
+        foreach (var e in s.SecretEnv ?? [])
+        {
+            var parts = e.Split('=', 2);
+            envVars.Add(new() { ["key"] = parts[0], ["value"] = parts.Length > 1 ? parts[1] : "", ["secret"] = true });
+        }
+        if (envVars.Count > 0) body["env"] = envVars;
+
+        return body;
+    }
+}

--- a/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
+++ b/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
@@ -1,0 +1,123 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Tendrils;
+
+/// <summary>
+/// ivy tendrils deploy — create and deploy a new Tendril instance on Sliplane.
+/// Calls POST /api/v1/tendrils on the tendril-deploy service.
+/// </summary>
+public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Settings>
+{
+    public sealed class Settings : TendrilApiSettings
+    {
+        // ── Required Sliplane targeting ────────────────────────────────────
+
+        [CommandOption("--sliplane-token <TOKEN>")]
+        [Description("Your Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        public string? SliplaneToken { get; init; }
+
+        [CommandOption("--project-id <ID>")]
+        [Description("Sliplane project ID where the Tendril service will be created")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--server-id <ID>")]
+        [Description("Sliplane server ID where the service will run")]
+        public required string ServerId { get; init; }
+
+        [CommandOption("--name <NAME>")]
+        [Description("Name for the new Sliplane service, e.g. tendril-artem")]
+        public required string ServiceName { get; init; }
+
+        // ── Tendril login credentials ──────────────────────────────────────
+
+        [CommandOption("--username <USERNAME>")]
+        [Description("Username for logging into the deployed Tendril web UI")]
+        public required string BasicAuthUsername { get; init; }
+
+        [CommandOption("--password <PASSWORD>")]
+        [Description("Password for the Tendril web UI (minimum 8 characters)")]
+        public required string BasicAuthPassword { get; init; }
+
+        // ── Agent API keys (all optional) ──────────────────────────────────
+
+        [CommandOption("--anthropic-key <KEY>")]
+        [Description("Anthropic API key → ANTHROPIC_API_KEY in the container")]
+        public string? AnthropicApiKey { get; init; }
+
+        [CommandOption("--claude-token <TOKEN>")]
+        [Description("Claude OAuth token (claude setup-token) → CLAUDE_CODE_OAUTH_TOKEN")]
+        public string? ClaudeCodeOAuthToken { get; init; }
+
+        [CommandOption("--github-token <TOKEN>")]
+        [Description("GitHub personal access token → GITHUB_TOKEN")]
+        public string? GitHubToken { get; init; }
+
+        [CommandOption("--openai-key <KEY>")]
+        [Description("OpenAI API key → OPENAI_API_KEY")]
+        public string? OpenAiApiKey { get; init; }
+
+        [CommandOption("--gemini-key <KEY>")]
+        [Description("Google Gemini API key → GEMINI_API_KEY")]
+        public string? GeminiApiKey { get; init; }
+
+        // ── Workspace repos ────────────────────────────────────────────────
+
+        [CommandOption("--repo <URL>")]
+        [Description("GitHub repo to clone into the container on startup (repeatable)")]
+        public string[]? Repos { get; init; }
+
+        // ── Optional overrides ─────────────────────────────────────────────
+
+        [CommandOption("--volume-id <ID>")]
+        [Description("Sliplane persistent volume ID to attach (recommended to persist data)")]
+        public string? VolumeId { get; init; }
+
+        [CommandOption("--git-repo <URL>")]
+        [Description("Source repo for the Tendril Dockerfile (defaults to official Ivy-Tendril repo)")]
+        public string? GitRepo { get; init; }
+
+        [CommandOption("--branch <BRANCH>")]
+        [Description("Branch to build from (default: development)")]
+        public string? Branch { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var client = settings.CreateTendrilClient();
+
+        // Sliplane token: explicit flag → env var
+        var sliplaneToken = settings.SliplaneToken
+            ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
+            ?? throw new InvalidOperationException(
+                "Sliplane token required. Use --sliplane-token or set SLIPLANE_API_KEY.");
+
+        var body = new Dictionary<string, object?>
+        {
+            ["sliplaneApiToken"]  = sliplaneToken,
+            ["projectId"]         = settings.ProjectId,
+            ["serverId"]          = settings.ServerId,
+            ["serviceName"]       = settings.ServiceName,
+            ["basicAuthUsername"] = settings.BasicAuthUsername,
+            ["basicAuthPassword"] = settings.BasicAuthPassword,
+        };
+
+        if (!string.IsNullOrEmpty(settings.AnthropicApiKey))      body["anthropicApiKey"]      = settings.AnthropicApiKey;
+        if (!string.IsNullOrEmpty(settings.ClaudeCodeOAuthToken))  body["claudeCodeOAuthToken"] = settings.ClaudeCodeOAuthToken;
+        if (!string.IsNullOrEmpty(settings.GitHubToken))           body["gitHubToken"]          = settings.GitHubToken;
+        if (!string.IsNullOrEmpty(settings.OpenAiApiKey))          body["openAiApiKey"]         = settings.OpenAiApiKey;
+        if (!string.IsNullOrEmpty(settings.GeminiApiKey))          body["geminiApiKey"]         = settings.GeminiApiKey;
+        if (settings.Repos is { Length: > 0 })                     body["repos"]                = settings.Repos;
+        if (!string.IsNullOrEmpty(settings.VolumeId))              body["volumeId"]             = settings.VolumeId;
+        if (!string.IsNullOrEmpty(settings.GitRepo))               body["gitRepo"]              = settings.GitRepo;
+        if (!string.IsNullOrEmpty(settings.Branch))                body["branch"]               = settings.Branch;
+
+        AnsiConsole.MarkupLine("[yellow]Deploying Tendril...[/]");
+        var result = await client.PostAsync("api/v1/tendrils", body);
+        YamlOutput.Write(result);
+        AnsiConsole.MarkupLine("[green]Tendril deployment accepted. Use 'ivy tendrils status' to check progress.[/]");
+        return 0;
+    }
+}

--- a/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
+++ b/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
@@ -122,7 +122,20 @@ public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Set
         AnsiConsole.MarkupLine("Deploying...");
         var result = await tendrilClient.PostAsync("api/v1/tendrils", body);
         YamlOutput.Write(result);
-        AnsiConsole.MarkupLine("[green]Done![/] Use 'ivy tendril status' to check progress.");
+
+        AnsiConsole.MarkupLine("[green]Done![/]");
+        AnsiConsole.WriteLine();
+
+        var nextCmd = $"{CliBrand.ToolCommandName} tendril status";
+        AnsiConsole.Write(
+            new Panel(
+                    new Markup(
+                        $"[grey]Run this until the instance is healthy (build takes a minute or two):[/]\n\n" +
+                        $"[bold yellow]$[/][bold aqua] [/][bold underline aqua]{Markup.Escape(nextCmd)}[/]"))
+                .Header($"[cyan]Command[/]")
+                .Border(BoxBorder.Rounded)
+                .Padding(1, 1));
+
         return 0;
     }
 

--- a/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
+++ b/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
@@ -86,22 +86,7 @@ public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Set
         var openAiKey    = PromptOptionalSecret("OpenAI API key [dim](optional)[/]:");
         var geminiKey    = PromptOptionalSecret("Gemini API key [dim](optional)[/]:");
 
-        // ── 6. Repos ───────────────────────────────────────────────────────
-        var repos = new List<string>();
-        if (Confirm("Clone GitHub repos into container?"))
-        {
-            while (true)
-            {
-                var repo = AnsiConsole.Prompt(
-                    new TextPrompt<string>("  Repo URL [dim](empty to finish)[/]:")
-                        .PromptStyle("green")
-                        .AllowEmpty());
-                if (string.IsNullOrWhiteSpace(repo)) break;
-                repos.Add(repo);
-            }
-        }
-
-        // ── 7. Volume ──────────────────────────────────────────────────────
+        // ── 6. Volume ──────────────────────────────────────────────────────
         string? volumeId = null;
         if (Confirm("Attach a persistent volume?"))
         {
@@ -132,8 +117,7 @@ public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Set
         if (githubToken  is not null) body["gitHubToken"]          = githubToken;
         if (openAiKey    is not null) body["openAiApiKey"]         = openAiKey;
         if (geminiKey    is not null) body["geminiApiKey"]         = geminiKey;
-        if (repos.Count > 0)          body["repos"]                = repos.ToArray();
-        if (volumeId     is not null) body["volumeId"]             = volumeId;
+        if (volumeId is not null) body["volumeId"] = volumeId;
 
         AnsiConsole.MarkupLine("Deploying...");
         var result = await tendrilClient.PostAsync("api/v1/tendrils", body);

--- a/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
+++ b/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
@@ -5,119 +5,168 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
-/// <summary>
-/// ivy tendrils deploy — create and deploy a new Tendril instance on Sliplane.
-/// Calls POST /api/v1/tendrils on the tendril-deploy service.
-/// </summary>
 public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings
     {
-        // ── Required Sliplane targeting ────────────────────────────────────
-
         [CommandOption("--sliplane-token <TOKEN>")]
-        [Description("Your Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        [Description("Sliplane API token (or set SLIPLANE_API_KEY env var)")]
         public string? SliplaneToken { get; init; }
-
-        [CommandOption("--project-id <ID>")]
-        [Description("Sliplane project ID where the Tendril service will be created")]
-        public required string ProjectId { get; init; }
-
-        [CommandOption("--server-id <ID>")]
-        [Description("Sliplane server ID where the service will run")]
-        public required string ServerId { get; init; }
-
-        [CommandOption("--name <NAME>")]
-        [Description("Name for the new Sliplane service, e.g. tendril-artem")]
-        public required string ServiceName { get; init; }
-
-        // ── Tendril login credentials ──────────────────────────────────────
-
-        [CommandOption("--username <USERNAME>")]
-        [Description("Username for logging into the deployed Tendril web UI")]
-        public required string BasicAuthUsername { get; init; }
-
-        [CommandOption("--password <PASSWORD>")]
-        [Description("Password for the Tendril web UI (minimum 8 characters)")]
-        public required string BasicAuthPassword { get; init; }
-
-        // ── Agent API keys (all optional) ──────────────────────────────────
-
-        [CommandOption("--anthropic-key <KEY>")]
-        [Description("Anthropic API key → ANTHROPIC_API_KEY in the container")]
-        public string? AnthropicApiKey { get; init; }
-
-        [CommandOption("--claude-token <TOKEN>")]
-        [Description("Claude OAuth token (claude setup-token) → CLAUDE_CODE_OAUTH_TOKEN")]
-        public string? ClaudeCodeOAuthToken { get; init; }
-
-        [CommandOption("--github-token <TOKEN>")]
-        [Description("GitHub personal access token → GITHUB_TOKEN")]
-        public string? GitHubToken { get; init; }
-
-        [CommandOption("--openai-key <KEY>")]
-        [Description("OpenAI API key → OPENAI_API_KEY")]
-        public string? OpenAiApiKey { get; init; }
-
-        [CommandOption("--gemini-key <KEY>")]
-        [Description("Google Gemini API key → GEMINI_API_KEY")]
-        public string? GeminiApiKey { get; init; }
-
-        // ── Workspace repos ────────────────────────────────────────────────
-
-        [CommandOption("--repo <URL>")]
-        [Description("GitHub repo to clone into the container on startup (repeatable)")]
-        public string[]? Repos { get; init; }
-
-        // ── Optional overrides ─────────────────────────────────────────────
-
-        [CommandOption("--volume-id <ID>")]
-        [Description("Sliplane persistent volume ID to attach (recommended to persist data)")]
-        public string? VolumeId { get; init; }
-
-        [CommandOption("--git-repo <URL>")]
-        [Description("Source repo for the Tendril Dockerfile (defaults to official Ivy-Tendril repo)")]
-        public string? GitRepo { get; init; }
-
-        [CommandOption("--branch <BRANCH>")]
-        [Description("Branch to build from (default: development)")]
-        public string? Branch { get; init; }
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
-        var client = settings.CreateTendrilClient();
+        var sliplaneToken = ConfigStore.Resolve(
+            flagValue: settings.SliplaneToken,
+            envVar:    Environment.GetEnvironmentVariable("SLIPLANE_API_KEY"),
+            configKey: "sliplane_api_key",
+            label:     "Sliplane API key",
+            hint:      "Find it at https://sliplane.io → Team Settings → API Tokens",
+            isSecret:  true);
 
-        // Sliplane token: explicit flag → env var
-        var sliplaneToken = settings.SliplaneToken
-            ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
-            ?? throw new InvalidOperationException(
-                "Sliplane token required. Use --sliplane-token or set SLIPLANE_API_KEY.");
+        var tendrilClient = settings.CreateTendrilClient();
+
+        // ── 1. Select server ───────────────────────────────────────────────
+        var serversDoc = await tendrilClient.GetAsync("api/v1/servers", sliplaneToken);
+        var servers = serversDoc.RootElement.EnumerateArray()
+            .Select(s => (Id: s.GetProperty("id").GetString()!, Name: s.GetProperty("name").GetString()!))
+            .ToList();
+
+        var serverName = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Server:")
+                .HighlightStyle("green")
+                .PageSize(10)
+                .AddChoices(servers.Select(s => s.Name)));
+        var serverId = servers.First(s => s.Name == serverName).Id;
+        AnsiConsole.MarkupLine($"Server: [green]{serverName}[/]");
+
+        // ── 2. Select project ──────────────────────────────────────────────
+        var projectsDoc = await tendrilClient.GetAsync("api/v1/projects", sliplaneToken);
+        var projects = projectsDoc.RootElement.EnumerateArray()
+            .Select(p => (Id: p.GetProperty("id").GetString()!, Name: p.GetProperty("name").GetString()!))
+            .ToList();
+
+        var projectName = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Project:")
+                .HighlightStyle("green")
+                .PageSize(10)
+                .AddChoices(projects.Select(p => p.Name)));
+        var projectId = projects.First(p => p.Name == projectName).Id;
+        AnsiConsole.MarkupLine($"Project: [green]{projectName}[/]");
+
+        // ── 3. Service name ────────────────────────────────────────────────
+        var serviceName = AnsiConsole.Prompt(
+            new TextPrompt<string>("Service name:")
+                .PromptStyle("green")
+                .DefaultValue("ivy-tendril")
+                .DefaultValueStyle(new Spectre.Console.Style(Spectre.Console.Color.Green)));
+
+        // ── 4. Login credentials ───────────────────────────────────────────
+        var username = AnsiConsole.Prompt(
+            new TextPrompt<string>("Username:")
+                .PromptStyle("green")
+                .Validate(v => string.IsNullOrWhiteSpace(v)
+                    ? ValidationResult.Error("[red]Cannot be empty.[/]")
+                    : ValidationResult.Success()));
+
+        var password = AnsiConsole.Prompt(
+            new TextPrompt<string>("Password [dim](min 8 chars)[/]:")
+                .PromptStyle("green")
+                .Secret()
+                .Validate(v => v.Length < 8
+                    ? ValidationResult.Error("[red]Minimum 8 characters.[/]")
+                    : ValidationResult.Success()));
+
+        // ── 5. API keys ────────────────────────────────────────────────────
+        var anthropicKey = PromptOptionalSecret("Anthropic API key [dim](optional)[/]:");
+        var claudeToken  = PromptOptionalSecret("Claude OAuth token [dim](optional)[/]:");
+        var githubToken  = PromptOptionalSecret("GitHub token [dim](optional)[/]:");
+        var openAiKey    = PromptOptionalSecret("OpenAI API key [dim](optional)[/]:");
+        var geminiKey    = PromptOptionalSecret("Gemini API key [dim](optional)[/]:");
+
+        // ── 6. Repos ───────────────────────────────────────────────────────
+        var repos = new List<string>();
+        if (Confirm("Clone GitHub repos into container?"))
+        {
+            while (true)
+            {
+                var repo = AnsiConsole.Prompt(
+                    new TextPrompt<string>("  Repo URL [dim](empty to finish)[/]:")
+                        .PromptStyle("green")
+                        .AllowEmpty());
+                if (string.IsNullOrWhiteSpace(repo)) break;
+                repos.Add(repo);
+            }
+        }
+
+        // ── 7. Volume ──────────────────────────────────────────────────────
+        string? volumeId = null;
+        if (Confirm("Attach a persistent volume?"))
+        {
+            volumeId = AnsiConsole.Prompt(
+                new TextPrompt<string>("Volume ID:")
+                    .PromptStyle("green"));
+        }
+
+        // ── 8. Confirm and deploy ──────────────────────────────────────────
+        if (!Confirm("Deploy?"))
+        {
+            AnsiConsole.MarkupLine("[dim]Cancelled.[/]");
+            return 0;
+        }
 
         var body = new Dictionary<string, object?>
         {
             ["sliplaneApiToken"]  = sliplaneToken,
-            ["projectId"]         = settings.ProjectId,
-            ["serverId"]          = settings.ServerId,
-            ["serviceName"]       = settings.ServiceName,
-            ["basicAuthUsername"] = settings.BasicAuthUsername,
-            ["basicAuthPassword"] = settings.BasicAuthPassword,
+            ["projectId"]         = projectId,
+            ["serverId"]          = serverId,
+            ["serviceName"]       = serviceName,
+            ["basicAuthUsername"] = username,
+            ["basicAuthPassword"] = password,
         };
 
-        if (!string.IsNullOrEmpty(settings.AnthropicApiKey))      body["anthropicApiKey"]      = settings.AnthropicApiKey;
-        if (!string.IsNullOrEmpty(settings.ClaudeCodeOAuthToken))  body["claudeCodeOAuthToken"] = settings.ClaudeCodeOAuthToken;
-        if (!string.IsNullOrEmpty(settings.GitHubToken))           body["gitHubToken"]          = settings.GitHubToken;
-        if (!string.IsNullOrEmpty(settings.OpenAiApiKey))          body["openAiApiKey"]         = settings.OpenAiApiKey;
-        if (!string.IsNullOrEmpty(settings.GeminiApiKey))          body["geminiApiKey"]         = settings.GeminiApiKey;
-        if (settings.Repos is { Length: > 0 })                     body["repos"]                = settings.Repos;
-        if (!string.IsNullOrEmpty(settings.VolumeId))              body["volumeId"]             = settings.VolumeId;
-        if (!string.IsNullOrEmpty(settings.GitRepo))               body["gitRepo"]              = settings.GitRepo;
-        if (!string.IsNullOrEmpty(settings.Branch))                body["branch"]               = settings.Branch;
+        if (anthropicKey is not null) body["anthropicApiKey"]     = anthropicKey;
+        if (claudeToken  is not null) body["claudeCodeOAuthToken"] = claudeToken;
+        if (githubToken  is not null) body["gitHubToken"]          = githubToken;
+        if (openAiKey    is not null) body["openAiApiKey"]         = openAiKey;
+        if (geminiKey    is not null) body["geminiApiKey"]         = geminiKey;
+        if (repos.Count > 0)          body["repos"]                = repos.ToArray();
+        if (volumeId     is not null) body["volumeId"]             = volumeId;
 
-        AnsiConsole.MarkupLine("[yellow]Deploying Tendril...[/]");
-        var result = await client.PostAsync("api/v1/tendrils", body);
+        AnsiConsole.MarkupLine("Deploying...");
+        var result = await tendrilClient.PostAsync("api/v1/tendrils", body);
         YamlOutput.Write(result);
-        AnsiConsole.MarkupLine("[green]Tendril deployment accepted. Use 'ivy tendrils status' to check progress.[/]");
+        AnsiConsole.MarkupLine("[green]Done![/] Use 'ivy tendrils status' to check progress.");
         return 0;
+    }
+
+    private static string? PromptOptionalSecret(string label)
+    {
+        var value = AnsiConsole.Prompt(
+            new TextPrompt<string>(label)
+                .PromptStyle("green")
+                .Secret()
+                .AllowEmpty());
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static bool Confirm(string label, bool defaultValue = false)
+    {
+        var def = defaultValue ? "y" : "n";
+        var answer = AnsiConsole.Prompt(
+            new TextPrompt<string>($"{label} [green][[y/n]] ({def})[/]")
+                .PromptStyle("green")
+                .AllowEmpty()
+                .Validate(v =>
+                {
+                    if (string.IsNullOrEmpty(v)) return ValidationResult.Success();
+                    return v.ToLower() is "y" or "n" or "yes" or "no"
+                        ? ValidationResult.Success()
+                        : ValidationResult.Error("[red]Please enter y or n.[/]");
+                }));
+
+        return string.IsNullOrEmpty(answer) ? defaultValue : answer.ToLower() is "y" or "yes";
     }
 }

--- a/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
+++ b/cli/src/Commands/Tendrils/DeployTendrilCommand.cs
@@ -138,7 +138,7 @@ public sealed class DeployTendrilCommand : AsyncCommand<DeployTendrilCommand.Set
         AnsiConsole.MarkupLine("Deploying...");
         var result = await tendrilClient.PostAsync("api/v1/tendrils", body);
         YamlOutput.Write(result);
-        AnsiConsole.MarkupLine("[green]Done![/] Use 'ivy tendrils status' to check progress.");
+        AnsiConsole.MarkupLine("[green]Done![/] Use 'ivy tendril status' to check progress.");
         return 0;
     }
 

--- a/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
+++ b/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 namespace Ivy.Cli.Commands.Tendrils;
 
 /// <summary>
-/// ivy tendril status — interactively pick a Tendril service and show its status.
+/// ivy-examples tendril status — interactively pick a Tendril service and show its status.
 /// If --project-id and --service-id are provided, skips the interactive prompt.
 /// </summary>
 public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusCommand.Settings>

--- a/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
+++ b/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel;
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Tendrils;
+
+/// <summary>
+/// ivy tendrils status — poll status of a deployed Tendril service.
+/// Calls GET /api/v1/tendrils/{projectId}/{serviceId}.
+/// </summary>
+public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusCommand.Settings>
+{
+    public sealed class Settings : TendrilApiSettings
+    {
+        [CommandOption("--sliplane-token <TOKEN>")]
+        [Description("Your Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        public string? SliplaneToken { get; init; }
+
+        [CommandOption("--project-id <ID>")]
+        [Description("Sliplane project ID of the Tendril service")]
+        public required string ProjectId { get; init; }
+
+        [CommandOption("--service-id <ID>")]
+        [Description("Sliplane service ID returned by 'ivy tendrils deploy'")]
+        public required string ServiceId { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        // Status endpoint requires X-Sliplane-Token header — pass it via query or we add it to client
+        // The tendril-deploy API reads it from the X-Sliplane-Token request header.
+        // We create a raw HTTP request to pass the extra header.
+        var sliplaneToken = settings.SliplaneToken
+            ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
+            ?? throw new InvalidOperationException(
+                "Sliplane token required. Use --sliplane-token or set SLIPLANE_API_KEY.");
+
+        var tendrilApiKey = settings.TendrilApiKey
+            ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY");
+
+        var baseUrl = settings.TendrilUrl
+            ?? Environment.GetEnvironmentVariable("TENDRIL_BASE_URL")
+            ?? throw new InvalidOperationException(
+                "Tendril base URL required. Use --tendril-url or set TENDRIL_BASE_URL.");
+
+        using var http = new System.Net.Http.HttpClient();
+        http.BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/");
+        if (!string.IsNullOrEmpty(tendrilApiKey))
+            http.DefaultRequestHeaders.Add("X-Api-Key", tendrilApiKey);
+        http.DefaultRequestHeaders.Add("X-Sliplane-Token", sliplaneToken);
+
+        var response = await http.GetAsync(
+            $"api/v1/tendrils/{settings.ProjectId}/{settings.ServiceId}");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var err = await response.Content.ReadAsStringAsync();
+            throw new System.Net.Http.HttpRequestException($"HTTP {(int)response.StatusCode}: {err}");
+        }
+
+        var stream = await response.Content.ReadAsStreamAsync();
+        var doc = await System.Text.Json.JsonDocument.ParseAsync(stream);
+        YamlOutput.Write(doc);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
+++ b/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
@@ -1,57 +1,135 @@
 using System.ComponentModel;
+using System.Text.Json;
 using Ivy.Cli.Infrastructure;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
 /// <summary>
-/// ivy tendrils status — poll status of a deployed Tendril service.
-/// Calls GET /api/v1/tendrils/{projectId}/{serviceId}.
+/// ivy tendrils status — interactively pick a Tendril service and show its status.
+/// If --project-id and --service-id are provided, skips the interactive prompt.
 /// </summary>
 public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings
     {
         [CommandOption("--sliplane-token <TOKEN>")]
-        [Description("Your Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        [Description("Sliplane API token (or set SLIPLANE_API_KEY env var)")]
         public string? SliplaneToken { get; init; }
 
         [CommandOption("--project-id <ID>")]
-        [Description("Sliplane project ID of the Tendril service")]
-        public required string ProjectId { get; init; }
+        [Description("Sliplane project ID (optional — skips interactive picker if provided with --service-id)")]
+        public string? ProjectId { get; init; }
 
         [CommandOption("--service-id <ID>")]
-        [Description("Sliplane service ID returned by 'ivy tendrils deploy'")]
-        public required string ServiceId { get; init; }
+        [Description("Sliplane service ID (optional — skips interactive picker if provided with --project-id)")]
+        public string? ServiceId { get; init; }
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
     {
-        // Status endpoint requires X-Sliplane-Token header — pass it via query or we add it to client
-        // The tendril-deploy API reads it from the X-Sliplane-Token request header.
-        // We create a raw HTTP request to pass the extra header.
-        var sliplaneToken = settings.SliplaneToken
-            ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
-            ?? throw new InvalidOperationException(
-                "Sliplane token required. Use --sliplane-token or set SLIPLANE_API_KEY.");
+        var sliplaneToken = ConfigStore.Resolve(
+            flagValue: settings.SliplaneToken,
+            envVar:    Environment.GetEnvironmentVariable("SLIPLANE_API_KEY"),
+            configKey: "sliplane_api_key",
+            label:     "Sliplane API key",
+            hint:      "Find it at [link]https://sliplane.io[/] → Team Settings → API Tokens",
+            isSecret:  true);
 
-        var tendrilApiKey = settings.TendrilApiKey
-            ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY");
+        var tendrilClient = settings.CreateTendrilClient();
 
+        string projectId;
+        string serviceId;
+
+        // If both IDs provided — use them directly
+        if (!string.IsNullOrEmpty(settings.ProjectId) && !string.IsNullOrEmpty(settings.ServiceId))
+        {
+            projectId = settings.ProjectId;
+            serviceId = settings.ServiceId;
+        }
+        else
+        {
+            // Load all services from all Tendril projects and let user pick
+            AnsiConsole.MarkupLine("[dim]Loading Tendril services...[/]");
+
+            var projectsDoc = await tendrilClient.GetAsync("api/v1/projects", sliplaneToken);
+            var projects = projectsDoc.RootElement.EnumerateArray().ToList();
+
+            if (projects.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]No projects found.[/]");
+                return 1;
+            }
+
+            // Fetch services for each project in parallel
+            var sliplaneClient = new SliplaneClient(sliplaneToken);
+            var allServices = new List<(string ProjectId, string ProjectName, string ServiceId, string ServiceName, string Status)>();
+
+            foreach (var project in projects)
+            {
+                var pid  = project.GetProperty("id").GetString()!;
+                var pname = project.GetProperty("name").GetString()!;
+
+                try
+                {
+                    var servicesDoc = await sliplaneClient.GetAsync($"projects/{pid}/services");
+                    foreach (var svc in servicesDoc.RootElement.EnumerateArray())
+                    {
+                        var sid    = svc.GetProperty("id").GetString()!;
+                        var sname  = svc.GetProperty("name").GetString()!;
+                        var status = svc.TryGetProperty("status", out var st) ? st.GetString() ?? "unknown" : "unknown";
+                        allServices.Add((pid, pname, sid, sname, status));
+                    }
+                }
+                catch { /* skip projects we can't access */ }
+            }
+
+            if (allServices.Count == 0)
+            {
+                AnsiConsole.MarkupLine("[yellow]No services found across Tendril projects.[/]");
+                return 1;
+            }
+
+            // Interactive picker
+            var choice = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]Tendril service[/] to check status:")
+                    .PageSize(12)
+                    .AddChoices(allServices.Select(s =>
+                        $"{s.ServiceName}  [dim]({s.ProjectName})[/]  [{StatusColor(s.Status)}]{s.Status}[/]")));
+
+            var index = allServices.FindIndex(s =>
+                choice.StartsWith(s.ServiceName + "  "));
+
+            if (index < 0)
+            {
+                AnsiConsole.MarkupLine("[red]Could not resolve selection.[/]");
+                return 1;
+            }
+
+            projectId = allServices[index].ProjectId;
+            serviceId = allServices[index].ServiceId;
+        }
+
+        // Fetch status from tendril-deploy API
+        using var http = new System.Net.Http.HttpClient();
         var baseUrl = settings.TendrilUrl
             ?? Environment.GetEnvironmentVariable("TENDRIL_BASE_URL")
-            ?? throw new InvalidOperationException(
-                "Tendril base URL required. Use --tendril-url or set TENDRIL_BASE_URL.");
+            ?? ConfigStore.Get("tendril_base_url")
+            ?? "https://ivy-tendril-deployment.sliplane.app";
 
-        using var http = new System.Net.Http.HttpClient();
         http.BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/");
+
+        var tendrilApiKey = settings.TendrilApiKey
+            ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY")
+            ?? ConfigStore.Get("tendril_api_key");
+
         if (!string.IsNullOrEmpty(tendrilApiKey))
             http.DefaultRequestHeaders.Add("X-Api-Key", tendrilApiKey);
         http.DefaultRequestHeaders.Add("X-Sliplane-Token", sliplaneToken);
 
-        var response = await http.GetAsync(
-            $"api/v1/tendrils/{settings.ProjectId}/{settings.ServiceId}");
-
+        var response = await http.GetAsync($"api/v1/tendrils/{projectId}/{serviceId}");
         if (!response.IsSuccessStatusCode)
         {
             var err = await response.Content.ReadAsStringAsync();
@@ -59,8 +137,17 @@ public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusComma
         }
 
         var stream = await response.Content.ReadAsStreamAsync();
-        var doc = await System.Text.Json.JsonDocument.ParseAsync(stream);
+        var doc = await JsonDocument.ParseAsync(stream);
         YamlOutput.Write(doc);
         return 0;
     }
+
+    private static string StatusColor(string status) => status.ToLower() switch
+    {
+        "running"  => "green",
+        "building" => "yellow",
+        "stopped"  => "red",
+        "error"    => "red",
+        _          => "dim"
+    };
 }

--- a/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
+++ b/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 namespace Ivy.Cli.Commands.Tendrils;
 
 /// <summary>
-/// ivy tendrils status — interactively pick a Tendril service and show its status.
+/// ivy tendril status — interactively pick a Tendril service and show its status.
 /// If --project-id and --service-id are provided, skips the interactive prompt.
 /// </summary>
 public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusCommand.Settings>

--- a/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
+++ b/cli/src/Commands/Tendrils/GetTendrilStatusCommand.cs
@@ -64,7 +64,7 @@ public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusComma
 
             // Fetch services for each project in parallel
             var sliplaneClient = new SliplaneClient(sliplaneToken);
-            var allServices = new List<(string ProjectId, string ProjectName, string ServiceId, string ServiceName, string Status)>();
+            var allServices = new List<(string ProjectId, string ProjectName, string ServiceId, string ServiceName, string Status, DateTimeOffset UpdatedAt)>();
 
             foreach (var project in projects)
             {
@@ -76,10 +76,11 @@ public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusComma
                     var servicesDoc = await sliplaneClient.GetAsync($"projects/{pid}/services");
                     foreach (var svc in servicesDoc.RootElement.EnumerateArray())
                     {
-                        var sid    = svc.GetProperty("id").GetString()!;
-                        var sname  = svc.GetProperty("name").GetString()!;
+                        var sid = svc.GetProperty("id").GetString()!;
+                        var sname = svc.GetProperty("name").GetString()!;
                         var status = svc.TryGetProperty("status", out var st) ? st.GetString() ?? "unknown" : "unknown";
-                        allServices.Add((pid, pname, sid, sname, status));
+                        var updatedAt = ParseServiceUpdatedAt(svc);
+                        allServices.Add((pid, pname, sid, sname, status, updatedAt));
                     }
                 }
                 catch { /* skip projects we can't access */ }
@@ -90,6 +91,12 @@ public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusComma
                 AnsiConsole.MarkupLine("[yellow]No services found across Tendril projects.[/]");
                 return 1;
             }
+
+            // Show most recently updated services first.
+            allServices = allServices
+                .OrderByDescending(s => s.UpdatedAt)
+                .ThenBy(s => s.ServiceName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             // Interactive picker
             var choice = AnsiConsole.Prompt(
@@ -150,4 +157,28 @@ public sealed class GetTendrilStatusCommand : AsyncCommand<GetTendrilStatusComma
         "error"    => "red",
         _          => "dim"
     };
+
+    private static DateTimeOffset ParseServiceUpdatedAt(JsonElement service)
+    {
+        // Sliplane API fields may vary by version/casing.
+        if (TryParseDate(service, "updated_at", out var updatedAt) ||
+            TryParseDate(service, "updatedAt", out updatedAt) ||
+            TryParseDate(service, "created_at", out updatedAt) ||
+            TryParseDate(service, "createdAt", out updatedAt))
+        {
+            return updatedAt;
+        }
+
+        return DateTimeOffset.MinValue;
+    }
+
+    private static bool TryParseDate(JsonElement obj, string property, out DateTimeOffset value)
+    {
+        value = default;
+        if (!obj.TryGetProperty(property, out var raw))
+            return false;
+
+        return raw.ValueKind == JsonValueKind.String &&
+               DateTimeOffset.TryParse(raw.GetString(), out value);
+    }
 }

--- a/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
@@ -1,15 +1,31 @@
+using System.ComponentModel;
 using Ivy.Cli.Infrastructure;
 using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
 /// <summary>ivy tendrils projects — list Sliplane projects available for Tendril deployment.</summary>
-public sealed class ListTendrilProjectsCommand : AsyncCommand<TendrilApiSettings>
+public sealed class ListTendrilProjectsCommand : AsyncCommand<ListTendrilProjectsCommand.Settings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, TendrilApiSettings settings)
+    public sealed class Settings : TendrilApiSettings
     {
+        [CommandOption("--sliplane-token <TOKEN>")]
+        [Description("Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        public string? SliplaneToken { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var sliplaneToken = ConfigStore.Resolve(
+            flagValue: settings.SliplaneToken,
+            envVar:    Environment.GetEnvironmentVariable("SLIPLANE_API_KEY"),
+            configKey: "sliplane_api_key",
+            label:     "Sliplane API key",
+            hint:      "Find it at [link]https://sliplane.io[/] → Team Settings → API Tokens",
+            isSecret:  true);
+
         var client = settings.CreateTendrilClient();
-        var result = await client.GetAsync("api/v1/projects");
+        var result = await client.GetAsync("api/v1/projects", sliplaneToken);
         YamlOutput.Write(result);
         return 0;
     }

--- a/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
@@ -1,0 +1,16 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Tendrils;
+
+/// <summary>ivy tendrils projects — list Sliplane projects available for Tendril deployment.</summary>
+public sealed class ListTendrilProjectsCommand : AsyncCommand<TendrilApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, TendrilApiSettings settings)
+    {
+        var client = settings.CreateTendrilClient();
+        var result = await client.GetAsync("api/v1/projects");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
-/// <summary>ivy tendrils projects — list Sliplane projects available for Tendril deployment.</summary>
+/// <summary>ivy tendril projects — list Sliplane projects available for Tendril deployment.</summary>
 public sealed class ListTendrilProjectsCommand : AsyncCommand<ListTendrilProjectsCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings

--- a/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilProjectsCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
-/// <summary>ivy tendril projects — list Sliplane projects available for Tendril deployment.</summary>
+/// <summary>ivy-examples tendril projects — list Sliplane projects available for Tendril deployment.</summary>
 public sealed class ListTendrilProjectsCommand : AsyncCommand<ListTendrilProjectsCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings

--- a/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
-/// <summary>ivy tendril servers — list Sliplane servers available for Tendril deployment.</summary>
+/// <summary>ivy-examples tendril servers — list Sliplane servers available for Tendril deployment.</summary>
 public sealed class ListTendrilServersCommand : AsyncCommand<ListTendrilServersCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings

--- a/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
@@ -1,0 +1,16 @@
+using Ivy.Cli.Infrastructure;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Commands.Tendrils;
+
+/// <summary>ivy tendrils servers — list Sliplane servers available for Tendril deployment.</summary>
+public sealed class ListTendrilServersCommand : AsyncCommand<TendrilApiSettings>
+{
+    public override async Task<int> ExecuteAsync(CommandContext context, TendrilApiSettings settings)
+    {
+        var client = settings.CreateTendrilClient();
+        var result = await client.GetAsync("api/v1/servers");
+        YamlOutput.Write(result);
+        return 0;
+    }
+}

--- a/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
@@ -1,15 +1,31 @@
+using System.ComponentModel;
 using Ivy.Cli.Infrastructure;
 using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
 /// <summary>ivy tendrils servers — list Sliplane servers available for Tendril deployment.</summary>
-public sealed class ListTendrilServersCommand : AsyncCommand<TendrilApiSettings>
+public sealed class ListTendrilServersCommand : AsyncCommand<ListTendrilServersCommand.Settings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, TendrilApiSettings settings)
+    public sealed class Settings : TendrilApiSettings
     {
+        [CommandOption("--sliplane-token <TOKEN>")]
+        [Description("Sliplane API token (or set SLIPLANE_API_KEY env var)")]
+        public string? SliplaneToken { get; init; }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    {
+        var sliplaneToken = ConfigStore.Resolve(
+            flagValue: settings.SliplaneToken,
+            envVar:    Environment.GetEnvironmentVariable("SLIPLANE_API_KEY"),
+            configKey: "sliplane_api_key",
+            label:     "Sliplane API key",
+            hint:      "Find it at [link]https://sliplane.io[/] → Team Settings → API Tokens",
+            isSecret:  true);
+
         var client = settings.CreateTendrilClient();
-        var result = await client.GetAsync("api/v1/servers");
+        var result = await client.GetAsync("api/v1/servers", sliplaneToken);
         YamlOutput.Write(result);
         return 0;
     }

--- a/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
+++ b/cli/src/Commands/Tendrils/ListTendrilServersCommand.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Ivy.Cli.Commands.Tendrils;
 
-/// <summary>ivy tendrils servers — list Sliplane servers available for Tendril deployment.</summary>
+/// <summary>ivy tendril servers — list Sliplane servers available for Tendril deployment.</summary>
 public sealed class ListTendrilServersCommand : AsyncCommand<ListTendrilServersCommand.Settings>
 {
     public sealed class Settings : TendrilApiSettings

--- a/cli/src/Infrastructure/ApiSettings.cs
+++ b/cli/src/Infrastructure/ApiSettings.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace Ivy.Cli.Infrastructure;
+
+/// <summary>
+/// Base settings for all Sliplane commands.
+/// API key is read from --api-key flag or SLIPLANE_API_KEY env var.
+/// </summary>
+public class ApiSettings : CommandSettings
+{
+    [CommandOption("--api-key <KEY>")]
+    [Description("Sliplane API key (or set SLIPLANE_API_KEY env var)")]
+    public string? ApiKey { get; init; }
+
+    [CommandOption("--org-id <ORG_ID>")]
+    [Description("Organization ID for legacy tokens (or set SLIPLANE_ORG_ID env var)")]
+    public string? OrgId { get; init; }
+
+    public SliplaneClient CreateClient()
+    {
+        var key = ApiKey ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
+            ?? throw new InvalidOperationException(
+                "Sliplane API key required. Use --api-key or set SLIPLANE_API_KEY.");
+        var org = OrgId ?? Environment.GetEnvironmentVariable("SLIPLANE_ORG_ID");
+        return new SliplaneClient(key, org);
+    }
+}
+
+/// <summary>
+/// Base settings for all Tendril commands.
+/// Tendril base URL: --tendril-url or TENDRIL_BASE_URL env var.
+/// Tendril API key: --tendril-api-key or TENDRIL_API_KEY env var (optional).
+/// </summary>
+public class TendrilApiSettings : CommandSettings
+{
+    [CommandOption("--tendril-url <URL>")]
+    [Description("Base URL of the tendril-deploy instance (or set TENDRIL_BASE_URL env var)")]
+    public string? TendrilUrl { get; init; }
+
+    [CommandOption("--tendril-api-key <KEY>")]
+    [Description("API key for tendril-deploy (or set TENDRIL_API_KEY env var). Optional if server has no key configured.")]
+    public string? TendrilApiKey { get; init; }
+
+    public TendrilClient CreateTendrilClient()
+    {
+        var url = TendrilUrl ?? Environment.GetEnvironmentVariable("TENDRIL_BASE_URL")
+            ?? throw new InvalidOperationException(
+                "Tendril base URL required. Use --tendril-url or set TENDRIL_BASE_URL.");
+        var key = TendrilApiKey ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY");
+        return new TendrilClient(url, key);
+    }
+}

--- a/cli/src/Infrastructure/ApiSettings.cs
+++ b/cli/src/Infrastructure/ApiSettings.cs
@@ -56,7 +56,7 @@ public class TendrilApiSettings : CommandSettings
             envVar:    Environment.GetEnvironmentVariable("TENDRIL_BASE_URL"),
             configKey: "tendril_base_url",
             label:     "Tendril base URL",
-            hint:      "e.g. [yellow]https://ivy-tendril-deploy.sliplane.app[/]",
+            hint:      "e.g. [yellow]https://ivy-tendril-deployment.sliplane.app[/]",
             isSecret:  false);
 
         // API key is optional for Tendril — don't prompt, just check flag/env/config

--- a/cli/src/Infrastructure/ApiSettings.cs
+++ b/cli/src/Infrastructure/ApiSettings.cs
@@ -51,15 +51,11 @@ public class TendrilApiSettings : CommandSettings
 
     public TendrilClient CreateTendrilClient()
     {
-        var url = ConfigStore.Resolve(
-            flagValue: TendrilUrl,
-            envVar:    Environment.GetEnvironmentVariable("TENDRIL_BASE_URL"),
-            configKey: "tendril_base_url",
-            label:     "Tendril base URL",
-            hint:      "e.g. [yellow]https://ivy-tendril-deployment.sliplane.app[/]",
-            isSecret:  false);
+        var url = TendrilUrl
+            ?? Environment.GetEnvironmentVariable("TENDRIL_BASE_URL")
+            ?? ConfigStore.Get("tendril_base_url")
+            ?? "https://ivy-tendril-deployment.sliplane.app";
 
-        // API key is optional for Tendril — don't prompt, just check flag/env/config
         var key = TendrilApiKey
             ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY")
             ?? ConfigStore.Get("tendril_api_key");

--- a/cli/src/Infrastructure/ApiSettings.cs
+++ b/cli/src/Infrastructure/ApiSettings.cs
@@ -5,12 +5,12 @@ namespace Ivy.Cli.Infrastructure;
 
 /// <summary>
 /// Base settings for all Sliplane commands.
-/// API key is read from --api-key flag or SLIPLANE_API_KEY env var.
+/// Key priority: --api-key flag → SLIPLANE_API_KEY env var → ~/.ivy/config.json → interactive prompt.
 /// </summary>
 public class ApiSettings : CommandSettings
 {
     [CommandOption("--api-key <KEY>")]
-    [Description("Sliplane API key (or set SLIPLANE_API_KEY env var)")]
+    [Description("Sliplane API key (or set SLIPLANE_API_KEY env var, or run once to save)")]
     public string? ApiKey { get; init; }
 
     [CommandOption("--org-id <ORG_ID>")]
@@ -19,18 +19,25 @@ public class ApiSettings : CommandSettings
 
     public SliplaneClient CreateClient()
     {
-        var key = ApiKey ?? Environment.GetEnvironmentVariable("SLIPLANE_API_KEY")
-            ?? throw new InvalidOperationException(
-                "Sliplane API key required. Use --api-key or set SLIPLANE_API_KEY.");
-        var org = OrgId ?? Environment.GetEnvironmentVariable("SLIPLANE_ORG_ID");
+        var key = ConfigStore.Resolve(
+            flagValue: ApiKey,
+            envVar:    Environment.GetEnvironmentVariable("SLIPLANE_API_KEY"),
+            configKey: "sliplane_api_key",
+            label:     "Sliplane API key",
+            hint:      "Find it at [link]https://sliplane.io[/] → Team Settings → API Tokens",
+            isSecret:  true);
+
+        var org = OrgId
+            ?? Environment.GetEnvironmentVariable("SLIPLANE_ORG_ID")
+            ?? ConfigStore.Get("sliplane_org_id");
+
         return new SliplaneClient(key, org);
     }
 }
 
 /// <summary>
 /// Base settings for all Tendril commands.
-/// Tendril base URL: --tendril-url or TENDRIL_BASE_URL env var.
-/// Tendril API key: --tendril-api-key or TENDRIL_API_KEY env var (optional).
+/// URL and key are resolved from flags → env vars → config file → interactive prompt.
 /// </summary>
 public class TendrilApiSettings : CommandSettings
 {
@@ -39,15 +46,25 @@ public class TendrilApiSettings : CommandSettings
     public string? TendrilUrl { get; init; }
 
     [CommandOption("--tendril-api-key <KEY>")]
-    [Description("API key for tendril-deploy (or set TENDRIL_API_KEY env var). Optional if server has no key configured.")]
+    [Description("API key for tendril-deploy (or set TENDRIL_API_KEY env var). Optional if server has no key.")]
     public string? TendrilApiKey { get; init; }
 
     public TendrilClient CreateTendrilClient()
     {
-        var url = TendrilUrl ?? Environment.GetEnvironmentVariable("TENDRIL_BASE_URL")
-            ?? throw new InvalidOperationException(
-                "Tendril base URL required. Use --tendril-url or set TENDRIL_BASE_URL.");
-        var key = TendrilApiKey ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY");
+        var url = ConfigStore.Resolve(
+            flagValue: TendrilUrl,
+            envVar:    Environment.GetEnvironmentVariable("TENDRIL_BASE_URL"),
+            configKey: "tendril_base_url",
+            label:     "Tendril base URL",
+            hint:      "e.g. [yellow]https://ivy-tendril-deploy.sliplane.app[/]",
+            isSecret:  false);
+
+        // API key is optional for Tendril — don't prompt, just check flag/env/config
+        var key = TendrilApiKey
+            ?? Environment.GetEnvironmentVariable("TENDRIL_API_KEY")
+            ?? ConfigStore.Get("tendril_api_key");
+
         return new TendrilClient(url, key);
     }
 }
+

--- a/cli/src/Infrastructure/ApiSettings.cs
+++ b/cli/src/Infrastructure/ApiSettings.cs
@@ -64,3 +64,31 @@ public class TendrilApiSettings : CommandSettings
     }
 }
 
+/// <summary>
+/// Base settings for all NuGet stats commands.
+/// URL defaults to https://ivy-nuget-stats.sliplane.app; optional API key.
+/// </summary>
+public class NuGetStatsSettings : CommandSettings
+{
+    [CommandOption("--nuget-stats-url <URL>")]
+    [Description("Base URL of the IvyInsights NuGet stats instance (or set NUGET_STATS_BASE_URL env var)")]
+    public string? NuGetStatsUrl { get; init; }
+
+    [CommandOption("--nuget-stats-key <KEY>")]
+    [Description("API key for IvyInsights (or set NUGET_STATS_API_KEY env var). Optional.")]
+    public string? NuGetStatsKey { get; init; }
+
+    public NuGetStatsClient CreateNuGetStatsClient()
+    {
+        var url = NuGetStatsUrl
+            ?? Environment.GetEnvironmentVariable("NUGET_STATS_BASE_URL")
+            ?? ConfigStore.Get("nuget_stats_base_url")
+            ?? "https://ivy-nuget-stats.sliplane.app";
+
+        var key = NuGetStatsKey
+            ?? Environment.GetEnvironmentVariable("NUGET_STATS_API_KEY")
+            ?? ConfigStore.Get("nuget_stats_api_key");
+
+        return new NuGetStatsClient(url, key);
+    }
+}

--- a/cli/src/Infrastructure/CliBrand.cs
+++ b/cli/src/Infrastructure/CliBrand.cs
@@ -1,0 +1,8 @@
+namespace Ivy.Cli.Infrastructure;
+
+/// <summary>Executable name produced by NuGet PackAsTool (<c>dotnet tool install</c>).</summary>
+internal static class CliBrand
+{
+    /// <summary>Mirrors <c>&lt;ToolCommandName&gt;</c> in <c>Ivy.Cli.csproj</c>; keep both in sync.</summary>
+    internal const string ToolCommandName = "ivy-examples";
+}

--- a/cli/src/Infrastructure/ConfigStore.cs
+++ b/cli/src/Infrastructure/ConfigStore.cs
@@ -87,7 +87,7 @@ public static class ConfigStore
         if (save)
         {
             Set(configKey, value);
-            AnsiConsole.MarkupLine($"[green]Saved.[/] You can also run [dim]ivy config set {configKey} <value>[/] anytime.");
+            AnsiConsole.MarkupLine($"[green]Saved.[/] You can also run [dim]{CliBrand.ToolCommandName} config set {configKey} <value>[/] anytime.");
         }
 
         return value;

--- a/cli/src/Infrastructure/ConfigStore.cs
+++ b/cli/src/Infrastructure/ConfigStore.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Spectre.Console;
+
+namespace Ivy.Cli.Infrastructure;
+
+/// <summary>
+/// Persists CLI configuration to ~/.ivy/config.json.
+/// Keys stored: sliplane_api_key, sliplane_org_id, tendril_base_url, tendril_api_key.
+/// </summary>
+public static class ConfigStore
+{
+    private static readonly string ConfigDir  = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".ivy");
+    private static readonly string ConfigFile = Path.Combine(ConfigDir, "config.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    // ── Public API ────────────────────────────────────────────────────────
+
+    public static string? Get(string key)
+    {
+        var config = Load();
+        return config.TryGetValue(key, out var val) ? val : null;
+    }
+
+    public static void Set(string key, string value)
+    {
+        var config = Load();
+        config[key] = value;
+        Save(config);
+    }
+
+    /// <summary>Removes a single key. Returns true if it existed.</summary>
+    public static bool Remove(string key)
+    {
+        var config = Load();
+        if (!config.Remove(key)) return false;
+        Save(config);
+        return true;
+    }
+
+    /// <summary>Deletes the entire config file.</summary>
+    public static void Clear()
+    {
+        if (File.Exists(ConfigFile))
+            File.Delete(ConfigFile);
+    }
+
+    /// <summary>
+    /// Resolves a value using priority: flag → env var → config file → interactive prompt.
+    /// If prompted, asks the user whether to save the value for future runs.
+    /// </summary>
+    public static string Resolve(
+        string?  flagValue,
+        string?  envVar,
+        string   configKey,
+        string   label,
+        string   hint,
+        bool     isSecret = true)
+    {
+        // 1. Flag
+        if (!string.IsNullOrWhiteSpace(flagValue)) return flagValue!;
+
+        // 2. Env var
+        if (!string.IsNullOrWhiteSpace(envVar)) return envVar!;
+
+        // 3. Config file
+        var stored = Get(configKey);
+        if (!string.IsNullOrWhiteSpace(stored)) return stored!;
+
+        // 4. Interactive prompt
+        AnsiConsole.MarkupLine($"[yellow]{label}[/] not set.");
+        AnsiConsole.MarkupLine($"  {hint}");
+
+        var prompt = new TextPrompt<string>($"Enter {label}:")
+            .PromptStyle("green")
+            .Validate(v => string.IsNullOrWhiteSpace(v)
+                ? ValidationResult.Error("[red]Cannot be empty.[/]")
+                : ValidationResult.Success());
+
+        if (isSecret) prompt.Secret();
+
+        var value = AnsiConsole.Prompt(prompt);
+
+        // Ask whether to save
+        var save = AnsiConsole.Confirm($"Save {label} to [dim]~/.ivy/config.json[/] for future runs?");
+        if (save)
+        {
+            Set(configKey, value);
+            AnsiConsole.MarkupLine($"[green]Saved.[/] You can also run [dim]ivy config set {configKey} <value>[/] anytime.");
+        }
+
+        return value;
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    private static Dictionary<string, string> Load()
+    {
+        if (!File.Exists(ConfigFile))
+            return new Dictionary<string, string>();
+
+        try
+        {
+            var json = File.ReadAllText(ConfigFile);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new();
+        }
+        catch
+        {
+            return new Dictionary<string, string>();
+        }
+    }
+
+    private static void Save(Dictionary<string, string> config)
+    {
+        Directory.CreateDirectory(ConfigDir);
+        File.WriteAllText(ConfigFile, JsonSerializer.Serialize(config, JsonOptions));
+    }
+}

--- a/cli/src/Infrastructure/NuGetStatsClient.cs
+++ b/cli/src/Infrastructure/NuGetStatsClient.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+
+namespace Ivy.Cli.Infrastructure;
+
+public sealed class NuGetStatsClient
+{
+    private readonly HttpClient _http;
+
+    public NuGetStatsClient(string baseUrl, string? apiKey = null)
+    {
+        _http = new HttpClient
+        {
+            BaseAddress = new Uri(baseUrl.TrimEnd('/') + "/")
+        };
+        if (!string.IsNullOrEmpty(apiKey))
+            _http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+    }
+
+    public async Task<JsonDocument> GetAsync(string path)
+    {
+        var response = await _http.GetAsync(path);
+        if (!response.IsSuccessStatusCode)
+        {
+            var err = await response.Content.ReadAsStringAsync();
+            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {err}");
+        }
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+}

--- a/cli/src/Infrastructure/SliplaneClient.cs
+++ b/cli/src/Infrastructure/SliplaneClient.cs
@@ -1,0 +1,71 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Ivy.Cli.Infrastructure;
+
+public sealed class SliplaneClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly HttpClient _http;
+
+    public SliplaneClient(string apiKey, string? orgId = null)
+    {
+        _http = new HttpClient { BaseAddress = new Uri("https://ctrl.sliplane.io/v0/") };
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        if (!string.IsNullOrEmpty(orgId))
+            _http.DefaultRequestHeaders.Add("X-Organization-ID", orgId);
+    }
+
+    public async Task<JsonDocument> GetAsync(string path)
+    {
+        var response = await _http.GetAsync(path);
+        await EnsureSuccess(response);
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    public async Task<JsonDocument> PostAsync(string path, object? body = null)
+    {
+        var content = body is null
+            ? null
+            : new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync(path, content);
+        await EnsureSuccess(response);
+        if (response.Content.Headers.ContentLength == 0
+            || response.StatusCode == System.Net.HttpStatusCode.NoContent
+            || response.StatusCode == System.Net.HttpStatusCode.Accepted)
+            return JsonDocument.Parse("{}");
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    public async Task<JsonDocument> PatchAsync(string path, object body)
+    {
+        var content = new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json");
+        var response = await _http.PatchAsync(path, content);
+        await EnsureSuccess(response);
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    public async Task DeleteAsync(string path)
+    {
+        var response = await _http.DeleteAsync(path);
+        await EnsureSuccess(response);
+    }
+
+    private static async Task EnsureSuccess(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {body}");
+        }
+    }
+}

--- a/cli/src/Infrastructure/TendrilClient.cs
+++ b/cli/src/Infrastructure/TendrilClient.cs
@@ -1,0 +1,57 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Ivy.Cli.Infrastructure;
+
+/// <summary>
+/// HTTP client for the tendril-deploy REST API.
+/// Base URL is read from TENDRIL_BASE_URL env var or --tendril-url flag.
+/// Auth is optional: if TendrilDeploy:ApiKey is configured on the server,
+/// pass it via TENDRIL_API_KEY or --tendril-api-key.
+/// </summary>
+public sealed class TendrilClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly HttpClient _http;
+
+    public TendrilClient(string baseUrl, string? apiKey = null)
+    {
+        var uri = baseUrl.TrimEnd('/') + "/";
+        _http = new HttpClient { BaseAddress = new Uri(uri) };
+        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (!string.IsNullOrEmpty(apiKey))
+            _http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+    }
+
+    public async Task<JsonDocument> GetAsync(string path)
+    {
+        var response = await _http.GetAsync(path);
+        await EnsureSuccess(response);
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    public async Task<JsonDocument> PostAsync(string path, object body)
+    {
+        var content = new StringContent(JsonSerializer.Serialize(body, JsonOptions), Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync(path, content);
+        await EnsureSuccess(response);
+        var stream = await response.Content.ReadAsStreamAsync();
+        return await JsonDocument.ParseAsync(stream);
+    }
+
+    private static async Task EnsureSuccess(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {body}");
+        }
+    }
+}

--- a/cli/src/Infrastructure/TendrilClient.cs
+++ b/cli/src/Infrastructure/TendrilClient.cs
@@ -29,9 +29,12 @@ public sealed class TendrilClient
             _http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
     }
 
-    public async Task<JsonDocument> GetAsync(string path)
+    public async Task<JsonDocument> GetAsync(string path, string? sliplaneToken = null)
     {
-        var response = await _http.GetAsync(path);
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        if (!string.IsNullOrEmpty(sliplaneToken))
+            request.Headers.Add("X-Sliplane-Token", sliplaneToken);
+        var response = await _http.SendAsync(request);
         await EnsureSuccess(response);
         var stream = await response.Content.ReadAsStreamAsync();
         return await JsonDocument.ParseAsync(stream);

--- a/cli/src/Infrastructure/YamlOutput.cs
+++ b/cli/src/Infrastructure/YamlOutput.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Ivy.Cli.Infrastructure;
+
+public static class YamlOutput
+{
+    private static readonly ISerializer Serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public static void Write(JsonDocument doc)
+    {
+        var obj = JsonToObject(doc.RootElement);
+        Console.WriteLine(Serializer.Serialize(obj).TrimEnd());
+    }
+
+    public static void WriteObject(object obj)
+    {
+        Console.WriteLine(Serializer.Serialize(obj).TrimEnd());
+    }
+
+    private static object? JsonToObject(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Object  => element.EnumerateObject().ToDictionary(p => p.Name, p => JsonToObject(p.Value)),
+        JsonValueKind.Array   => element.EnumerateArray().Select(JsonToObject).ToList(),
+        JsonValueKind.String  => element.GetString(),
+        JsonValueKind.Number  => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+        JsonValueKind.True    => (object)true,
+        JsonValueKind.False   => false,
+        _                     => null
+    };
+}

--- a/cli/src/Ivy.Cli.csproj
+++ b/cli/src/Ivy.Cli.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <!-- dotnet tool settings -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>ivy</ToolCommandName>
+
+    <!-- NuGet package metadata -->
+    <PackageId>Ivy.Cli</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Ivy-Interactive</Authors>
+    <Description>Unified CLI for Ivy Interactive infrastructure — Sliplane, Tendrils, and more.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Ivy-Interactive/Ivy-Examples</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" Condition="Exists('..\..\README.md')" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+</Project>

--- a/cli/src/Ivy.Cli.csproj
+++ b/cli/src/Ivy.Cli.csproj
@@ -7,7 +7,7 @@
 
     <!-- dotnet tool settings -->
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>ivy</ToolCommandName>
+    <ToolCommandName>ivy-examples</ToolCommandName>
 
     <!-- NuGet package metadata -->
     <PackageId>Ivy.Cli</PackageId>

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -1,5 +1,5 @@
 using Ivy.Cli.Commands.Config;
-
+using Ivy.Cli.Commands.NuGet;
 using Ivy.Cli.Commands.Sliplane;
 using Ivy.Cli.Commands.Sliplane.Credentials;
 using Ivy.Cli.Commands.Sliplane.OAuth;
@@ -147,6 +147,24 @@ app.Configure(config =>
             branch.AddCommand<ListOAuthClientUsersCommand>("users")
                 .WithDescription("List OAuth client users");
         });
+    });
+
+    // ── NuGet stats (IvyInsights) ─────────────────────────────────────
+    config.AddBranch("nuget", nuget =>
+    {
+        nuget.SetDescription("NuGet package statistics (IvyInsights)");
+        nuget.AddCommand<NuGetSummaryCommand>("summary")
+            .WithDescription("Overall stats summary");
+        nuget.AddCommand<NuGetStarsCommand>("stars")
+            .WithDescription("Star counts per package");
+        nuget.AddCommand<NuGetStarredCommand>("starred")
+            .WithDescription("List starred packages");
+        nuget.AddCommand<NuGetUnstarredCommand>("unstarred")
+            .WithDescription("List unstarred packages");
+        nuget.AddCommand<NuGetDownloadsCommand>("downloads")
+            .WithDescription("Download counts per package");
+        nuget.AddCommand<NuGetDownloadsHistoryCommand>("downloads-history")
+            .WithDescription("Download history over time");
     });
 
     // ── Tendril ───────────────────────────────────────────────────────

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -9,6 +9,21 @@ using Ivy.Cli.Commands.Sliplane.Services;
 using Ivy.Cli.Commands.Tendrils;
 using Spectre.Console.Cli;
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Command description style guide
+//
+// Top-level branches: "<Action> <project> <scope>" — e.g. "Manage Sliplane resources".
+// Sub-branches:       "Manage <resource-plural>"   — context (Sliplane/...) comes from path.
+// Leaf commands follow a verb-first imperative pattern in Title case:
+//   list   → "List <resource-plural>"
+//   get    → "Get <resource>"
+//   create → "Create <resource>"
+//   update → "Update <resource>"
+//   delete → "Delete <resource>"
+//   other  → "<Verb> <resource>"   (e.g. "Pause service", "Rescale server")
+// Keep descriptions short (≤ 60 chars). Put usage examples in README, not in descriptions.
+// ─────────────────────────────────────────────────────────────────────────────
+
 var app = new CommandApp();
 
 app.Configure(config =>
@@ -16,138 +31,138 @@ app.Configure(config =>
     config.SetApplicationName("ivy");
     config.SetApplicationVersion("0.1.0");
 
-    // ── Config ────────────────────────────────────────────────────────
+    // ── Config (CLI-wide) ─────────────────────────────────────────────
     config.AddBranch("config", cfg =>
     {
         cfg.SetDescription("Manage saved CLI configuration (~/.ivy/config.json)");
         cfg.AddCommand<ConfigListCommand>("list")
-            .WithDescription("Show all saved config values");
+            .WithDescription("List config values");
         cfg.AddCommand<ConfigGetCommand>("get")
-            .WithDescription("Get a saved config value");
+            .WithDescription("Get config value");
         cfg.AddCommand<ConfigSetCommand>("set")
-            .WithDescription("Save a config value (e.g. ivy config set sliplane_api_key sk-xxx)");
+            .WithDescription("Set config value");
         cfg.AddCommand<ConfigUnsetCommand>("unset")
-            .WithDescription("Remove a single config value (e.g. ivy config unset sliplane_api_key)");
+            .WithDescription("Unset config value");
         cfg.AddCommand<ConfigClearCommand>("clear")
-            .WithDescription("Delete all saved config from ~/.ivy/config.json");
+            .WithDescription("Clear all config");
     });
 
-    // ── Sliplane: identity ─────────────────────────────────────────────
-    config.AddCommand<MeCommand>("me")
-        .WithDescription("Get current Sliplane identity and token context");
-
-    // ── Sliplane: projects ─────────────────────────────────────────────
-    config.AddBranch("projects", branch =>
+    // ── Sliplane ──────────────────────────────────────────────────────
+    config.AddBranch("sliplane", sliplane =>
     {
-        branch.SetDescription("Manage Sliplane projects");
-        branch.AddCommand<ListProjectsCommand>("list")
-            .WithDescription("List all projects");
-        branch.AddCommand<CreateProjectCommand>("create")
-            .WithDescription("Create a new project");
-        branch.AddCommand<UpdateProjectCommand>("update")
-            .WithDescription("Update a project name");
-        branch.AddCommand<DeleteProjectCommand>("delete")
-            .WithDescription("Delete a project");
+        sliplane.SetDescription("Manage Sliplane resources");
+
+        sliplane.AddCommand<MeCommand>("me")
+            .WithDescription("Get current identity");
+
+        sliplane.AddBranch("projects", branch =>
+        {
+            branch.SetDescription("Manage projects");
+            branch.AddCommand<ListProjectsCommand>("list")
+                .WithDescription("List projects");
+            branch.AddCommand<CreateProjectCommand>("create")
+                .WithDescription("Create project");
+            branch.AddCommand<UpdateProjectCommand>("update")
+                .WithDescription("Update project");
+            branch.AddCommand<DeleteProjectCommand>("delete")
+                .WithDescription("Delete project");
+        });
+
+        sliplane.AddBranch("servers", branch =>
+        {
+            branch.SetDescription("Manage servers");
+            branch.AddCommand<ListServersCommand>("list")
+                .WithDescription("List servers");
+            branch.AddCommand<GetServerCommand>("get")
+                .WithDescription("Get server");
+            branch.AddCommand<CreateServerCommand>("create")
+                .WithDescription("Create server");
+            branch.AddCommand<DeleteServerCommand>("delete")
+                .WithDescription("Delete server");
+            branch.AddCommand<RescaleServerCommand>("rescale")
+                .WithDescription("Rescale server (scale up only)");
+            branch.AddCommand<ServerMetricsCommand>("metrics")
+                .WithDescription("Get server metrics");
+            branch.AddCommand<ListServerVolumesCommand>("volumes")
+                .WithDescription("List server volumes");
+            branch.AddCommand<CreateServerVolumeCommand>("create-volume")
+                .WithDescription("Create server volume");
+        });
+
+        sliplane.AddBranch("services", branch =>
+        {
+            branch.SetDescription("Manage services");
+            branch.AddCommand<ListServicesCommand>("list")
+                .WithDescription("List services");
+            branch.AddCommand<GetServiceCommand>("get")
+                .WithDescription("Get service");
+            branch.AddCommand<CreateServiceCommand>("create")
+                .WithDescription("Create service");
+            branch.AddCommand<UpdateServiceCommand>("update")
+                .WithDescription("Update service");
+            branch.AddCommand<DeleteServiceCommand>("delete")
+                .WithDescription("Delete service");
+            branch.AddCommand<PauseServiceCommand>("pause")
+                .WithDescription("Pause service");
+            branch.AddCommand<UnpauseServiceCommand>("unpause")
+                .WithDescription("Unpause service");
+            branch.AddCommand<DeployServiceCommand>("deploy")
+                .WithDescription("Deploy service");
+            branch.AddCommand<ServiceLogsCommand>("logs")
+                .WithDescription("Get service logs");
+            branch.AddCommand<ServiceMetricsCommand>("metrics")
+                .WithDescription("Get service metrics");
+            branch.AddCommand<ServiceEventsCommand>("events")
+                .WithDescription("Get service events");
+            branch.AddCommand<AddDomainCommand>("add-domain")
+                .WithDescription("Add service domain");
+            branch.AddCommand<RemoveDomainCommand>("remove-domain")
+                .WithDescription("Remove service domain");
+        });
+
+        sliplane.AddBranch("credentials", branch =>
+        {
+            branch.SetDescription("Manage registry credentials");
+            branch.AddCommand<ListCredentialsCommand>("list")
+                .WithDescription("List credentials");
+            branch.AddCommand<GetCredentialsCommand>("get")
+                .WithDescription("Get credentials");
+            branch.AddCommand<CreateCredentialsCommand>("create")
+                .WithDescription("Create credentials");
+            branch.AddCommand<UpdateCredentialsCommand>("update")
+                .WithDescription("Update credentials");
+            branch.AddCommand<DeleteCredentialsCommand>("delete")
+                .WithDescription("Delete credentials");
+        });
+
+        sliplane.AddBranch("oauth", branch =>
+        {
+            branch.SetDescription("Manage OAuth clients");
+            branch.AddCommand<ListOAuthClientsCommand>("list")
+                .WithDescription("List OAuth clients");
+            branch.AddCommand<GetOAuthClientCommand>("get")
+                .WithDescription("Get OAuth client");
+            branch.AddCommand<UpdateOAuthClientCommand>("update")
+                .WithDescription("Update OAuth client");
+            branch.AddCommand<ListOAuthClientUsersCommand>("users")
+                .WithDescription("List OAuth client users");
+        });
     });
 
-    // ── Sliplane: servers ──────────────────────────────────────────────
-    config.AddBranch("servers", branch =>
-    {
-        branch.SetDescription("Manage Sliplane servers");
-        branch.AddCommand<ListServersCommand>("list")
-            .WithDescription("List all servers");
-        branch.AddCommand<GetServerCommand>("get")
-            .WithDescription("Get server details");
-        branch.AddCommand<CreateServerCommand>("create")
-            .WithDescription("Create a new server");
-        branch.AddCommand<DeleteServerCommand>("delete")
-            .WithDescription("Delete a server");
-        branch.AddCommand<RescaleServerCommand>("rescale")
-            .WithDescription("Rescale a server (scale up only)");
-        branch.AddCommand<ServerMetricsCommand>("metrics")
-            .WithDescription("Get server metrics");
-        branch.AddCommand<ListServerVolumesCommand>("volumes")
-            .WithDescription("List server volumes");
-        branch.AddCommand<CreateServerVolumeCommand>("create-volume")
-            .WithDescription("Create a volume on a server");
-    });
-
-    // ── Sliplane: services ─────────────────────────────────────────────
-    config.AddBranch("services", branch =>
-    {
-        branch.SetDescription("Manage Sliplane services");
-        branch.AddCommand<ListServicesCommand>("list")
-            .WithDescription("List services in a project (or all projects)");
-        branch.AddCommand<GetServiceCommand>("get")
-            .WithDescription("Get service details");
-        branch.AddCommand<CreateServiceCommand>("create")
-            .WithDescription("Create a new service");
-        branch.AddCommand<UpdateServiceCommand>("update")
-            .WithDescription("Update a service");
-        branch.AddCommand<DeleteServiceCommand>("delete")
-            .WithDescription("Delete a service");
-        branch.AddCommand<PauseServiceCommand>("pause")
-            .WithDescription("Pause a service");
-        branch.AddCommand<UnpauseServiceCommand>("unpause")
-            .WithDescription("Unpause a service");
-        branch.AddCommand<DeployServiceCommand>("deploy")
-            .WithDescription("Trigger a deployment");
-        branch.AddCommand<ServiceLogsCommand>("logs")
-            .WithDescription("Get service logs");
-        branch.AddCommand<ServiceMetricsCommand>("metrics")
-            .WithDescription("Get service metrics");
-        branch.AddCommand<ServiceEventsCommand>("events")
-            .WithDescription("Get service events");
-        branch.AddCommand<AddDomainCommand>("add-domain")
-            .WithDescription("Add a custom domain");
-        branch.AddCommand<RemoveDomainCommand>("remove-domain")
-            .WithDescription("Remove a custom domain");
-    });
-
-    // ── Sliplane: registry credentials ────────────────────────────────
-    config.AddBranch("credentials", branch =>
-    {
-        branch.SetDescription("Manage Sliplane registry credentials");
-        branch.AddCommand<ListCredentialsCommand>("list")
-            .WithDescription("List all registry credentials");
-        branch.AddCommand<GetCredentialsCommand>("get")
-            .WithDescription("Get registry credentials details");
-        branch.AddCommand<CreateCredentialsCommand>("create")
-            .WithDescription("Create registry credentials");
-        branch.AddCommand<UpdateCredentialsCommand>("update")
-            .WithDescription("Update registry credentials name");
-        branch.AddCommand<DeleteCredentialsCommand>("delete")
-            .WithDescription("Delete registry credentials");
-    });
-
-    // ── Sliplane: OAuth ────────────────────────────────────────────────
-    config.AddBranch("oauth", branch =>
-    {
-        branch.SetDescription("Manage Sliplane OAuth clients");
-        branch.AddCommand<ListOAuthClientsCommand>("list")
-            .WithDescription("List OAuth clients");
-        branch.AddCommand<GetOAuthClientCommand>("get")
-            .WithDescription("Get OAuth client details");
-        branch.AddCommand<UpdateOAuthClientCommand>("update")
-            .WithDescription("Update OAuth client metadata");
-        branch.AddCommand<ListOAuthClientUsersCommand>("users")
-            .WithDescription("List OAuth client authorized users");
-    });
-
-    // ── Tendrils ───────────────────────────────────────────────────────
+    // ── Tendril ───────────────────────────────────────────────────────
     // Requires: TENDRIL_BASE_URL (+ TENDRIL_API_KEY if server has key configured)
     //           SLIPLANE_API_KEY (for status/servers/projects that forward to Sliplane)
-    config.AddBranch("tendrils", branch =>
+    config.AddBranch("tendril", tendril =>
     {
-        branch.SetDescription("Deploy and manage Tendril instances via tendril-deploy API");
-        branch.AddCommand<DeployTendrilCommand>("deploy")
-            .WithDescription("Deploy a new Tendril instance on Sliplane");
-        branch.AddCommand<GetTendrilStatusCommand>("status")
-            .WithDescription("Get status of a deployed Tendril service");
-        branch.AddCommand<ListTendrilServersCommand>("servers")
-            .WithDescription("List Sliplane servers available for Tendril deployment");
-        branch.AddCommand<ListTendrilProjectsCommand>("projects")
-            .WithDescription("List Sliplane projects available for Tendril deployment");
+        tendril.SetDescription("Manage Tendril deployments");
+        tendril.AddCommand<DeployTendrilCommand>("deploy")
+            .WithDescription("Deploy Tendril instance");
+        tendril.AddCommand<GetTendrilStatusCommand>("status")
+            .WithDescription("Get Tendril status");
+        tendril.AddCommand<ListTendrilServersCommand>("servers")
+            .WithDescription("List available servers");
+        tendril.AddCommand<ListTendrilProjectsCommand>("projects")
+            .WithDescription("List available projects");
     });
 });
 

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -28,7 +28,7 @@ var app = new CommandApp();
 
 app.Configure(config =>
 {
-    config.SetApplicationName("ivy");
+    config.SetApplicationName("ivy-examples");
     config.SetApplicationVersion("0.1.0");
 
     // ── Config (CLI-wide) ─────────────────────────────────────────────

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -149,10 +149,10 @@ app.Configure(config =>
         });
     });
 
-    // ── NuGet stats (IvyInsights) ─────────────────────────────────────
+    // ── NuGet ─────────────────────────────────────────────────────────
     config.AddBranch("nuget", nuget =>
     {
-        nuget.SetDescription("NuGet package statistics (IvyInsights)");
+        nuget.SetDescription("Manage NuGet package statistics");
         nuget.AddCommand<NuGetSummaryCommand>("summary")
             .WithDescription("Overall stats summary");
         nuget.AddCommand<NuGetStarsCommand>("stars")

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -1,0 +1,136 @@
+using Ivy.Cli.Commands.Sliplane;
+using Ivy.Cli.Commands.Sliplane.Credentials;
+using Ivy.Cli.Commands.Sliplane.OAuth;
+using Ivy.Cli.Commands.Sliplane.Projects;
+using Ivy.Cli.Commands.Sliplane.Servers;
+using Ivy.Cli.Commands.Sliplane.Services;
+using Ivy.Cli.Commands.Tendrils;
+using Spectre.Console.Cli;
+
+var app = new CommandApp();
+
+app.Configure(config =>
+{
+    config.SetApplicationName("ivy");
+    config.SetApplicationVersion("0.1.0");
+
+    // ── Sliplane: identity ─────────────────────────────────────────────
+    config.AddCommand<MeCommand>("me")
+        .WithDescription("Get current Sliplane identity and token context");
+
+    // ── Sliplane: projects ─────────────────────────────────────────────
+    config.AddBranch("projects", branch =>
+    {
+        branch.SetDescription("Manage Sliplane projects");
+        branch.AddCommand<ListProjectsCommand>("list")
+            .WithDescription("List all projects");
+        branch.AddCommand<CreateProjectCommand>("create")
+            .WithDescription("Create a new project");
+        branch.AddCommand<UpdateProjectCommand>("update")
+            .WithDescription("Update a project name");
+        branch.AddCommand<DeleteProjectCommand>("delete")
+            .WithDescription("Delete a project");
+    });
+
+    // ── Sliplane: servers ──────────────────────────────────────────────
+    config.AddBranch("servers", branch =>
+    {
+        branch.SetDescription("Manage Sliplane servers");
+        branch.AddCommand<ListServersCommand>("list")
+            .WithDescription("List all servers");
+        branch.AddCommand<GetServerCommand>("get")
+            .WithDescription("Get server details");
+        branch.AddCommand<CreateServerCommand>("create")
+            .WithDescription("Create a new server");
+        branch.AddCommand<DeleteServerCommand>("delete")
+            .WithDescription("Delete a server");
+        branch.AddCommand<RescaleServerCommand>("rescale")
+            .WithDescription("Rescale a server (scale up only)");
+        branch.AddCommand<ServerMetricsCommand>("metrics")
+            .WithDescription("Get server metrics");
+        branch.AddCommand<ListServerVolumesCommand>("volumes")
+            .WithDescription("List server volumes");
+        branch.AddCommand<CreateServerVolumeCommand>("create-volume")
+            .WithDescription("Create a volume on a server");
+    });
+
+    // ── Sliplane: services ─────────────────────────────────────────────
+    config.AddBranch("services", branch =>
+    {
+        branch.SetDescription("Manage Sliplane services");
+        branch.AddCommand<ListServicesCommand>("list")
+            .WithDescription("List services in a project (or all projects)");
+        branch.AddCommand<GetServiceCommand>("get")
+            .WithDescription("Get service details");
+        branch.AddCommand<CreateServiceCommand>("create")
+            .WithDescription("Create a new service");
+        branch.AddCommand<UpdateServiceCommand>("update")
+            .WithDescription("Update a service");
+        branch.AddCommand<DeleteServiceCommand>("delete")
+            .WithDescription("Delete a service");
+        branch.AddCommand<PauseServiceCommand>("pause")
+            .WithDescription("Pause a service");
+        branch.AddCommand<UnpauseServiceCommand>("unpause")
+            .WithDescription("Unpause a service");
+        branch.AddCommand<DeployServiceCommand>("deploy")
+            .WithDescription("Trigger a deployment");
+        branch.AddCommand<ServiceLogsCommand>("logs")
+            .WithDescription("Get service logs");
+        branch.AddCommand<ServiceMetricsCommand>("metrics")
+            .WithDescription("Get service metrics");
+        branch.AddCommand<ServiceEventsCommand>("events")
+            .WithDescription("Get service events");
+        branch.AddCommand<AddDomainCommand>("add-domain")
+            .WithDescription("Add a custom domain");
+        branch.AddCommand<RemoveDomainCommand>("remove-domain")
+            .WithDescription("Remove a custom domain");
+    });
+
+    // ── Sliplane: registry credentials ────────────────────────────────
+    config.AddBranch("credentials", branch =>
+    {
+        branch.SetDescription("Manage Sliplane registry credentials");
+        branch.AddCommand<ListCredentialsCommand>("list")
+            .WithDescription("List all registry credentials");
+        branch.AddCommand<GetCredentialsCommand>("get")
+            .WithDescription("Get registry credentials details");
+        branch.AddCommand<CreateCredentialsCommand>("create")
+            .WithDescription("Create registry credentials");
+        branch.AddCommand<UpdateCredentialsCommand>("update")
+            .WithDescription("Update registry credentials name");
+        branch.AddCommand<DeleteCredentialsCommand>("delete")
+            .WithDescription("Delete registry credentials");
+    });
+
+    // ── Sliplane: OAuth ────────────────────────────────────────────────
+    config.AddBranch("oauth", branch =>
+    {
+        branch.SetDescription("Manage Sliplane OAuth clients");
+        branch.AddCommand<ListOAuthClientsCommand>("list")
+            .WithDescription("List OAuth clients");
+        branch.AddCommand<GetOAuthClientCommand>("get")
+            .WithDescription("Get OAuth client details");
+        branch.AddCommand<UpdateOAuthClientCommand>("update")
+            .WithDescription("Update OAuth client metadata");
+        branch.AddCommand<ListOAuthClientUsersCommand>("users")
+            .WithDescription("List OAuth client authorized users");
+    });
+
+    // ── Tendrils ───────────────────────────────────────────────────────
+    // Requires: TENDRIL_BASE_URL (+ TENDRIL_API_KEY if server has key configured)
+    //           SLIPLANE_API_KEY (for status/servers/projects that forward to Sliplane)
+    config.AddBranch("tendrils", branch =>
+    {
+        branch.SetDescription("Deploy and manage Tendril instances via tendril-deploy API");
+        branch.AddCommand<DeployTendrilCommand>("deploy")
+            .WithDescription("Deploy a new Tendril instance on Sliplane");
+        branch.AddCommand<GetTendrilStatusCommand>("status")
+            .WithDescription("Get status of a deployed Tendril service");
+        branch.AddCommand<ListTendrilServersCommand>("servers")
+            .WithDescription("List Sliplane servers available for Tendril deployment");
+        branch.AddCommand<ListTendrilProjectsCommand>("projects")
+            .WithDescription("List Sliplane projects available for Tendril deployment");
+    });
+});
+
+return app.Run(args);

--- a/cli/src/Program.cs
+++ b/cli/src/Program.cs
@@ -1,3 +1,5 @@
+using Ivy.Cli.Commands.Config;
+
 using Ivy.Cli.Commands.Sliplane;
 using Ivy.Cli.Commands.Sliplane.Credentials;
 using Ivy.Cli.Commands.Sliplane.OAuth;
@@ -13,6 +15,22 @@ app.Configure(config =>
 {
     config.SetApplicationName("ivy");
     config.SetApplicationVersion("0.1.0");
+
+    // ── Config ────────────────────────────────────────────────────────
+    config.AddBranch("config", cfg =>
+    {
+        cfg.SetDescription("Manage saved CLI configuration (~/.ivy/config.json)");
+        cfg.AddCommand<ConfigListCommand>("list")
+            .WithDescription("Show all saved config values");
+        cfg.AddCommand<ConfigGetCommand>("get")
+            .WithDescription("Get a saved config value");
+        cfg.AddCommand<ConfigSetCommand>("set")
+            .WithDescription("Save a config value (e.g. ivy config set sliplane_api_key sk-xxx)");
+        cfg.AddCommand<ConfigUnsetCommand>("unset")
+            .WithDescription("Remove a single config value (e.g. ivy config unset sliplane_api_key)");
+        cfg.AddCommand<ConfigClearCommand>("clear")
+            .WithDescription("Delete all saved config from ~/.ivy/config.json");
+    });
 
     // ── Sliplane: identity ─────────────────────────────────────────────
     config.AddCommand<MeCommand>("me")


### PR DESCRIPTION
## Summary

Adds a new `ivy-examples` CLI tool under `cli/` — a unified command-line interface
for Ivy Interactive infrastructure built with C# (.NET 10) and Spectre.Console.

## Commands

### `config`
Persistent configuration stored in `~/.ivy/config.json`. Keys are resolved via
flag → env var → config file → interactive prompt (with an option to save).

- `config list` — show all saved values (secrets masked)
- `config get <key>` / `set <key> <value>` / `unset <key>` / `clear`

### `sliplane`
Full coverage of the Sliplane API: projects, servers, services, credentials, OAuth clients.

### `tendril`
- `tendril deploy` — interactive wizard: server → project → service name → credentials →
  API keys (optional) → repos → volume → confirm
- `tendril status` — interactive service picker with live status colors
- `tendril servers` / `tendril projects`

### `nuget`
NuGet package statistics via IvyInsights (`https://ivy-nuget-stats.sliplane.app`):

- `nuget summary` — overall stats
- `nuget stars` — star counts per package
- `nuget starred` / `nuget unstarred`
- `nuget downloads` / `nuget downloads-history`

## Infrastructure

- `SliplaneClient` — wraps `https://ctrl.sliplane.io/v0/`
- `TendrilClient` — wraps the tendril-deploy API
- `NuGetStatsClient` — wraps IvyInsights
- `ConfigStore` — reads/writes `~/.ivy/config.json`
- `YamlOutput` — renders JSON responses as YAML

## UX Details

- All prompts follow a consistent style: white labels, green selections/input, dim hints, red errors
- Confirmation prompts show `[y/n] (n)` in green
- Optional fields show `(optional)` hint
- Previous selections remain visible after choosing from a list
- No blank lines between prompts

## Installation

```bash
cd cli/src
dotnet pack
dotnet tool install --global --add-source ./nupkg Ivy.Cli
```


<img width="300" height="302" alt="Знімок екрана 2026-05-07 о 19 38 29" src="https://github.com/user-attachments/assets/4d9a4487-e519-4a17-8095-68000aabf230" />

https://github.com/user-attachments/assets/82b28f13-f684-494e-809f-b790d7005dd6
### ivy-examples config
<img width="410" height="242" alt="Знімок екрана 2026-05-07 о 19 49 05" src="https://github.com/user-attachments/assets/fcd5b1ab-ae8a-4fac-8fbd-85e23a5891b4" />

### ivy-examples sliplane
<img width="441" height="259" alt="Знімок екрана 2026-05-07 о 19 49 34" src="https://github.com/user-attachments/assets/4bdbb8e0-3b0e-41a7-ae9e-18a68a1c6da9" />

### ivy-examples nuget
<img width="418" height="249" alt="Знімок екрана 2026-05-07 о 19 49 52" src="https://github.com/user-attachments/assets/d4493304-835e-45b4-9520-30863e08d6e5" />

### ivy-examples tendril
<img width="421" height="233" alt="Знімок екрана 2026-05-07 о 19 50 05" src="https://github.com/user-attachments/assets/3881b974-e2be-4342-b3a8-ba718c8c5175" />

