### PR TITLE
[ci/cd]: correct Ivy.Auth.Sliplane name in auto version bump

### DIFF
--- a/.github/workflows/build-all-projects.yml
+++ b/.github/workflows/build-all-projects.yml
@@ -295,7 +295,7 @@ jobs:
             "Ivy.Analyser"
             "Ivy.Auth.GitHub"
             "Ivy.Auth.Clerk"
-            "Ivy.Auth.Sliplan"
+            "Ivy.Auth.Sliplane"
           )
 
           # Shared function: check version guards and update a file


### PR DESCRIPTION
## Summary
- Fix typo in `build-all-projects.yml`: `Ivy.Auth.Sliplan` → `Ivy.Auth.Sliplane` in the Ivy package list used by the automated version bump job.
- Ensures projects with `PackageReference Include="Ivy.Auth.Sliplane"` get updated when CI bumps Ivy packages to the latest stable version.

## Test plan
- [ ] Confirm `Ivy.Auth.Sliplane` appears in the `packages=(...)` array in `.github/workflows/build-all-projects.yml`
- [ ] (Optional) Run the **Update Ivy version** job manually or wait for schedule and verify `sliplane-manage` / other demos get version bumps