### PR TITLE
Update ActivityHeatmap package to 1.2.59 in ivy-nuget-stats

### DIFF
--- a/project-demos/ivy-nuget-stats/IvyInsights.csproj
+++ b/project-demos/ivy-nuget-stats/IvyInsights.csproj
@@ -18,7 +18,7 @@
   
   <ItemGroup>
     <PackageReference Include="Ivy" Version="1.2.59" />
-    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.58" />
+    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.59" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />
   </ItemGroup>


### PR DESCRIPTION
Updates `Ivy.Widgets.ActivityHeatmap` to `1.2.59`.

This update should contain the updated tooltip.
<img width="439" height="262" alt="ActivityHeatmap  1-2-59" src="https://github.com/user-attachments/assets/195f5db5-8dcd-4e9a-8349-d97c4ef31926" />
