### PR TITLE
[tendril-deploy]: remove workspace repo step from deploy wizard

### DIFF
--- a/project-demos/tendril-deploy/Api/DeployRequest.cs
+++ b/project-demos/tendril-deploy/Api/DeployRequest.cs
@@ -92,7 +92,7 @@ public sealed class DeployRequest
 
     /// <summary>
     /// Sliplane persistent volume ID to attach at <c>TendrilHome</c>.
-    /// Without a volume, data is lost on redeploy.
+    /// If omitted, a new volume is created on <see cref="ServerId"/> (name derived from <see cref="ServiceName"/>).
     /// </summary>
     public string? VolumeId { get; set; }
 

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -267,9 +267,17 @@ public class TendrilDeployView : ViewBase
                     ? TendrilCloneBootstrap.BuildServiceCmdWrapped()
                     : null;
 
+                var volumeId = m.VolumeId?.Trim();
+                if (string.IsNullOrWhiteSpace(volumeId))
+                {
+                    var volumeName = TendrilDeployService.AutoDataVolumeName(m.Name);
+                    var created = await client.CreateVolumeAsync(_apiToken, m.ServerId, volumeName);
+                    volumeId = created.Id;
+                }
+
                 List<(string VolumeId, string MountPath)>? volumes = null;
-                if (!string.IsNullOrWhiteSpace(m.VolumeId))
-                    volumes = [(m.VolumeId.Trim(), home)];
+                if (!string.IsNullOrWhiteSpace(volumeId))
+                    volumes = [(volumeId, home)];
 
                 var service = await client.CreateServiceAsync(_apiToken, m.ProjectId,
                     ServiceRequestFactory.BuildCreateRequest(

--- a/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
+++ b/project-demos/tendril-deploy/Apps/Views/TendrilDeployView.cs
@@ -125,10 +125,6 @@ public class TendrilDeployView : ViewBase
         /// so we freeze the validated step-0 model and deploy from this snapshot.
         /// </summary>
         var validatedDeployForm = UseState<TendrilDeployFormModel?>(() => null);
-        var repoCloneRows = UseState(() => new List<TendrilBootstrapRepoEntry>
-        {
-            new(Guid.NewGuid(), "")
-        });
         var deployedService = UseState<(string ProjectId, SliplaneService Service)?>(() => null);
         var deployError = UseState<string?>(() => null);
         var validationFailed = UseState(false);
@@ -202,19 +198,7 @@ public class TendrilDeployView : ViewBase
                 return;
             }
 
-            List<EnvironmentVariable> cloneEnvVars;
-            try
-            {
-                cloneEnvVars = TendrilCloneBootstrap.BuildCloneEnvVars(
-                    repoCloneRows.Value
-                        .Select(e => new TendrilCloneBootstrap.Row(e.CloneUrl))
-                        .ToList());
-            }
-            catch (ArgumentException ex)
-            {
-                deployError.Set(ex.Message);
-                return;
-            }
+            var cloneEnvVars = new List<EnvironmentVariable>();
 
             var anthropic = (anthropicKey.Value ?? "").Trim();
             var claudeOAuth = (claudeOAuthToken.Value ?? "").Trim();
@@ -234,7 +218,7 @@ public class TendrilDeployView : ViewBase
                 deployError.Set(ex.Message);
                 basicAuthStepError.Set(ex.Message);
                 basicAuthValidationFailed.Set(true);
-                stepIndex.Set(3);
+                stepIndex.Set(2);
                 return;
             }
 
@@ -410,8 +394,7 @@ public class TendrilDeployView : ViewBase
         {
             new StepperItem("1", stepIndex.Value > 0 ? Icons.Check : null, "Welcome", "Server & name"),
             new StepperItem("2", stepIndex.Value > 1 ? Icons.Check : null, "Secrets", "API keys"),
-            new StepperItem("3", stepIndex.Value > 2 ? Icons.Check : null, "Repositories", "Workspaces"),
-            new StepperItem("4", deployedService.Value != null ? Icons.Check : null, "Login", "Basic auth"),
+            new StepperItem("3", deployedService.Value != null ? Icons.Check : null, "Login", "Basic auth"),
         };
 
         ValueTask OnStepperSelect(Event<Stepper, int> e)
@@ -420,47 +403,12 @@ public class TendrilDeployView : ViewBase
             {
                 stepIndex.Set(e.Value);
                 if (e.Value == 0)
-                {
                     validatedDeployForm.Set(null);
-                    repoCloneRows.Set([new TendrilBootstrapRepoEntry(Guid.NewGuid(), "")]);
-                }
             }
 
             return ValueTask.CompletedTask;
         }
 
