### PR TITLE
(ivy-nuget-stats): Update Ivy to 1.2.59 in ivy-nuget-stats

### DIFF
--- a/project-demos/ivy-nuget-stats/IvyInsights.csproj
+++ b/project-demos/ivy-nuget-stats/IvyInsights.csproj
@@ -17,7 +17,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.58" />
+    <PackageReference Include="Ivy" Version="1.2.59" />
     <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.58" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />


### PR DESCRIPTION
Updated Ivy from 1.2.58 to 1.2.59 in `ivy-nuget-stats` demo project.