### PR TITLE
chore: update Ivy package dependencies to 1.3.1

### DIFF
--- a/agent-demos/ascii-art-generator/ASCIIArtGenerator.csproj
+++ b/agent-demos/ascii-art-generator/ASCIIArtGenerator.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/cat-facts/CatFacts.csproj
+++ b/agent-demos/cat-facts/CatFacts.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/certificate-decoder/Certificate.Decoder.csproj
+++ b/agent-demos/certificate-decoder/Certificate.Decoder.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/css-gradient-text-generator/CSSGradientTextGenerator.csproj
+++ b/agent-demos/css-gradient-text-generator/CSSGradientTextGenerator.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/ctrf/CTRF.csproj
+++ b/agent-demos/ctrf/CTRF.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/data-anonymizer/Data.Anonymizer.csproj
+++ b/agent-demos/data-anonymizer/Data.Anonymizer.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/emoji-voting-booth/Test.EmojiVotingBooth.csproj
+++ b/agent-demos/emoji-voting-booth/Test.EmojiVotingBooth.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/excel-formula-explainer/Excel.Formula.Explainer.csproj
+++ b/agent-demos/excel-formula-explainer/Excel.Formula.Explainer.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/gradient-generator/GradientGenerator.csproj
+++ b/agent-demos/gradient-generator/GradientGenerator.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/hangfire-job-dashboard/Hangfire.Job.Dashboard.csproj
+++ b/agent-demos/hangfire-job-dashboard/Hangfire.Job.Dashboard.csproj
@@ -11,7 +11,7 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Apps" />

--- a/agent-demos/html-agility-pack-scraper/Html.Agility.Pack.Scraper.csproj
+++ b/agent-demos/html-agility-pack-scraper/Html.Agility.Pack.Scraper.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/lovable-event-planner/Lovable.Event.Planner.csproj
+++ b/agent-demos/lovable-event-planner/Lovable.Event.Planner.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/lovable-travel-booking/LovableTravelBooking.csproj
+++ b/agent-demos/lovable-travel-booking/LovableTravelBooking.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/meeting-cost-calculator/MeetingCostCalculator.csproj
+++ b/agent-demos/meeting-cost-calculator/MeetingCostCalculator.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/pdf-compressor/PDF.Compressor.csproj
+++ b/agent-demos/pdf-compressor/PDF.Compressor.csproj
@@ -12,8 +12,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/readability-score-calculator/Readability.Score.Calculator.csproj
+++ b/agent-demos/readability-score-calculator/Readability.Score.Calculator.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/rick-and-morty-graphql/RickAndMortyGraphQL.csproj
+++ b/agent-demos/rick-and-morty-graphql/RickAndMortyGraphQL.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/swapi-graph-ql/SWAPI.Graph.QL.csproj
+++ b/agent-demos/swapi-graph-ql/SWAPI.Graph.QL.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/todo/Todo.csproj
+++ b/agent-demos/todo/Todo.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/agent-demos/trevor-blades-countries/Trevor.Blades.Countries.csproj
+++ b/agent-demos/trevor-blades-countries/Trevor.Blades.Countries.csproj
@@ -11,8 +11,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/HtmlAgilityPack/HtmlAgilityPackExample.csproj
+++ b/packages-demos/HtmlAgilityPack/HtmlAgilityPackExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/aspose-barcode/AsposeBarCodeExample.csproj
+++ b/packages-demos/aspose-barcode/AsposeBarCodeExample.csproj
@@ -16,8 +16,8 @@
   
   
   <ItemGroup>
-     <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+     <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/aspose-ocr/AsposeOcrExample.csproj
+++ b/packages-demos/aspose-ocr/AsposeOcrExample.csproj
@@ -18,8 +18,8 @@
   
   <ItemGroup>
     <PackageReference Include="Aspose.OCR" Version="25.11.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/aspose-words/AsposeWordsExample.csproj