-        var reposHintCallout = new Callout(
-            Text.Markdown(
-                """
-                Each filled row is one repo cloned when the container starts. In Tendril project settings, **Your repository folder** must be the **path inside the container** (the folder that contains `.git`), not the clone URL.
-
-                **Example**
-
-                - `TENDRIL_HOME` is `/data/tendril`
-                - This row is `https://github.com/acme/hello-world`
-                - After startup the repo is at `/data/tendril/repos/acme/hello-world`
-                - So in **Your repository folder** enter: `/data/tendril/repos/acme/hello-world`
-                """.ReplaceLineEndings("\n")),
-            "Repositories",
-            CalloutVariant.Info);
-
-        object repoSections = Layout.Vertical().Gap(4).Width(Size.Full())
-            | Text.H4("Repositories")
-            | Text.Block("One URL per row. Leave empty to skip. Add adds another row.")
-            | (Layout.Vertical().Gap(2).Width(Size.Full())
-                | repoCloneRows.Value.Select(e => (object)new TendrilBootstrapRepoRowView(e.Id, repoCloneRows))
-                    .ToArray())
-            | new Button("Add").Icon(Icons.Plus).Outline()
-                .OnClick(_ =>
-                {
-                    repoCloneRows.Set(xs =>
-                    {
-                        var copy = xs.ToList();
-                        copy.Add(new TendrilBootstrapRepoEntry(Guid.NewGuid(), ""));
-                        return copy;
-                    });
-                    return ValueTask.CompletedTask;
-                });
         var welcomeNoteCallout = new Callout(
             Layout.Vertical().Gap(3)
                 | Text.Block(
@@ -487,8 +435,6 @@ public class TendrilDeployView : ViewBase
                 | Text.H1("Welcome to Ivy Tendril").Align(TextAlignment.Center),
             1 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
                 | Text.H1("API keys").Align(TextAlignment.Center),
-            2 => Layout.Vertical().Gap(2).AlignContent(Align.Center)
-                | Text.H1("Repositories").Align(TextAlignment.Center),
             _ => Layout.Vertical().Gap(2).AlignContent(Align.Center)
                 | Text.H1("Protect your deployment").Align(TextAlignment.Center),
         };
@@ -502,9 +448,6 @@ public class TendrilDeployView : ViewBase
             1 => Layout.Vertical().Gap(4).Width(Size.Full())
                 | secretsHintCallout
                 | agentSections,
-            2 => Layout.Vertical().Gap(4).Width(Size.Full())
-                | reposHintCallout
-                | repoSections,
             _ => Layout.Vertical().Gap(4).Width(Size.Full())
                 | basicAuthSections,
         };
@@ -532,7 +475,6 @@ public class TendrilDeployView : ViewBase
                     {
                         stepIndex.Set(0);
                         validatedDeployForm.Set(null);
-                        repoCloneRows.Set([new TendrilBootstrapRepoEntry(Guid.NewGuid(), "")]);
                         return ValueTask.CompletedTask;
                     })
                 | new Spacer()
@@ -548,31 +490,6 @@ public class TendrilDeployView : ViewBase
                         stepIndex.Set(2);
                         return ValueTask.CompletedTask;
                     }),
-            2 => Layout.Horizontal().Width(Size.Full()).Gap(4)
-                | new Button("Back")
-                    .Icon(Icons.ChevronLeft)
-                    .Variant(ButtonVariant.Outline)
-                    .Large()
-                    .BorderRadius(BorderRadius.Full)
-                    .Width(Size.Fraction(0.31f))
-                    .OnClick(_ =>
-                    {
-                        stepIndex.Set(1);
-                        return ValueTask.CompletedTask;
-                    })
-                | new Spacer()
-                | new Button("Continue")
-                    .Icon(Icons.ChevronRight, Align.Right)
-                    .Primary()
-                    .Large()
-                    .BorderRadius(BorderRadius.Full)
-                    .Width(Size.Fraction(0.31f))
-                    .OnClick(async _ =>
-                    {
-                        basicAuthValidationFailed.Set(false);
-                        stepIndex.Set(3);
-                        await Task.CompletedTask;
-                    }),
             _ => Layout.Horizontal().Width(Size.Full()).Gap(4)
                 | new Button("Back")
                     .Icon(Icons.ChevronLeft)
@@ -582,7 +499,7 @@ public class TendrilDeployView : ViewBase
                     .Width(Size.Fraction(0.31f))
                     .OnClick(_ =>
                     {
-                        stepIndex.Set(2);
+                        stepIndex.Set(1);
                         return ValueTask.CompletedTask;
                     })
                 | new Spacer()

--- a/project-demos/tendril-deploy/Models/SliplaneModels.cs
+++ b/project-demos/tendril-deploy/Models/SliplaneModels.cs
@@ -47,6 +47,8 @@ public record SliplaneServiceDomain(string Id, string Domain, bool IsCustom);
 
 public record SliplaneServiceVolumeInfo(string Id, string Name, string MountPath);
 
+public record SliplaneVolume(string Id, string Name);
+
 public record SliplaneServiceResources(double CpuLimit, int MemoryLimit);
 
 public record SliplaneServiceNetwork(

--- a/project-demos/tendril-deploy/Services/SliplaneApiClient.cs
+++ b/project-demos/tendril-deploy/Services/SliplaneApiClient.cs
@@ -71,6 +71,51 @@ public class SliplaneApiClient
         return await ParseObjectAsync<SliplaneService>(response);
     }
 