+++ b/packages-demos/aspose-words/AsposeWordsExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="Aspose.Words" Version="25.12.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/barcodelib/BarcodelibExample.csproj
+++ b/packages-demos/barcodelib/BarcodelibExample.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+		<PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/bogus/BogusExample.csproj
+++ b/packages-demos/bogus/BogusExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.5" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/closedxml/ClosedXmlExample.csproj
+++ b/packages-demos/closedxml/ClosedXmlExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/constructs/ConstructsExample.csproj
+++ b/packages-demos/constructs/ConstructsExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Constructs" Version="10.4.4" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/cronos/CronosExample.csproj
+++ b/packages-demos/cronos/CronosExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="Cronos" Version="0.11.1" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/csvhelper/CsvHelperExample.csproj
+++ b/packages-demos/csvhelper/CsvHelperExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/diffengine/DiffengineExample.csproj
+++ b/packages-demos/diffengine/DiffengineExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DiffEngine" Version="18.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/diffplex/DiffPlexExample.csproj
+++ b/packages-demos/diffplex/DiffPlexExample.csproj
@@ -18,8 +18,8 @@
   
   <ItemGroup>
     <PackageReference Include="DiffPlex" Version="1.9.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/dnsclient/DnsClientExample.csproj
+++ b/packages-demos/dnsclient/DnsClientExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.8.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/enums-net/EnumsNetExample.csproj
+++ b/packages-demos/enums-net/EnumsNetExample.csproj
@@ -18,8 +18,8 @@
   
   <ItemGroup>
     <PackageReference Include="Enums.NET" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/epplus/EPPlusExample.csproj
+++ b/packages-demos/epplus/EPPlusExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EPPlus" Version="8.4.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/exceldatareader/ExcelDataReaderExample.csproj
+++ b/packages-demos/exceldatareader/ExcelDataReaderExample.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="ExcelDataReader" Version="3.8.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.8.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/fastmember/FastMemberExample.csproj
+++ b/packages-demos/fastmember/FastMemberExample.csproj
@@ -16,8 +16,8 @@
   
   <ItemGroup>
     <PackageReference Include="FastMember" Version="1.5.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/fluentdatetime/FluentDateTimeExample.csproj
+++ b/packages-demos/fluentdatetime/FluentDateTimeExample.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
 <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/fuzzysharp/FuzzySharpExample.csproj
+++ b/packages-demos/fuzzysharp/FuzzySharpExample.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/github/GitHubExample.csproj
+++ b/packages-demos/github/GitHubExample.csproj
@@ -17,8 +17,8 @@
   
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/handlebars-net/HandlebarsNetExample.csproj
+++ b/packages-demos/handlebars-net/HandlebarsNetExample.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.1.6" />
     <PackageReference Include="Handlebars.Net.Helpers" Version="2.5.3" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/humanizer/HumanizerExample.csproj
+++ b/packages-demos/humanizer/HumanizerExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 <ItemGroup>
     <PackageReference Include="Humanizer" Version="3.0.1" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/ibannet/IbanNetExample.csproj
+++ b/packages-demos/ibannet/IbanNetExample.csproj
@@ -18,8 +18,8 @@
   
   <ItemGroup>
     <PackageReference Include="IbanNet" Version="6.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/jwt/Jwt.csproj
+++ b/packages-demos/jwt/Jwt.csproj
@@ -8,8 +8,8 @@
     <RootNamespace>Jwt</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/magick-net-q16-anycpu/MagickNetQ16AnyCpuExample.csproj
+++ b/packages-demos/magick-net-q16-anycpu/MagickNetQ16AnyCpuExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/mapster/MapsterExample.csproj
+++ b/packages-demos/mapster/MapsterExample.csproj
@@ -17,8 +17,8 @@
   
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/microsoft-semantickernel/MicrosoftSemanticKernelExample.csproj
+++ b/packages-demos/microsoft-semantickernel/MicrosoftSemanticKernelExample.csproj
@@ -18,8 +18,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/mimemapping/MimeMappingExample.csproj
+++ b/packages-demos/mimemapping/MimeMappingExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/miniexcel/MiniExcelExample.csproj
+++ b/packages-demos/miniexcel/MiniExcelExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/naudio/NAudioExample.csproj
+++ b/packages-demos/naudio/NAudioExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/newtonsoft-json/NewtonsoftJsonExample.csproj
+++ b/packages-demos/newtonsoft-json/NewtonsoftJsonExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/nodatime/NodaTimeExample.csproj
+++ b/packages-demos/nodatime/NodaTimeExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference> 