+    /// <summary>POST /servers/{serverId}/volumes — 201 returns <c>id</c> and <c>name</c>.</summary>
+    public async Task<SliplaneVolume> CreateVolumeAsync(string apiToken, string serverId, string name)
+    {
+        var body = new { name };
+        var response = await SendAsync(HttpMethod.Post, $"/servers/{serverId}/volumes", apiToken, body);
+
+        if (response == null)
+        {
+            throw new InvalidOperationException(
+                "Sliplane API did not respond when creating the volume. Check your network connection and API token.");
+        }
+
+        var responseBody = string.Empty;
+        try
+        {
+            responseBody = await response.Content.ReadAsStringAsync();
+        }
+        catch
+        {
+            // leave empty
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var message = $"Sliplane API returned {(int)response.StatusCode} {response.StatusCode} when creating the volume.";
+            if (!string.IsNullOrWhiteSpace(responseBody))
+                message += $" Details: {responseBody}";
+
+            throw new InvalidOperationException(message);
+        }
+
+        var volume = string.IsNullOrWhiteSpace(responseBody)
+            ? null
+            : JsonSerializer.Deserialize<SliplaneVolume>(responseBody,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        if (string.IsNullOrWhiteSpace(volume?.Id))
+        {
+            throw new InvalidOperationException(
+                "Sliplane returned an empty or invalid volume payload after volume creation.");
+        }
+
+        return volume;
+    }
+
     public async Task<List<SliplaneServiceEvent>> GetServiceEventsAsync(string apiToken, string projectId, string serviceId)
     {
         var response = await SendAsync(HttpMethod.Get, $"/projects/{projectId}/services/{serviceId}/events", apiToken);

--- a/project-demos/tendril-deploy/Services/TendrilDeployService.cs
+++ b/project-demos/tendril-deploy/Services/TendrilDeployService.cs
@@ -1,5 +1,6 @@
 namespace TendrilDeploy.Services;
 
+using System.Text.RegularExpressions;
 using TendrilDeploy.Api;
 using TendrilDeploy.Models;
 using TendrilDeploy.Apps;
@@ -105,9 +106,18 @@ public class TendrilDeployService
             : null;
 
         // ── 6. Volume mounts ──────────────────────────────────────────────
+        // If no volume ID was provided, auto-create one on the selected server.
+        var volumeId = req.VolumeId?.Trim();
+        if (string.IsNullOrWhiteSpace(volumeId))
+        {
+            var volumeName = AutoDataVolumeName(req.ServiceName);
+            var created = await _client.CreateVolumeAsync(req.SliplaneApiToken, req.ServerId, volumeName);
+            volumeId = created.Id;
+        }
+
         List<(string VolumeId, string MountPath)>? volumes = null;
-        if (!string.IsNullOrWhiteSpace(req.VolumeId))
-            volumes = [(req.VolumeId.Trim(), home)];
+        if (!string.IsNullOrWhiteSpace(volumeId))
+            volumes = [(volumeId, home)];
 
         // ── 7. Create the Sliplane service ────────────────────────────────
         var service = await _client.CreateServiceAsync(
@@ -181,5 +191,22 @@ public class TendrilDeployService
         var v = (value ?? "").Trim();
         if (v.Length > 0)
             list.Add(new EnvironmentVariable(key, v, Secret: true));
+    }
+
+    /// <summary>
+    /// Sliplane volume names should be URL-safe-ish; keep alphanumerics, dot, underscore, hyphen.
+    /// </summary>
+    public static string AutoDataVolumeName(string serviceName)
+    {
+        var raw = (serviceName ?? "").Trim().ToLowerInvariant();
+        if (raw.Length == 0)
+            return "tendril-data";
+
+        var slug = Regex.Replace(raw, @"[^a-z0-9._-]+", "-", RegexOptions.CultureInvariant);
+        slug = Regex.Replace(slug, "-{2,}", "-", RegexOptions.CultureInvariant).Trim('-');
+        if (slug.Length == 0)
+            slug = "tendril";
+
+        return $"{slug}-data";
     }
 }


### PR DESCRIPTION
## Summary

Simplifies the **Tendril Deploy** wizard by removing the **Repositories / Workspaces** step and all clone-URL UI. The flow is now **Welcome → API keys → Basic auth** (3 steps instead of 4).

## Changes

- Removed `repoCloneRows` state, repo rows UI (`TendrilBootstrapRepoRowView`), repos callout, and the extra stepper / footer for that screen.
- `HandleDeploy()` always uses an **empty** list for clone env vars built from the wizard (equivalent to configuring no workspace repos in the UI).
- Adjusted step indices when showing basic-auth validation errors (`3` → `2`) and **Back** from login (**2** → **1**).

## Behaviour / product note

- **`DeployRequest.Repos`**, **`TendrilDeployService`**, and the **REST API** paths for repos are unchanged.
- The **Ivy UI wizard** no longer lets users add repos to clone on startup. Users who need that should use the **API** (`repos` in the body) or another documented path.



https://github.com/user-attachments/assets/9552ba01-51fd-4105-891d-9241e19638fe