--- a/packages-demos/ollamasharp/OllamaSharpExample.csproj
+++ b/packages-demos/ollamasharp/OllamaSharpExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/openai/OpenAIExample.csproj
+++ b/packages-demos/openai/OpenAIExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/puppeteersharp/PuppeteerSharpExample.csproj
+++ b/packages-demos/puppeteersharp/PuppeteerSharpExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/qrcoder/QrCoderExample.csproj
+++ b/packages-demos/qrcoder/QrCoderExample.csproj
@@ -13,8 +13,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/questpdf/QuestPdfExample.csproj
+++ b/packages-demos/questpdf/QuestPdfExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/restsharp/RestSharpExample.csproj
+++ b/packages-demos/restsharp/RestSharpExample.csproj
@@ -15,8 +15,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/scriban/ScribanExample.csproj
+++ b/packages-demos/scriban/ScribanExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/serialize-linq/SerializeLinqExample.csproj
+++ b/packages-demos/serialize-linq/SerializeLinqExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/sharpyaml/SharpYamlExample.csproj
+++ b/packages-demos/sharpyaml/SharpYamlExample.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
 <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/shopifysharp/ShopifySharpExample.csproj
+++ b/packages-demos/shopifysharp/ShopifySharpExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/simmetrics-net/SimMetricsNetExample.csproj
+++ b/packages-demos/simmetrics-net/SimMetricsNetExample.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Bogus" Version="35.6.5" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/smartformat-net/SmartFormatNetExample.csproj
+++ b/packages-demos/smartformat-net/SmartFormatNetExample.csproj
@@ -14,8 +14,8 @@
      </ItemGroup>
      
      <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/stripe-net/StripeNetExample.csproj
+++ b/packages-demos/stripe-net/StripeNetExample.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/superpower/SuperpowerExample.csproj
+++ b/packages-demos/superpower/SuperpowerExample.csproj
@@ -13,8 +13,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/timezonenames/TimeZoneConverterExample.csproj
+++ b/packages-demos/timezonenames/TimeZoneConverterExample.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/ulid/UlidExample.csproj
+++ b/packages-demos/ulid/UlidExample.csproj
@@ -13,8 +13,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/unitsnet/UnitsNetExample.csproj
+++ b/packages-demos/unitsnet/UnitsNetExample.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
 <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/xlparser/XLParserExample.csproj
+++ b/packages-demos/xlparser/XLParserExample.csproj
@@ -17,8 +17,8 @@
   
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/yamldotnet/YamlDotNetExample.csproj
+++ b/packages-demos/yamldotnet/YamlDotNetExample.csproj
@@ -13,8 +13,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/packages-demos/zstring/ZStringExample.csproj
+++ b/packages-demos/zstring/ZStringExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/QueryParamIdApp/QueryParamIdApp.csproj
+++ b/project-demos/QueryParamIdApp/QueryParamIdApp.csproj
@@ -11,10 +11,10 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/auth-github-test/Auth.GitHub.Test.csproj
+++ b/project-demos/auth-github-test/Auth.GitHub.Test.csproj
@@ -19,12 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.GitHub" Version="1.2.72" />
+    <PackageReference Include="Ivy.Auth.GitHub" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/project-demos/autodealer-crm/AutodealerCrm.csproj
+++ b/project-demos/autodealer-crm/AutodealerCrm.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/book-library/BookLibrary.csproj
+++ b/project-demos/book-library/BookLibrary.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/cold-call-tracker/ColdCallTracker.csproj
+++ b/project-demos/cold-call-tracker/ColdCallTracker.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/course-template/CourseTemplate.csproj
+++ b/project-demos/course-template/CourseTemplate.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/crm-vc/Vc.csproj
+++ b/project-demos/crm-vc/Vc.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/github-wrapped/GitHubWrapped.csproj
+++ b/project-demos/github-wrapped/GitHubWrapped.csproj
@@ -15,12 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.GitHub" Version="1.2.72" />
+    <PackageReference Include="Ivy.Auth.GitHub" Version="1.3.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.6" />
     <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
   </ItemGroup>

--- a/project-demos/helloworld/Helloworld.csproj
+++ b/project-demos/helloworld/Helloworld.csproj
@@ -14,8 +14,8 @@
     <EmbeddedResource Include="Assets/**/*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/ivy-ask-statistics/IvyAskStatistics.csproj
+++ b/project-demos/ivy-ask-statistics/IvyAskStatistics.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/ivy-nuget-stats/IvyInsights.csproj
+++ b/project-demos/ivy-nuget-stats/IvyInsights.csproj
@@ -17,8 +17,8 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.2.72" />
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Widgets.ActivityHeatmap" Version="1.3.1" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.12.40" />
   </ItemGroup>

--- a/project-demos/llm-tornado-ollama/LlmTornadoExample.csproj
+++ b/project-demos/llm-tornado-ollama/LlmTornadoExample.csproj
@@ -16,8 +16,8 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+      <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/llm-tornado-openai/LlmTornadoExample.csproj
+++ b/project-demos/llm-tornado-openai/LlmTornadoExample.csproj
@@ -16,8 +16,8 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+      <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/microsoft-agent-framework/MicrosoftAgentFramework.csproj
+++ b/project-demos/microsoft-agent-framework/MicrosoftAgentFramework.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/opperai/OpperaiExample.csproj
+++ b/project-demos/opperai/OpperaiExample.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/pr-staging-deploy/PrStagingDeploy.csproj
+++ b/project-demos/pr-staging-deploy/PrStagingDeploy.csproj
@@ -9,8 +9,8 @@
     <UserSecretsId>pr-staging-deploy-001</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/showcase-crm/ShowcaseCrm.csproj
+++ b/project-demos/showcase-crm/ShowcaseCrm.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/sliplane-deploy/SliplaneDeploy.csproj
+++ b/project-demos/sliplane-deploy/SliplaneDeploy.csproj
@@ -13,12 +13,12 @@
     <Compile Remove="tools/**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.72" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.3.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/project-demos/sliplane-manage/SliplaneManage.csproj
+++ b/project-demos/sliplane-manage/SliplaneManage.csproj
@@ -16,12 +16,12 @@
     <Folder Include="Connections" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.72" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.3.1" />
   </ItemGroup>
 </Project>
 

--- a/project-demos/snowflake-dashboard/SnowflakeDashboard.csproj
+++ b/project-demos/snowflake-dashboard/SnowflakeDashboard.csproj
@@ -17,8 +17,8 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+      <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/snowflake/SnowflakeExample.csproj
+++ b/project-demos/snowflake/SnowflakeExample.csproj
@@ -16,8 +16,8 @@
 
   
     <ItemGroup>
-      <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+      <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/project-demos/tendril-deploy/TendrilDeploy.csproj
+++ b/project-demos/tendril-deploy/TendrilDeploy.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Isopoh.Cryptography.Argon2" Version="2.0.0" />
-    <PackageReference Include="Ivy" Version="1.2.72" />
-    <PackageReference Include="Ivy.Analyser" Version="1.2.72">
+    <PackageReference Include="Ivy" Version="1.3.1" />
+    <PackageReference Include="Ivy.Analyser" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.2.72" />
+    <PackageReference Include="Ivy.Auth.Sliplane" Version="1.3.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates all Ivy Framework packages in the Ivy-Examples repository to the latest release version 1.3.1.